### PR TITLE
Bug 1679375 - Implement the base of the metrics database module

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,8 @@
       "templateFile": "copyright.template.txt"
       }
     ],
-    "semi": ["error", "always"]
+    "semi": ["error", "always"],
+    "no-debugger":  ["error"]
   },
   "parser": "@typescript-eslint/parser",
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/glean.js",
   "scripts": {
     "test": "npm run build:test-webext && ts-mocha tests/**/*.spec.ts --paths -p ./tsconfig.json  --timeout 0",
-    "test:debug": "ts-mocha --paths -p ./tsconfig.json --inspect-brk",
+    "test:debug": "ts-mocha tests/**/*.spec.ts --paths -p ./tsconfig.json --inspect-brk",
     "lint": "eslint . --ext .ts,.js,.json",
     "fix": "eslint . --ext .ts,.js,.json --fix",
     "build:webext": "webpack --config webpack.config.webext.js --mode production",

--- a/src/database.ts
+++ b/src/database.ts
@@ -99,7 +99,6 @@ class Database {
    * @param value The value we want to record to the given metric.
    */
   async record(metric: Metric, value: string): Promise<void> {
-    debugger;
     if (metric.disabled) {
       return;
     }

--- a/src/database.ts
+++ b/src/database.ts
@@ -50,7 +50,7 @@ export function isValidPingPayload(v: StorageValue): v is PingPayload {
  * {
  *  "pingName": {
  *    "metricType (i.e. boolean)": {
- *      "metricCategory?.metricName": metricPayload
+ *      "metricIdentifier": metricPayload
  *    }
  *  }
  * }

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,0 +1,243 @@
+// /* This Source Code Form is subject to the terms of the Mozilla Public
+//  * License, v. 2.0. If a copy of the MPL was not distributed with this
+//  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { StorageValue, Store } from "storage";
+import PersistentStore from "storage/persistent";
+import Metric, { Lifetime } from "metrics";
+import { isObject, isString, isUndefined } from "utils";
+
+export interface PingPayload {
+  [aMetricType: string]: {
+    [aMetricIdentifier: string]: string
+  }
+}
+
+/**
+ * Verifies if a given value is a valid PingPayload.
+ *
+ * @param v The value to verify
+ */
+export function isValidPingPayload(v: StorageValue): v is PingPayload {
+  if (isObject(v)) {
+    // The root keys should all be metric types.
+    for (const metricType in v) {
+      const metrics = v[metricType];
+      if (isObject(metrics)) {
+        for (const metricIdentifier in metrics) {
+          if (!isString(metrics[metricIdentifier])) {
+            return false;
+          }
+        }
+      } else {
+        return false;
+      }
+    }
+    return true;
+  } else {
+    return false;
+  }
+
+}
+
+/**
+ * The metrics database is an abstraction layer on top of the underlying storage.
+ *
+ * Metric data is saved to the database in the following format:
+ *
+ * {
+ *  "pingName": {
+ *    "metricType (i.e. boolean)": {
+ *      "metricCategory?.metricName": metricPayload
+ *    }
+ *  }
+ * }
+ *
+ * We have one store such in format for each lifetime: user, ping and application.
+ *
+ */
+class Database {
+  private userStore: Store;
+  private pingStore: Store;
+  private appStore: Store;
+
+  constructor() {
+    this.userStore = new PersistentStore("user");
+    this.pingStore = new PersistentStore("ping");
+    this.appStore = new PersistentStore("app");
+  }
+
+  /**
+   * The key under which to save a metrics value.
+   *
+   * @param metric The metric for which to build the storage key
+   */
+  private _buildStorageKey(metric: Metric): string {
+    if (metric.category) {
+      return `${metric.category}.${metric.name}`;
+    } else {
+      return metric.name;
+    }
+  }
+
+  /**
+   * Returns the store instance for a given lifetime.
+   *
+   * @param lifetime The lifetime related to the store we want to retrieve.
+   *
+   * @returns The store related to the given lifetime.
+   *
+   * @throws If the provided lifetime does not have a related store.
+   */
+  private _chooseStore(lifetime: Lifetime): Store {
+    switch (lifetime) {
+    case Lifetime.User:
+      return this.userStore;
+    case Lifetime.Ping:
+      return this.pingStore;
+    case Lifetime.Application:
+      return this.appStore;
+    default:
+      throw Error(`Attempted to retrive a store for an unknown lifetime: ${lifetime}`);
+    }
+  }
+
+  /**
+   * Records a given value to a given metric.
+   * Will overwrite in case there is already a value in there.
+   *
+   * @param metric The metric to record to.
+   * @param value The value we want to record to the given metric.
+   */
+  async record(metric: Metric, value: string): Promise<void> {
+    if (!metric.disabled) {
+      const store = this._chooseStore(metric.lifetime);
+      const storageKey = this._buildStorageKey(metric);
+      for (const ping of metric.sendInPings) {
+        await store.update([ping, metric.type, storageKey], () => value);
+      }
+    }
+  }
+
+  /**
+   * Records a given value to a given metric,
+   * by applying a transformation function on the value currently persisted.
+   *
+   * @param metric The metric to record to.
+   * @param transformFn The transformation function to apply to the currently persisted value.
+   */
+  async transform(metric: Metric, transformFn: (v?: string) => string): Promise<void> {
+    if (!metric.disabled) {
+      const store = this._chooseStore(metric.lifetime);
+      const storageKey = this._buildStorageKey(metric);
+      for (const ping of metric.sendInPings) {
+        const finalTransformFn = (v: StorageValue): string => {
+          if (isObject(v)) {
+            throw new Error(`Unexpected value found for metric ${metric}: ${JSON.stringify(v)}.`);
+          }
+          return transformFn(v);
+        };
+        await store.update([ping, metric.type, storageKey], finalTransformFn);
+      }
+    }
+  }
+
+  /**
+   * Gets the persisted payload of a given metric in a given ping.
+   *
+   * @param ping The ping from which we want to retrieve the given metric.
+   * @param metric An object containing the information about the metric to retrieve.
+   *
+   * @returns The string encoded payload persisted for the given metric,
+   *          `undefined` in case the metric has not been recorded yet.
+   */
+  async getMetric(ping: string, metric: Metric): Promise<string | undefined> {
+    const store = this._chooseStore(metric.lifetime);
+    const storageKey = this._buildStorageKey(metric);
+    const value = await store.get([ping, metric.type, storageKey]);
+    if (isObject(value)) {
+      console.error(`Unexpected value found for metric ${metric}: ${JSON.stringify(value)}. Clearing.`);
+      await store.delete([ping, metric.type, storageKey]);
+      return;
+    } else {
+      return value;
+    }
+  }
+
+  /**
+   * Gets all of the persisted metrics related to a given ping.
+   *
+   * # Note
+   *
+   * If the value in storage for any of the metrics in a ping is of an unexpected type,
+   * the whole ping payload for that lifetime will be thrown away.
+   *
+   * @param ping The name of the ping to retrieve.
+   * @param clearPingLifetimeData Whether or not to clear the ping lifetime metrics retrieved.
+   *
+   * @returns An object containing all the metrics recorded to the given ping,
+   *          `undefined` in case the ping doesn't contain any recorded metrics.
+   */
+  async getPing(ping: string, clearPingLifetimeData: boolean): Promise<PingPayload | undefined> {
+    const getAndValidatePingData = async (storeName: string, store: Store): Promise<PingPayload> => {
+      const data = await store.get([ping]);
+      if (isUndefined(data)) {
+        return {};
+      }
+
+      if (!isValidPingPayload(data)) {
+        console.error(`Unexpected value found for ping ${ping} in ${storeName} store: ${JSON.stringify(data)}. Clearing.`);
+        await store.delete([ping]);
+        return {};
+      }
+
+      return data;
+    };
+
+    const userData = await getAndValidatePingData("user", this.userStore);
+    const pingData = await getAndValidatePingData("ping", this.pingStore);
+    const appData = await getAndValidatePingData("app", this.appStore);
+
+    if (clearPingLifetimeData) {
+      await this.clear(Lifetime.Ping);
+    }
+
+    // Start out with the ping lifetime data,
+    // because it is the one that will probably have more data since it is the default.
+    const response: PingPayload = { ...pingData };
+    // Merge the other two lifetimes data with it.
+    for (const data of [userData, appData]) {
+      for (const metricType in data) {
+        response[metricType] = {
+          ...response[metricType],
+          ...data[metricType]
+        };
+      }
+    }
+
+    if (Object.keys(response).length === 0) {
+      return;
+    } else {
+      return response;
+    }
+  }
+
+  /**
+   * Clears currently persisted data for a given lifetime.
+   *
+   * @param lifetime The lifetime to clear.
+   *        If not provided, data for all lifetimes will be cleared.
+   */
+  async clear(lifetime?: Lifetime): Promise<void> {
+    if (lifetime) {
+      const store = this._chooseStore(lifetime);
+      await store.delete([]);
+    } else {
+      await this.userStore.delete([]);
+      await this.pingStore.delete([]);
+      await this.appStore.delete([]);
+    }
+  }
+}
+
+export default Database;

--- a/src/database.ts
+++ b/src/database.ts
@@ -53,7 +53,7 @@ export function isValidPingPayload(v: StorageValue): v is PingPayload {
  *  }
  * }
  *
- * We have one store such in format for each lifetime: user, ping and application.
+ * We have one store in this format for each lifetime: user, ping and application.
  *
  */
 class Database {

--- a/src/database.ts
+++ b/src/database.ts
@@ -99,7 +99,8 @@ class Database {
    * @param value The value we want to record to the given metric.
    */
   async record(metric: Metric, value: string): Promise<void> {
-    if (!metric.disabled) {
+    debugger;
+    if (metric.disabled) {
       return;
     }
 
@@ -118,7 +119,7 @@ class Database {
    * @param transformFn The transformation function to apply to the currently persisted value.
    */
   async transform(metric: Metric, transformFn: (v?: string) => string): Promise<void> {
-    if (!metric.disabled) {
+    if (metric.disabled) {
       return;
     }
 

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -48,7 +48,9 @@ class Metric implements CommonMetricData {
     this.lifetime = meta.lifetime;
     this.disabled = meta.disabled;
 
-    if (meta.category) this.category = meta.category;
+    if (meta.category) {
+      this.category = meta.category;
+    }
   }
 }
 

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * An enum representing the possible metric lifetimes.
+ */
+export const enum Lifetime {
+  // The metric is reset with each sent ping
+  Ping = "ping",
+  // The metric is reset on application restart
+  Application = "application",
+  // The metric is reset with each user profile
+  User = "user",
+}
+
+/**
+ * The common set of data shared across all different metric types.
+ */
+interface CommonMetricData {
+  // The metric's name.
+  readonly name: string,
+  // The metric's category.
+  readonly category?: string,
+  // List of ping names to include this metric in.
+  readonly sendInPings: string[],
+  // The metric's lifetime.
+  readonly lifetime: Lifetime,
+  // Whether or not the metric is disabled.
+  //
+  // Disabled metrics are never recorded.
+  readonly disabled: boolean
+}
+
+class Metric implements CommonMetricData {
+  readonly type: string;
+  readonly name: string;
+  readonly category?: string;
+  readonly sendInPings: string[];
+  readonly lifetime: Lifetime;
+  readonly disabled: boolean;
+
+  constructor(type: string, meta: CommonMetricData) {
+    this.type = type;
+
+    this.name = meta.name;
+    this.sendInPings = meta.sendInPings;
+    this.lifetime = meta.lifetime;
+    this.disabled = meta.disabled;
+
+    if (meta.category) this.category = meta.category;
+  }
+}
+
+export default Metric;

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -52,6 +52,19 @@ class Metric implements CommonMetricData {
       this.category = meta.category;
     }
   }
+
+  /**
+   * This metric's unique identifier, including the category and name.
+   *
+   * @returns The generated identifier.
+   */
+  get identifier(): string {
+    if (this.category) {
+      return `${this.category}.${this.name}`;
+    } else {
+      return this.name;
+    }
+  }
 }
 
 export default Metric;

--- a/src/storage/persistent/index.ts
+++ b/src/storage/persistent/index.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Persistent storage implementation is platform dependent.
+// Each platform will have a different build
+// which will alias `storage/persistent` to the correct impl.
+//
+// We leave this index.ts file as a fallback for tests.
+import WeakStore from "storage/weak";
+export default WeakStore;

--- a/src/storage/utils.ts
+++ b/src/storage/utils.ts
@@ -81,7 +81,7 @@ export function updateNestedObject(
     return returnObject;
   } catch(e) {
     console.error("Error while transforming stored value. Ignoring old value.", e.message);
-    target[finalKey] = transformFn();
+    target[finalKey] = transformFn(undefined);
     return returnObject;
   }
 }

--- a/src/storage/utils.ts
+++ b/src/storage/utils.ts
@@ -81,7 +81,7 @@ export function updateNestedObject(
     return returnObject;
   } catch(e) {
     console.error("Error while transforming stored value. Ignoring old value.", e.message);
-    target[finalKey] = transformFn(undefined);
+    target[finalKey] = transformFn();
     return returnObject;
   }
 }

--- a/src/storage/utils.ts
+++ b/src/storage/utils.ts
@@ -75,8 +75,15 @@ export function updateNestedObject(
 
   const finalKey = index[index.length - 1];
   const current = target[finalKey];
-  target[finalKey] = transformFn(current);
-  return returnObject;
+  try {
+    const value = transformFn(current);
+    target[finalKey] = value;
+    return returnObject;
+  } catch(e) {
+    console.error("Error while transforming stored value. Ignoring old value.", e.message);
+    target[finalKey] = transformFn(undefined);
+    return returnObject;
+  }
 }
 
 /**

--- a/tests/database.spec.ts
+++ b/tests/database.spec.ts
@@ -1,0 +1,474 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import assert from "assert";
+
+import Database, { isValidPingPayload } from "database";
+import Metric, { Lifetime } from "metrics";
+
+describe("Database", function() {
+  describe("record", function() {
+    it("records to the correct place at the underlying store", async function() {
+      const db = new Database();
+      const userMetric = new Metric("aMetricType", {
+        category: "user",
+        name: "aMetric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.User,
+        disabled: false
+      });
+      await db.record(userMetric, "userValue");
+      assert.strictEqual(
+        await db["userStore"].get(["aPing", "aMetricType", "user.aMetric"]),
+        "userValue"
+      );
+
+      const pingMetric = new Metric("aMetricType", {
+        category: "ping",
+        name: "aMetric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Ping,
+        disabled: false
+      });
+      await db.record(pingMetric, "pingValue");
+      assert.strictEqual(
+        await db["pingStore"].get(["aPing", "aMetricType", "ping.aMetric"]),
+        "pingValue"
+      );
+
+      const appMetric = new Metric("aMetricType", {
+        category: "app",
+        name: "aMetric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      });
+      await db.record(appMetric, "appValue");
+      assert.strictEqual(
+        await db["appStore"].get(["aPing", "aMetricType", "app.aMetric"]),
+        "appValue"
+      );
+    });
+
+    it("records at all the pings defined in a metric", async function() {
+      const db = new Database();
+      const metric = new Metric("aMetricType", {
+        name: "aMetric",
+        sendInPings: ["aPing", "otherPing", "oneMorePing"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      });
+
+      await db.record(metric, "aValue");
+      const recorded1 = await db["appStore"].get(["aPing", "aMetricType", "aMetric"]);
+      assert.strictEqual(recorded1, "aValue");
+      const recorded2 = await db["appStore"].get(["otherPing", "aMetricType", "aMetric"]);
+      assert.strictEqual(recorded2, "aValue");
+      const recorded3 = await db["appStore"].get(["oneMorePing", "aMetricType", "aMetric"]);
+      assert.strictEqual(recorded3, "aValue");
+    });
+
+    it("overwrites old value if necessary", async function() {
+      const db = new Database();
+      const metric = new Metric("aMetricType", {
+        name: "aMetric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      });
+
+      await db.record(metric, "aValue");
+      await db.record(metric, "overwrittenValue");
+      const recorded = await db["appStore"].get(["aPing", "aMetricType", "aMetric"]);
+      assert.strictEqual(recorded, "overwrittenValue");
+    });
+
+    it("doesn't record if metric is disabled", async function() {
+      const db = new Database();
+      const metric = new Metric("aMetricType", {
+        name: "aMetric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Application,
+        disabled: true
+      });
+
+      await db.record(metric, "aValue");
+      const recorded = await db["appStore"].get(["aPing", "aMetricType", "aMetric"]);
+      assert.strictEqual(recorded, undefined);
+    });
+  });
+
+  describe("transform", function() {
+    it("transforms to the correct place at the underlying store", async function() {
+      const db = new Database();
+      const userMetric = new Metric("aMetricType", {
+        category: "user",
+        name: "aMetric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.User,
+        disabled: false
+      });
+      await db.transform(userMetric, (v?: string) => v ? `USER_${v}` : "USER");
+      assert.strictEqual(
+        await db["userStore"].get(["aPing", "aMetricType", "user.aMetric"]),
+        "USER"
+      );
+
+      const pingMetric = new Metric("aMetricType", {
+        category: "ping",
+        name: "aMetric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Ping,
+        disabled: false
+      });
+      await db.transform(pingMetric,(v?: string) => v ? `PING_${v}` : "PING");
+      assert.strictEqual(
+        await db["pingStore"].get(["aPing", "aMetricType", "ping.aMetric"]),
+        "PING"
+      );
+
+      const appMetric = new Metric("aMetricType", {
+        category: "app",
+        name: "aMetric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      });
+      await db.transform(appMetric, (v?: string) => v ? `APP_${v}` : "APP");
+      assert.strictEqual(
+        await db["appStore"].get(["aPing", "aMetricType", "app.aMetric"]),
+        "APP"
+      );
+    });
+
+    it("transforms at all the pings defined in a metric", async function() {
+      const db = new Database();
+      const metric = new Metric("aMetricType", {
+        name: "aMetric",
+        sendInPings: ["aPing", "otherPing", "oneMorePing"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      });
+
+      await db.transform(metric, (v?: string) => v ? `EXTRA_${v}` : "EXTRA");
+      const recorded1 = await db["appStore"].get(["aPing", "aMetricType", "aMetric"]);
+      assert.strictEqual(recorded1, "EXTRA");
+      const recorded2 = await db["appStore"].get(["otherPing", "aMetricType", "aMetric"]);
+      assert.strictEqual(recorded2, "EXTRA");
+      const recorded3 = await db["appStore"].get(["oneMorePing", "aMetricType", "aMetric"]);
+      assert.strictEqual(recorded3, "EXTRA");
+    });
+
+    it("ignores old value in case object is found on a metrics index", async function() {
+      const db = new Database();
+      const metric = new Metric("aMetricType", {
+        name: "aMetric",
+        sendInPings: ["aPing", "otherPing", "oneMorePing"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      });
+
+      await db["appStore"].update(
+        ["aPing", "aMetricType", "aMetric"],
+        () => ({ "out": "of place" })
+      );
+
+      await db.transform(metric, (v?: string) => v ? `EXTRA_${v}` : "EXTRA");
+      const recorded = await db["appStore"].get(["aPing", "aMetricType", "aMetric"]);
+      assert.strictEqual(recorded, "EXTRA");
+    });
+
+    it("doesn't transform if metric is disabled", async function() {
+      const db = new Database();
+      const metric = new Metric("aMetricType", {
+        name: "aMetric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Application,
+        disabled: true
+      });
+
+      await db.transform(metric, (v?: string) => v ? `EXTRA_${v}` : "EXTRA");
+      const recorded = await db["appStore"].get(["aPing", "aMetricType", "aMetric"]);
+      assert.strictEqual(recorded, undefined);
+    });
+  });
+
+  describe("getMetric", function() {
+    it("gets correct metric from correct ping", async function() {
+      const db = new Database();
+      const metric = new Metric("aMetricType", {
+        name: "aMetric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      });
+
+      await db.record(metric, "aValue");
+      assert.strictEqual(await db.getMetric("aPing", metric), "aValue");
+    });
+
+    it("doesn't error if trying to get a metric that hasn't been recorded yet", async function() {
+      const db = new Database();
+      const metric = new Metric("aMetricType", {
+        name: "aMetric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      });
+
+      assert.strictEqual(await db.getMetric("aPing", metric), undefined);
+    });
+
+    it("deletes entry in case an unexpected value in encountered", async function() {
+      const db = new Database();
+      const metric = new Metric("aMetricType", {
+        name: "aMetric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      });
+
+      await db["appStore"].update(
+        ["aPing", "aMetricType", "aMetric"],
+        () => ({ "out": "of place" })
+      );
+
+      assert.strictEqual(await db.getMetric("aPing", metric), undefined);
+      assert.strictEqual(await db["appStore"].get(["aPing", "aMetricType", "aMetric"]), undefined);
+    });
+  });
+
+  describe("getPing", function() {
+    it("isValidPingPayload validates correctly", function() {
+      // Invalids
+      assert.strictEqual(false, isValidPingPayload("not even an object"));
+      assert.strictEqual(false, isValidPingPayload({ 1: "an array-like object in not a ping!" }));
+      assert.strictEqual(false, isValidPingPayload({
+        "aPing": {
+          "string": {
+            "too.nested": "not quite"
+          }
+        }
+      }));
+      assert.strictEqual(false, isValidPingPayload({ "string": "almost!" }));
+      // Valids
+      assert.strictEqual(true, isValidPingPayload({ "string": {} }));
+      assert.strictEqual(true, isValidPingPayload({ "string": { "there.we": "go" } }));
+      assert.strictEqual(true, isValidPingPayload({
+        "string": {
+          "string.one": "foo",
+          "string.two": "bar",
+          "string.three": "baz",
+        }
+      }));
+      assert.strictEqual(true, isValidPingPayload({
+        "string": {
+          "string.one": "foo",
+          "string.two": "bar",
+          "string.three": "baz",
+        },
+        "datetime": {
+          "this.is": "what",
+          "ping": "payload",
+          "looks": "like"
+        }
+      }));
+      assert.strictEqual(true, isValidPingPayload({}));
+    });
+
+    it("when incorrect data is found on the storage, it is deleted", async function() {
+      const db = new Database();
+      await db["appStore"].update(["aPing"], () => "not even a string");
+      assert.strictEqual(await db.getPing("aPing", false), undefined);
+      assert.strictEqual(await db["appStore"].get(["aPing"]), undefined);
+    });
+
+    it("getting a ping with metric from only one lifetime works correctly", async function() {
+      const db = new Database();
+      await db["appStore"].update(["aPing"], () => ({
+        "string": {
+          "string.one": "foo",
+          "string.two": "bar",
+          "string.three": "baz",
+        },
+        "datetime": {
+          "this.is": "what",
+          "ping": "payload",
+          "looks": "like"
+        }
+      }));
+
+      assert.deepStrictEqual(await db.getPing("aPing", false), {
+        "string": {
+          "string.one": "foo",
+          "string.two": "bar",
+          "string.three": "baz",
+        },
+        "datetime": {
+          "this.is": "what",
+          "ping": "payload",
+          "looks": "like"
+        }
+      });
+    });
+
+    it("getting a ping with metric from multiple lifetimes works correctly", async function() {
+      const db = new Database();
+      await db["userStore"].update(["aPing"], () => ({
+        "uuid": {
+          "client_info.client_id": "foo",
+        },
+        "datetime": {
+          "client_info.first_run_date": "0182341",
+        },
+        "string": {
+          "locale": "pt_BR"
+        }
+      }));
+      await db["pingStore"].update(["aPing"], () => ({
+        "string": {
+          "string.one": "foo",
+          "string.two": "bar",
+          "string.three": "baz",
+        },
+        "datetime": {
+          "this.is": "what",
+          "ping": "payload",
+          "looks": "like"
+        }
+      }));
+      await db["appStore"].update(["aPing"], () => ({
+        "string": {
+          "aaaaaand": "etc",
+        },
+      }));
+
+      assert.deepStrictEqual(await db.getPing("aPing", false), {
+        "uuid": {
+          "client_info.client_id": "foo",
+        },
+        "string": {
+          "locale": "pt_BR",
+          "string.one": "foo",
+          "string.two": "bar",
+          "string.three": "baz",
+          "aaaaaand": "etc",
+        },
+        "datetime": {
+          "client_info.first_run_date": "0182341",
+          "this.is": "what",
+          "ping": "payload",
+          "looks": "like"
+        }
+      });
+    });
+
+    it("ping lifetime data is cleared when clearPingLifetimeData is passed", async function() {
+      const db = new Database();
+      const userMetric = new Metric("aMetricType", {
+        category: "user",
+        name: "metric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.User,
+        disabled: false
+      });
+      await db.record(userMetric, "userValue");
+
+      const pingMetric = new Metric("aMetricType", {
+        category: "ping",
+        name: "metric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Ping,
+        disabled: false
+      });
+      await db.record(pingMetric, "pingValue");
+
+      const appMetric = new Metric("aMetricType", {
+        category: "app",
+        name: "metric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      });
+      await db.record(appMetric, "appValue");
+
+      await db.getPing("aPing", true);
+      assert.notDeepStrictEqual(await db["userStore"]._getWholeStore(), {});
+      assert.deepStrictEqual(await db["pingStore"]._getWholeStore(), {});
+      assert.notDeepStrictEqual(await db["appStore"]._getWholeStore(), {});
+    });
+  });
+
+  describe("clear", function() {
+    it("clear all stores works correctly", async function() {
+      const db = new Database();
+      const userMetric = new Metric("aMetricType", {
+        category: "user",
+        name: "metric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.User,
+        disabled: false
+      });
+      await db.record(userMetric, "userValue");
+
+      const pingMetric = new Metric("aMetricType", {
+        category: "ping",
+        name: "metric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Ping,
+        disabled: false
+      });
+      await db.record(pingMetric, "pingValue");
+
+      const appMetric = new Metric("aMetricType", {
+        category: "app",
+        name: "metric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      });
+      await db.record(appMetric, "appValue");
+
+      await db.clear();
+      assert.deepStrictEqual(await db["userStore"]._getWholeStore(), {});
+      assert.deepStrictEqual(await db["pingStore"]._getWholeStore(), {});
+      assert.deepStrictEqual(await db["appStore"]._getWholeStore(), {});
+    });
+
+    it("clears separate stores correctly", async function() {
+      const db = new Database();
+      const userMetric = new Metric("aMetricType", {
+        category: "user",
+        name: "metric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.User,
+        disabled: false
+      });
+      await db.record(userMetric, "userValue");
+
+      const pingMetric = new Metric("aMetricType", {
+        category: "ping",
+        name: "metric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Ping,
+        disabled: false
+      });
+      await db.record(pingMetric, "pingValue");
+
+      const appMetric = new Metric("aMetricType", {
+        category: "app",
+        name: "metric",
+        sendInPings: ["aPing"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      });
+      await db.record(appMetric, "appValue");
+
+      await db.clear(Lifetime.User);
+      assert.deepStrictEqual(await db["userStore"]._getWholeStore(), {});
+      assert.notDeepStrictEqual(await db["pingStore"]._getWholeStore(), {});
+      assert.notDeepStrictEqual(await db["appStore"]._getWholeStore(), {});
+    });
+  });
+});

--- a/tests/database.spec.ts
+++ b/tests/database.spec.ts
@@ -430,7 +430,7 @@ describe("Database", function() {
       });
       await db.record(appMetric, "appValue");
 
-      await db.clear();
+      await db.clearAll();
       assert.deepStrictEqual(await db["userStore"]._getWholeStore(), {});
       assert.deepStrictEqual(await db["pingStore"]._getWholeStore(), {});
       assert.deepStrictEqual(await db["appStore"]._getWholeStore(), {});


### PR DESCRIPTION
As was described in the proposal, the database module will differ from the glean-core database module.

While it will serve as an abstraction layer over the underlying storage, it will also be the interface to retrive the ping / metric payload data from the storage. This is a bit easier for Glean.js, because the data is saved already in the format that is expected by the ping schema.

I will leave comments on the code about some doubts that lingered after I was finished with this implementation.