### PR TITLE
Bug 1677445 - Implement PingType and ping maker

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,12 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { version } = require("../package.json");
+import { version } from "../package.json";
 
 export const GLEAN_SCHEMA_VERSION = 1;
 
 // The version for the current build of Glean.js
+//
+// PACKAGE_VERSION is defined as a global by webpack,
+// we need a default here for testing when the app is not build with webpack.
 export const GLEAN_VERSION = version;
 
 // The name of a "ping" that will include Glean ping_info metrics,
@@ -15,6 +17,8 @@ export const GLEAN_VERSION = version;
 //
 // Note that this is not really a ping,
 // but a neat way to gather metrics in the metrics database.
+//
+// See: https://mozilla.github.io/glean/book/dev/core/internal/reserved-ping-names.html
 export const PING_INFO_STORAGE = "glean_ping_info";
 
 // The name of a "ping" that will include the Glean client_info metrics,
@@ -22,4 +26,6 @@ export const PING_INFO_STORAGE = "glean_ping_info";
 //
 // Note that this is not really a ping,
 // but a neat way to gather metrics in the metrics database.
+//
+// See: https://mozilla.github.io/glean/book/dev/core/internal/reserved-ping-names.html
 export const CLIENT_INFO_STORAGE = "glean_client_info";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { version } = require("../package.json");
+
+export const GLEAN_SCHEMA_VERSION = 1;
+
+// The version for the current build of Glean.js
+export const GLEAN_VERSION = version;
+
+// The name of a "ping" that will include Glean ping_info metrics,
+// such as ping sequence numbers.
+//
+// Note that this is not really a ping,
+// but a neat way to gather metrics in the metrics database.
+export const PING_INFO_STORAGE = "glean_ping_info";
+
+// The name of a "ping" that will include the Glean client_info metrics,
+// such as ping sequence numbers.
+//
+// Note that this is not really a ping,
+// but a neat way to gather metrics in the metrics database.
+export const CLIENT_INFO_STORAGE = "glean_client_info";

--- a/src/glean.ts
+++ b/src/glean.ts
@@ -25,6 +25,8 @@ class Glean {
   }
   // Whether or not to record metrics.
   private _uploadEnabled: boolean;
+  // The time the Glean object was initialized.
+  private _startTime: Date;
   // Whether or not Glean has been initialized.
   private _initialized: boolean;
 
@@ -38,6 +40,7 @@ class Glean {
         Use Glean.instance instead to access the Glean singleton.`);
     }
 
+    this._startTime = new Date();
     this._initialized = false;
     this._db = {
       metrics: new MetricsDatabase(),
@@ -94,6 +97,15 @@ class Glean {
 
   static set uploadEnabled(value: boolean) {
     Glean.instance._uploadEnabled = value;
+  }
+
+  /**
+   * Gets the time this Glean instance was created.
+   *
+   * @returns The Date object representing the time this Glean instance was created.
+   */
+  static get startTime(): Date {
+    return Glean.instance._startTime;
   }
 
   static get applicationId(): string | undefined {

--- a/src/glean.ts
+++ b/src/glean.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import MetricsDatabase from "metrics/database";
+import PingsDatabase from "pings/database";
 import { isUndefined, sanitizeApplicationId } from "utils";
 
 /**
@@ -20,6 +21,7 @@ class Glean {
   // The metrics and pings databases.
   private _db: {
     metrics: MetricsDatabase,
+    pings: PingsDatabase
   }
   // Whether or not to record metrics.
   private _uploadEnabled: boolean;
@@ -39,6 +41,7 @@ class Glean {
     this._initialized = false;
     this._db = {
       metrics: new MetricsDatabase(),
+      pings: new PingsDatabase()
     };
     // Temporarily setting this to true always, until Bug 1677444 is resolved.
     this._uploadEnabled = true;
@@ -75,8 +78,13 @@ class Glean {
     return Glean.instance._db.metrics;
   }
 
-  static get db(): Database {
-    return Glean.instance._db;
+  /**
+   * Gets this Glean's instance pings database.
+   *
+   * @returns This Glean's instance pings database.
+   */
+  static get pingsDatabase(): PingsDatabase {
+    return Glean.instance._db.pings;
   }
 
   // TODO: Make the following functions `private` once Bug 1682769 is resolved.
@@ -106,8 +114,9 @@ class Glean {
   static async testRestGlean(): Promise<void> {
     // Reset upload enabled state, not to inerfere with other tests.
     Glean.uploadEnabled = true;
-    // Clear the database.
+    // Clear the databases.
     await Glean.metricsDatabase.clearAll();
+    await Glean.pingsDatabase.clearAll();
   }
 }
 

--- a/src/glean.ts
+++ b/src/glean.ts
@@ -2,15 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Database from "database";
+import MetricsDatabase from "metrics/database";
 import { isUndefined } from "utils";
 
 class Glean {
   // The Glean singleton.
   private static _instance?: Glean;
 
-  // The metrics database.
-  private _db: Database;
+  // The metrics and pings databases.
+  private _db: {
+    metrics: MetricsDatabase,
+  }
   // Whether or not to record metrics.
   private _uploadEnabled: boolean;
 
@@ -21,7 +23,9 @@ class Glean {
         Use Glean.instance instead to access the Glean singleton.`);
     }
 
-    this._db = new Database();
+    this._db = {
+      metrics: new MetricsDatabase(),
+    };
     // Temporarily setting this to true always, until Bug 1677444 is resolved.
     this._uploadEnabled = true;
   }
@@ -34,6 +38,14 @@ class Glean {
     return Glean._instance;
   }
 
+  /**
+   * Gets this Glean's instance metrics database.
+   *
+   * @returns This Glean's instance metrics database.
+   */
+  static get metricsDatabase(): MetricsDatabase {
+    return Glean.instance._db.metrics;
+  }
 
   static get db(): Database {
     return Glean.instance._db;
@@ -59,7 +71,7 @@ class Glean {
     // Reset upload enabled state, not to inerfere with other tests.
     Glean.uploadEnabled = true;
     // Clear the database.
-    await Glean.db.clearAll();
+    await Glean.metricsDatabase.clearAll();
   }
 }
 

--- a/src/glean.ts
+++ b/src/glean.ts
@@ -6,14 +6,6 @@ import MetricsDatabase from "metrics/database";
 import PingsDatabase from "pings/database";
 import { isUndefined, sanitizeApplicationId } from "utils";
 
-/**
- * The Glean configuration.
- */
-interface Configuration {
-  // The application ID (will be sanitized during initialization).
-  applicationId: string,
-}
-
 class Glean {
   // The Glean singleton.
   private static _instance?: Glean;
@@ -25,8 +17,6 @@ class Glean {
   }
   // Whether or not to record metrics.
   private _uploadEnabled: boolean;
-  // The time the Glean object was initialized.
-  private _startTime: Date;
   // Whether or not Glean has been initialized.
   private _initialized: boolean;
 
@@ -40,7 +30,6 @@ class Glean {
         Use Glean.instance instead to access the Glean singleton.`);
     }
 
-    this._startTime = new Date();
     this._initialized = false;
     this._db = {
       metrics: new MetricsDatabase(),
@@ -61,15 +50,15 @@ class Glean {
   /**
    * Initialize Glean. This method should only be called once, subsequent calls will be no-op.
    *
-   * @param config The Glean configuration.
+   * @param applicationId The application ID (will be sanitized during initialization).
    */
-  static initialize(config: Configuration): void {
+  static initialize(applicationId: string): void {
     if (Glean.instance._initialized) {
       console.warn("Attempted to initialize Glean, but it has already been initialized. Ignoring.");
       return;
     }
 
-    Glean.instance._applicationId = sanitizeApplicationId(config.applicationId);
+    Glean.instance._applicationId = sanitizeApplicationId(applicationId);
   }
 
   /**
@@ -97,15 +86,6 @@ class Glean {
 
   static set uploadEnabled(value: boolean) {
     Glean.instance._uploadEnabled = value;
-  }
-
-  /**
-   * Gets the time this Glean instance was created.
-   *
-   * @returns The Date object representing the time this Glean instance was created.
-   */
-  static get startTime(): Date {
-    return Glean.instance._startTime;
   }
 
   static get applicationId(): string | undefined {

--- a/src/metrics/database.ts
+++ b/src/metrics/database.ts
@@ -78,7 +78,7 @@ function createMetricsPayload(v: Metrics): Metrics {
  * We have one store in this format for each lifetime: user, ping and application.
  *
  */
-class Database {
+class MetricsDatabase {
   private userStore: Store;
   private pingStore: Store;
   private appStore: Store;
@@ -221,7 +221,7 @@ class Database {
    * @returns An object containing all the metrics recorded to the given ping,
    *          `undefined` in case the ping doesn't contain any recorded metrics.
    */
-  async getPing(ping: string, clearPingLifetimeData: boolean): Promise<Metrics | undefined> {
+  async getPingMetrics(ping: string, clearPingLifetimeData: boolean): Promise<Metrics | undefined> {
     const userData = await this.getAndValidatePingData(ping, Lifetime.User);
     const pingData = await this.getAndValidatePingData(ping, Lifetime.Ping);
     const appData = await this.getAndValidatePingData(ping, Lifetime.Application);
@@ -267,4 +267,4 @@ class Database {
   }
 }
 
-export default Database;
+export default MetricsDatabase;

--- a/src/metrics/types/boolean.ts
+++ b/src/metrics/types/boolean.ts
@@ -40,7 +40,7 @@ class BooleanMetricType extends MetricType {
     }
 
     const metric = new BooleanMetric(value);
-    await Glean.db.record(this, metric);
+    await Glean.metricsDatabase.record(this, metric);
   }
 
   /**
@@ -57,7 +57,7 @@ class BooleanMetricType extends MetricType {
    * @returns The value found in storage or `undefined` if nothing was found.
    */
   async testGetValue(ping: string): Promise<boolean | undefined> {
-    return Glean.db.getMetric<boolean>(ping, this);
+    return Glean.metricsDatabase.getMetric<boolean>(ping, this);
   }
 }
 

--- a/src/metrics/types/counter.ts
+++ b/src/metrics/types/counter.ts
@@ -87,7 +87,7 @@ class CounterMetricType extends MetricType {
       };
     })(amount);
 
-    await Glean.db.transform(this, transformFn);
+    await Glean.metricsDatabase.transform(this, transformFn);
   }
 
   /**
@@ -104,7 +104,7 @@ class CounterMetricType extends MetricType {
    * @returns The value found in storage or `undefined` if nothing was found.
    */
   async testGetValue(ping: string): Promise<number | undefined> {
-    return Glean.db.getMetric<number>(ping, this);
+    return Glean.metricsDatabase.getMetric<number>(ping, this);
   }
 }
 

--- a/src/metrics/types/datetime.ts
+++ b/src/metrics/types/datetime.ts
@@ -40,6 +40,14 @@ export class DatetimeMetric extends Metric<DatetimeInternalRepresentation, strin
     super(v);
   }
 
+  static fromDate(v: Date, timeUnit: TimeUnit): DatetimeMetric {
+    return new DatetimeMetric({
+      timeUnit,
+      timezone: v.getTimezoneOffset(),
+      date: v.toISOString()
+    });
+  }
+
   /**
    * Gets the datetime data as a Date object.
    *
@@ -198,11 +206,7 @@ class DatetimeMetricType extends MetricType {
       break;
     }
 
-    const metric = new DatetimeMetric({
-      timeUnit: this.timeUnit,
-      timezone: value.getTimezoneOffset(),
-      date: value.toISOString(),
-    });
+    const metric = DatetimeMetric.fromDate(value, this.timeUnit);
     await Glean.metricsDatabase.record(this, metric);
   }
 

--- a/src/metrics/types/datetime.ts
+++ b/src/metrics/types/datetime.ts
@@ -203,7 +203,7 @@ class DatetimeMetricType extends MetricType {
       timezone: value.getTimezoneOffset(),
       date: value.toISOString(),
     });
-    await Glean.db.record(this, metric);
+    await Glean.metricsDatabase.record(this, metric);
   }
 
   /**
@@ -220,7 +220,7 @@ class DatetimeMetricType extends MetricType {
    * @returns The value found in storage or `undefined` if nothing was found.
    */
   private async testGetValueAsDatetimeMetric(ping: string): Promise<DatetimeMetric | undefined> {
-    const value = await Glean.db.getMetric<DatetimeInternalRepresentation>(ping, this);
+    const value = await Glean.metricsDatabase.getMetric<DatetimeInternalRepresentation>(ping, this);
     if (value) {
       return new DatetimeMetric(value);
     }

--- a/src/metrics/utils.ts
+++ b/src/metrics/utils.ts
@@ -5,11 +5,11 @@
 import { Metric } from "metrics";
 import { JSONValue } from "utils";
 
-import { BooleanMetric } from "metrics/boolean";
-import { CounterMetric } from "metrics/counter";
-import { StringMetric } from "metrics/string";
-import { UUIDMetric } from "metrics/uuid";
-import { DatetimeMetric } from "./datetime";
+import { BooleanMetric } from "metrics/types/boolean";
+import { CounterMetric } from "metrics/types/counter";
+import { StringMetric } from "metrics/types/string";
+import { UUIDMetric } from "metrics/types/uuid";
+import { DatetimeMetric } from "./types/datetime";
 
 /**
  * A map containing all supported internal metrics and its constructors.

--- a/src/pings/database.ts
+++ b/src/pings/database.ts
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Metrics as MetricsPayload } from "metrics/database";
+import { Store } from "storage";
+import PersistentStore from "storage/persistent";
+import { JSONObject } from "utils";
+
+export interface PingInfo extends JSONObject {
+  seq: number,
+  start_time: string,
+  end_time: string,
+  reason?: string,
+}
+
+export interface ClientInfo extends JSONObject {
+  client_id?: string,
+  locale?: string,
+  device_model?: string,
+  device_manufacturer?: string,
+  app_channel?: string,
+  // Even though all the next fields are required by the schema
+  // we can't guarantee that they will be present.
+  // Active discussion about this is happening on Bug 1685705.
+  app_build?: string,
+  app_display_version?: string,
+  architecture?: string,
+  first_run_date?: string,
+  os?: string,
+  os_version?: string,
+  telemetry_sdk_build: string
+}
+
+/**
+ * This definition must be in sync with
+ * the Glean ping [schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/glean/glean/glean.1.schema.json)
+ */
+export interface PingPayload extends JSONObject {
+  ping_info: PingInfo,
+  client_info: ClientInfo,
+  metrics?: MetricsPayload,
+  events?: JSONObject,
+}
+
+/**
+ * Debug headers to be added to a ping.
+ */
+export interface PingHeaders extends JSONObject {
+  "X-Debug-Id"?: string,
+  "X-Source-Tags"?: string,
+}
+
+
+/**
+ * The pings database is an abstraction layer on top of the underlying storage.
+ *
+ * Ping data is saved to the database in the following format:
+ *
+ * {
+ *  "<identifier>": {
+ *    "path": string,
+ *    "payload": PingPayload,
+ *    "headers": PingHeaders,
+ *  }
+ * }
+ */
+class PingsDatabase {
+  private store: Store;
+
+  constructor() {
+    this.store = new PersistentStore("pings");
+  }
+
+  /**
+   * Records a new ping to the ping database.
+   *
+   * @param path The path where this ping must be submitted to.
+   * @param identifier The identifier under which to store the ping.
+   * @param payload The payload of the ping to record.
+   * @param headers Optional headers to include on the final ping request.
+   */
+  async recordPing(
+    path: string,
+    identifier: string,
+    payload: PingPayload,
+    headers?: PingHeaders
+  ): Promise<void> {
+    await this.store.update([identifier], () => {
+      const base = {
+        path,
+        payload
+      };
+      return headers ? { ...base, headers } : base;
+    });
+  }
+
+  /**
+   * Clears all the pings from the database.
+   */
+  async clearAll(): Promise<void> {
+    await this.store.delete([]);
+  }
+}
+
+export default PingsDatabase;

--- a/src/pings/index.ts
+++ b/src/pings/index.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { v4 as UUIDv4 } from "uuid";
+
+import collectAndStorePing from "pings/maker";
+import Glean from "glean";
+
+/**
+ * Stores information about a ping.
+ *
+ * This is required so that given metric data queued on disk we can send
+ * pings with the correct settings, e.g. whether it has a client_id.
+ */
+class PingType {
+  /**
+   * Creates a new ping type for the given name,
+   * whether to include the client ID and whether to send this ping empty.
+   *
+   * @param name  The name of the ping.
+   * @param includeClientId Whether to include the client ID in the assembled ping when submitting.
+   * @param sendIfEmtpy Whether the ping should be sent empty or not.
+   * @param reasonCodes The valid reason codes for this ping.
+   */
+  constructor (
+    readonly name: string,
+    readonly includeClientId: boolean,
+    readonly sendIfEmtpy: boolean,
+    readonly reasonCodes: string[]
+  ) {}
+
+  /**
+   * Collects and submits a ping for eventual uploading.
+   *
+   * The ping content is assembled as soon as possible, but upload is not
+   * guaranteed to happen immediately, as that depends on the upload policies.
+   *
+   * If the ping currently contains no content, it will not be sent,
+   * unless it is configured to be sent if empty.
+   *
+   * @param reason The reason the ping was triggered. Included in the
+   *               `ping_info.reason` part of the payload.
+   *
+   * @returns Whether or not the ping was successfully submitted.
+   */
+  async submit(reason?: string): Promise<boolean> {
+    if (!Glean.uploadEnabled) {
+      console.info("Glean disabled: not submitting any pings.");
+      return false;
+    }
+
+    let correctedReason = reason;
+    if (reason && !this.reasonCodes.includes(reason)) {
+      console.error(`Invalid reason code ${reason} from ${this.name}. Ignoring.`);
+      correctedReason = undefined;
+    }
+
+    const identifier = UUIDv4();
+    await collectAndStorePing(identifier, this, correctedReason);
+    return true;
+  }
+}
+
+export default PingType;

--- a/src/pings/maker.ts
+++ b/src/pings/maker.ts
@@ -1,0 +1,219 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { GLEAN_SCHEMA_VERSION, GLEAN_VERSION, PING_INFO_STORAGE, CLIENT_INFO_STORAGE } from "../constants";
+import CounterMetricType, { CounterMetric } from "metrics/types/counter";
+import DatetimeMetricType, { DatetimeMetric } from "metrics/types/datetime";
+import { Lifetime } from "metrics";
+import TimeUnit from "metrics/time_unit";
+import { ClientInfo, PingInfo, PingHeaders, PingPayload } from "pings/database";
+import PingType from "pings";
+import Glean from "glean";
+
+/**
+ * Gets, and then increments, the sequence number for a given ping.
+ *
+ * @param ping The ping for which we want to get the sequence number.
+ *
+ * @returns The current number (before incrementing).
+ */
+export async function getSequenceNumber(ping: PingType): Promise<number> {
+  const seq = new CounterMetricType({
+    name: `${ping.name}#sequence`,
+    sendInPings: [PING_INFO_STORAGE],
+    lifetime: Lifetime.User,
+    disabled: false
+  });
+
+  const currentSeqData = await Glean.metricsDatabase.getMetric(PING_INFO_STORAGE, seq);
+  await seq.add(1);
+
+  if (currentSeqData) {
+    // Creating a new counter metric validates that the metric stored is actually a number.
+    // When we `add` we deal with getting rid of that number from storage,
+    // no need to worry about that here.
+    try {
+      const metric = new CounterMetric(currentSeqData);
+      return metric.payload();
+    } catch(e) {
+      console.warn(`Unexpected value found for sequence number in ping ${ping.name}. Ignoring.`);
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Gets the formatted start and end times for this ping
+ * and updates for the next ping.
+ *
+ * @param ping The ping for which we want to get the times.
+ *
+ * @returns An object containing start and times in their payload format.
+ */
+export async function getStartEndTimes(ping: PingType): Promise<{ startTime: string, endTime: string }> {
+  const start = new DatetimeMetricType({
+    name: `${ping.name}#start`,
+    sendInPings: [PING_INFO_STORAGE],
+    lifetime: Lifetime.User,
+    disabled: false
+  }, TimeUnit.Minute);
+
+  // "startTime" is the time the ping was generated the last time.
+  // If not available, we use the date the Glean object was initialized.
+  const startTimeData = await Glean.metricsDatabase.getMetric(PING_INFO_STORAGE, start);
+  let startTime: DatetimeMetric;
+  if (startTimeData) {
+    startTime = new DatetimeMetric(startTimeData);
+  } else {
+    startTime = DatetimeMetric.fromDate(Glean.startTime, TimeUnit.Minute);
+  }
+
+  // Update the start time with the current time.
+  const endTimeData = new Date();
+  await start.set(endTimeData);
+  const endTime = DatetimeMetric.fromDate(endTimeData, TimeUnit.Minute);
+
+  return {
+    startTime: startTime.payload(),
+    endTime: endTime.payload()
+  };
+}
+
+/**
+ * Builds the `ping_info` section of a ping.
+ *
+ * @param ping The ping to build the `ping_info` section for.
+ * @param reason The reason for submitting this ping.
+ *
+ * @returns The final `ping_info` section in its payload format.
+ */
+export async function buildPingInfoSection(ping: PingType, reason?: string): Promise<PingInfo> {
+  const seq = await getSequenceNumber(ping);
+  const { startTime, endTime } = await getStartEndTimes(ping);
+
+  const pingInfo: PingInfo = {
+    seq,
+    start_time: startTime,
+    end_time: endTime
+  };
+
+  if (reason) {
+    pingInfo.reason = reason;
+  }
+
+  return pingInfo;
+}
+
+/**
+ * Builds the `client_info` section of a ping.
+ *
+ * @param ping The ping to build the `client_info` section for.
+ *
+ * @returns The final `client_info` section in its payload format.
+ */
+export async function buildClientInfoSection(ping: PingType): Promise<ClientInfo> {
+  let clientInfo = await Glean.metricsDatabase.getPingMetrics(CLIENT_INFO_STORAGE, true);
+  if (!clientInfo) {
+    // TODO: Watch Bug 1685705 and change behaviour in here accordingly.
+    console.warn("Empty client info data. Will submit anyways.");
+    clientInfo = {};
+  }
+
+  let finalClientInfo: ClientInfo = {
+    "telemetry_sdk_build": GLEAN_VERSION
+  };
+  for (const metricType in clientInfo) {
+    finalClientInfo = { ...finalClientInfo, ...clientInfo[metricType] };
+  }
+
+  if (!ping.includeClientId) {
+    delete finalClientInfo["client_id"];
+  }
+
+  return finalClientInfo;
+}
+
+/**
+ * Gathers all the headers to be included to the final ping request.
+ *
+ * This guarantees that if headers are disabled after the ping collection,
+ * ping submission will still contain the desired headers.
+ *
+ * The current headers gathered here are:
+ * - [X-Debug-Id]
+ * - [X-Source-Tags]
+ *
+ * @returns An object with the headers to include
+ *          or `undefined` if there are no headers to include.
+ */
+export async function getPingHeaders(): Promise<PingHeaders | undefined> {
+  // TODO: Returning nothing for now until Bug 1685718 is resolved.
+  return;
+}
+
+/**
+ * Collects a snapshot for the given ping from storage and attach required meta information.
+ *
+ * @param ping The ping to collect for.
+ * @param reason An optional reason code to include in the ping.
+ *
+ * @returns A fully assembled JSON representation of the ping payload.
+ *          If there is no data stored for the ping, `undefined` is returned.
+ */
+export async function collectPing(ping: PingType, reason?: string): Promise<PingPayload | undefined> {
+  const metricsData = await Glean.metricsDatabase.getPingMetrics(ping.name, true);
+  if (!metricsData && !ping.sendIfEmtpy) {
+    console.info(`Storage for ${ping.name} empty. Bailing out.`);
+    return;
+  } else if (!metricsData) {
+    console.info(`Storage for ${ping.name} empty. Ping will still be sent.`);
+  }
+
+  const metrics = metricsData ? { metrics: metricsData } : {};
+  const pingInfo = await buildPingInfoSection(ping, reason);
+  const clientInfo = await buildClientInfoSection(ping);
+  return {
+    ...metrics,
+    ping_info: pingInfo,
+    client_info: clientInfo,
+  };
+}
+
+/**
+ * Build a pings submition path.
+ *
+ * @param identifier The pings UUID identifier.
+ * @param ping  The ping to build a path for.
+ *
+ * @returns The final submission path.
+ */
+function makePath(identifier: string, ping: PingType): string {
+  return `/submit/${Glean.applicationId}/${ping.name}/${GLEAN_SCHEMA_VERSION}/${identifier}`;
+}
+
+/**
+ * Collects and stores a ping on the pings database.
+ *
+ * @param identifier The pings UUID identifier.
+ * @param ping The ping to submit.
+ * @param reason An optional reason code to include in the ping.
+ *
+ * @returns A promise that is resolved once collection and storing is done.
+ */
+export async function collectAndStorePing(identifier: string, ping: PingType, reason?: string): Promise<void> {
+  const payload = await collectPing(ping, reason);
+  if (!payload) {
+    return;
+  }
+  const headers = await getPingHeaders();
+  return Glean.pingsDatabase.recordPing(
+    makePath(identifier, ping),
+    identifier,
+    payload,
+    headers
+  );
+}
+
+export default collectAndStorePing;

--- a/src/pings/maker.ts
+++ b/src/pings/maker.ts
@@ -11,6 +11,9 @@ import { ClientInfo, PingInfo, PingHeaders, PingPayload } from "pings/database";
 import PingType from "pings";
 import Glean from "glean";
 
+// The moment the current Glean.js session started.
+const GLEAN_START_TIME = new Date();
+
 /**
  * Gets, and then increments, the sequence number for a given ping.
  *
@@ -67,7 +70,7 @@ export async function getStartEndTimes(ping: PingType): Promise<{ startTime: str
   if (startTimeData) {
     startTime = new DatetimeMetric(startTimeData);
   } else {
-    startTime = DatetimeMetric.fromDate(Glean.startTime, TimeUnit.Minute);
+    startTime = DatetimeMetric.fromDate(GLEAN_START_TIME, TimeUnit.Minute);
   }
 
   // Update the start time with the current time.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,3 +92,26 @@ export function isBoolean(v: unknown): v is boolean {
 export function isNumber(v: unknown): v is number {
   return ((typeof v === "number" || (typeof v === "object" && v !== null && v.constructor === Number)) && !isNaN(v));
 }
+
+/**
+ * Generates a pipeline-friendly string
+ * that replaces non alphanumeric characters with dashes.
+ *
+ * @param applicationId The application if to sanitize.
+ *
+ * @returns The sanitized applicaiton id.
+ */
+export function sanitizeApplicationId(applicationId: string): string {
+  let result = "";
+  const tester = /([a-z0-9])/i;
+  for (let i = 0; i < applicationId.length; i++) {
+    if (tester.test(applicationId[i])) {
+      result += applicationId[i].toLowerCase();
+    } else {
+      if (result[result.length - 1] !== "-") {
+        result += "-";
+      }
+    }
+  }
+  return result;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@
 // We will intentionaly leave `null` out even though it is a valid JSON primitive.
 export type JSONPrimitive = string | number | boolean;
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
-export type JSONObject = { [member: string]: JSONValue };
+export type JSONObject = { [member: string]: JSONValue | undefined };
 export type JSONArray = JSONValue[];
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,16 +102,5 @@ export function isNumber(v: unknown): v is number {
  * @returns The sanitized applicaiton id.
  */
 export function sanitizeApplicationId(applicationId: string): string {
-  let result = "";
-  const tester = /([a-z0-9])/i;
-  for (let i = 0; i < applicationId.length; i++) {
-    if (tester.test(applicationId[i])) {
-      result += applicationId[i].toLowerCase();
-    } else {
-      if (result[result.length - 1] !== "-") {
-        result += "-";
-      }
-    }
-  }
-  return result;
+  return applicationId.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
 }

--- a/tests/metrics/boolean.spec.ts
+++ b/tests/metrics/boolean.spec.ts
@@ -5,7 +5,7 @@
 import assert from "assert";
 
 import Glean from "glean";
-import BooleanMetricType from "metrics/boolean";
+import BooleanMetricType from "metrics/types/boolean";
 import { Lifetime } from "metrics";
 
 describe("BooleanMetric", function() {
@@ -52,7 +52,7 @@ describe("BooleanMetric", function() {
     await metric.set(true);
     assert.strictEqual(await metric.testGetValue("aPing"), true);
 
-    const snapshot = await Glean.db.getPing("aPing", true);
+    const snapshot = await Glean.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "boolean": {
         "aCategory.aBooleanMetric": true

--- a/tests/metrics/counter.spec.ts
+++ b/tests/metrics/counter.spec.ts
@@ -5,7 +5,7 @@
 import assert from "assert";
 
 import Glean from "glean";
-import CounterMetricType from "metrics/counter";
+import CounterMetricType from "metrics/types/counter";
 import { Lifetime } from "metrics";
   
 describe("CounterMetric", function() {
@@ -52,7 +52,7 @@ describe("CounterMetric", function() {
     await metric.add(10);
     assert.strictEqual(await metric.testGetValue("aPing"), 10);
   
-    const snapshot = await Glean.db.getPing("aPing", true);
+    const snapshot = await Glean.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "counter": {
         "aCategory.aCounterMetric": 10

--- a/tests/metrics/database.spec.ts
+++ b/tests/metrics/database.spec.ts
@@ -4,9 +4,9 @@
 
 import assert from "assert";
 
-import Database, { isValidInternalMetricsRepresentation } from "database";
+import Database, { isValidInternalMetricsRepresentation } from "metrics/database";
 import { Lifetime } from "metrics";
-import StringMetricType, { StringMetric } from "metrics/string";
+import StringMetricType, { StringMetric } from "metrics/types/string";
 import { JSONValue } from "utils";
 
 describe("Database", function() {
@@ -232,7 +232,7 @@ describe("Database", function() {
     });
   });
 
-  describe("getPing", function() {
+  describe("getPingMetrics", function() {
     it("isValidInternalMetricsRepresentation validates correctly", function() {
       // Invalids
       assert.strictEqual(false, isValidInternalMetricsRepresentation("not even an object"));
@@ -273,7 +273,7 @@ describe("Database", function() {
     it("when incorrect data is found on the storage, it is deleted", async function() {
       const db = new Database();
       await db["appStore"].update(["aPing"], () => "not even a string");
-      assert.strictEqual(await db.getPing("aPing", false), undefined);
+      assert.strictEqual(await db.getPingMetrics("aPing", false), undefined);
       assert.strictEqual(await db["appStore"].get(["aPing"]), undefined);
     });
 
@@ -292,7 +292,7 @@ describe("Database", function() {
         }
       }));
 
-      assert.deepStrictEqual(await db.getPing("aPing", false), {
+      assert.deepStrictEqual(await db.getPingMetrics("aPing", false), {
         "string": {
           "string.one": "foo",
           "string.two": "bar",
@@ -334,7 +334,7 @@ describe("Database", function() {
         },
       }));
 
-      assert.deepStrictEqual(await db.getPing("aPing", false), {
+      assert.deepStrictEqual(await db.getPingMetrics("aPing", false), {
         "boolean": {
           "client_info.client_id": false,
           "this.is": true,
@@ -380,7 +380,7 @@ describe("Database", function() {
       });
       await db.record(appMetric, new StringMetric("appValue"));
 
-      await db.getPing("aPing", true);
+      await db.getPingMetrics("aPing", true);
       assert.notDeepStrictEqual(await db["userStore"]._getWholeStore(), {});
       assert.deepStrictEqual(await db["pingStore"]._getWholeStore(), {});
       assert.notDeepStrictEqual(await db["appStore"]._getWholeStore(), {});

--- a/tests/metrics/database.spec.ts
+++ b/tests/metrics/database.spec.ts
@@ -9,7 +9,7 @@ import { Lifetime } from "metrics";
 import StringMetricType, { StringMetric } from "metrics/types/string";
 import { JSONValue } from "utils";
 
-describe("Database", function() {
+describe("MetricsDatabase", function() {
   describe("record", function() {
     it("records to the correct place at the underlying store", async function() {
       const db = new Database();

--- a/tests/metrics/datetime.spec.ts
+++ b/tests/metrics/datetime.spec.ts
@@ -6,7 +6,7 @@ import assert from "assert";
 import sinon from "sinon";
 
 import Glean from "glean";
-import DatetimeMetricType, { DatetimeMetric } from "metrics/datetime";
+import DatetimeMetricType, { DatetimeMetric } from "metrics/types/datetime";
 import { Lifetime } from "metrics";
 import TimeUnit from "metrics/time_unit";
 
@@ -93,7 +93,7 @@ describe("DatetimeMetric", function() {
     await metric.set(new Date(1995, 4, 25, 8, 15, 45, 385));
     assert.strictEqual(await metric.testGetValueAsString("aPing"), "1995-05-25T08:15+05:00");
 
-    const snapshot = await Glean.db.getPing("aPing", true);
+    const snapshot = await Glean.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "datetime": {
         "aCategory.aDatetimeMetric": "1995-05-25T08:15+05:00"
@@ -203,7 +203,7 @@ describe("DatetimeMetric", function() {
       timezone: 60,
       date: "2021-01-07T14:41:26.312Z"
     });
-    await Glean.db.record(metric, concreteMetric);
+    await Glean.metricsDatabase.record(metric, concreteMetric);
 
     // 1. The monkeypatched timezone it -300 (+05:00)
     // 2. The timezone manually set on the metric above is 60 (-01:00)

--- a/tests/metrics/string.spec.ts
+++ b/tests/metrics/string.spec.ts
@@ -5,7 +5,7 @@
 import assert from "assert";
 
 import Glean from "glean";
-import StringMetricType, { MAX_LENGTH_VALUE } from "metrics/string";
+import StringMetricType, { MAX_LENGTH_VALUE } from "metrics/types/string";
 import { Lifetime } from "metrics";
  
 describe("StringMetric", function() {
@@ -52,7 +52,7 @@ describe("StringMetric", function() {
     await metric.set("test_string_value");
     assert.strictEqual(await metric.testGetValue("aPing"), "test_string_value");
  
-    const snapshot = await Glean.db.getPing("aPing", true);
+    const snapshot = await Glean.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "string": {
         "aCategory.aStringMetric": "test_string_value"

--- a/tests/metrics/uuid.spec.ts
+++ b/tests/metrics/uuid.spec.ts
@@ -6,7 +6,7 @@ import assert from "assert";
 import { v4 as UUIDv4 } from "uuid";
 
 import Glean from "glean";
-import UUIDMetricType from "metrics/uuid";
+import UUIDMetricType from "metrics/types/uuid";
 import { Lifetime } from "metrics";
  
 describe("UUIDMetric", function() {
@@ -69,7 +69,7 @@ describe("UUIDMetric", function() {
     await metric.set(expected);
     assert.strictEqual(await metric.testGetValue("aPing"), expected);
 
-    const snapshot = await Glean.db.getPing("aPing", true);
+    const snapshot = await Glean.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "uuid": {
         "aCategory.aUUIDMetric": expected

--- a/tests/pings/database.spec.ts
+++ b/tests/pings/database.spec.ts
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import assert from "assert";
+
+import Database from "pings/database";
+
+describe("PingsDatabase", function() {
+  it("records correctly to the correct place at the underlying storage", async function() {
+    const db = new Database();
+    const path = "some/random/path/doesnt/matter";
+    const identifier = "THE IDENTIFIER";
+    const payload = {
+      ping_info: {
+        seq: 1,
+        start_time: "2020-01-11+01:00",
+        end_time: "2020-01-12+01:00",
+      },
+      client_info: {
+        telemetry_sdk_build: "32.0.0"
+      }
+    };
+    await db.recordPing(path, identifier, payload);
+    assert.deepStrictEqual(await db["store"].get([identifier]), {
+      path, payload
+    });
+
+    const headers = { "X-Debug-Id": "test" };
+    const otherIdentifier = "THE OTHER IDENTIFIER";
+    await db.recordPing(path, otherIdentifier, payload, headers);
+    assert.deepStrictEqual(await db["store"].get([otherIdentifier]), {
+      path, payload, headers
+    });
+
+    assert.strictEqual(Object.keys(await db["store"]._getWholeStore()).length, 2);
+  });
+
+  it("clearing works", async function() {
+    const db = new Database();
+    const path = "some/random/path/doesnt/matter";
+    const payload = {
+      ping_info: {
+        seq: 1,
+        start_time: "2020-01-11+01:00",
+        end_time: "2020-01-12+01:00",
+      },
+      client_info: {
+        telemetry_sdk_build: "32.0.0"
+      }
+    };
+
+    await db.recordPing(path, "foo", payload);
+    await db.recordPing(path, "bar", payload);
+    await db.recordPing(path, "baz", payload);
+    await db.recordPing(path, "qux", payload);
+    assert.strictEqual(Object.keys(await db["store"]._getWholeStore()).length, 4);
+
+    await db.clearAll();
+    assert.strictEqual(Object.keys(await db["store"]._getWholeStore()).length, 0);
+  });
+});

--- a/tests/pings/index.spec.ts
+++ b/tests/pings/index.spec.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import assert from "assert";
+
+import PingType from "pings";
+import CounterMetricType from "metrics/types/counter";
+import { Lifetime } from "metrics";
+import Glean from "glean";
+
+describe("PingType", function() {
+  beforeEach(async function() {
+    await Glean.testRestGlean();
+  });
+
+  it("collects and stores ping on submit", async function () {
+    const ping = new PingType("custom", true, false, []);
+    const counter = new CounterMetricType({
+      category: "aCategory",
+      name: "aCounterMetric",
+      sendInPings: ["custom"],
+      lifetime: Lifetime.Ping,
+      disabled: false
+    });
+    await counter.add();
+
+    assert.ok(await ping.submit());
+    // TODO: Make this nicer once we have a nice way to check if pings are enqueued,
+    // possibly once Bug 1677440 is resolved.
+    const storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    assert.strictEqual(Object.keys(storedPings).length, 1);
+  });
+
+  it("empty pings with send if emtpy flag are submitted", async function () {
+    const ping1 = new PingType("ping1", true, false, []);
+    const ping2 = new PingType("ping2", true, true, []);
+
+
+    // TODO: Make this nicer once we have a nice way to check if pings are enqueued,
+    // possibly once Bug 1677440 is resolved.
+    assert.ok(await ping1.submit());
+    let storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    assert.strictEqual(Object.keys(storedPings).length, 0);
+
+    assert.ok(await ping2.submit());
+    storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    assert.strictEqual(Object.keys(storedPings).length, 1);
+  });
+
+  it("no pings are submitted if upload is disabled", async function() {
+    Glean.uploadEnabled = false;
+
+    const ping = new PingType("custom", true, false, []);
+    assert.strictEqual(await ping.submit(), false);
+    // TODO: Make this nicer once we have a nice way to check if pings are enqueued,
+    // possibly once Bug 1677440 is resolved.
+    const storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    assert.strictEqual(Object.keys(storedPings).length, 0);
+  });
+});

--- a/tests/pings/maker.spec.ts
+++ b/tests/pings/maker.spec.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import assert from "assert";
+
+import PingType from "pings";
+import * as PingMaker from "pings/maker";
+import Glean from "glean";
+
+describe("PingMaker", function() {
+  beforeEach(async function() {
+    await Glean.testRestGlean();
+  });
+
+  it("ping info must contain a non-empty start and end time", async function() {
+    const ping = new PingType("custom", true, false, []);
+    const pingInfo = await PingMaker.buildPingInfoSection(ping);
+
+    const startTime = new Date(pingInfo.start_time);
+    const endTime = new Date(pingInfo.end_time);
+
+    assert.ok(startTime.getTime() <= endTime.getTime());
+  });
+
+  it("buildPingInfo must report all the required fields", async function() {
+    const ping = new PingType("custom", true, false, []);
+    const pingInfo = await PingMaker.buildPingInfoSection(ping);
+
+    assert.ok("seq" in pingInfo);
+    assert.ok("start_time" in pingInfo);
+    assert.ok("end_time" in pingInfo);
+  });
+
+  it("buildClientInfo must report all the available data", async function() {
+    const ping = new PingType("custom", true, false, []);
+    const clientInfo = await PingMaker.buildClientInfoSection(ping);
+
+    assert.ok("telemetry_sdk_build" in clientInfo);
+  });
+
+  it("collectPing must return `undefined` if pings that must not be sent if empty, is empty", async function() {
+    const ping = new PingType("custom", true, false, []);
+    assert.strictEqual(await PingMaker.collectPing(ping), undefined);
+  });
+
+  it("sequence numbers must be sequential", async function() {
+    const ping1 = new PingType("ping1", true, true, []);
+    const ping2 = new PingType("ping2", true, true, []);
+
+    for(let i = 0; i <= 10; i++) {
+      assert.strictEqual(await PingMaker.getSequenceNumber(ping1), i);
+      assert.strictEqual(await PingMaker.getSequenceNumber(ping2), i);
+    }
+
+    await PingMaker.getSequenceNumber(ping1);
+    assert.strictEqual(await PingMaker.getSequenceNumber(ping1), 12);
+    assert.strictEqual(await PingMaker.getSequenceNumber(ping2), 11);
+    assert.strictEqual(await PingMaker.getSequenceNumber(ping1), 13);
+  });
+});

--- a/tests/pings/maker.spec.ts
+++ b/tests/pings/maker.spec.ts
@@ -39,7 +39,7 @@ describe("PingMaker", function() {
     assert.ok("telemetry_sdk_build" in clientInfo);
   });
 
-  it("collectPing must return `undefined` if pings that must not be sent if empty, is empty", async function() {
+  it("collectPing must return `undefined` if ping that must not be sent if empty, is empty", async function() {
     const ping = new PingType("custom", true, false, []);
     assert.strictEqual(await PingMaker.collectPing(ping), undefined);
   });

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import assert from "assert";
-import { isBoolean, isNumber, isObject, isString, isUndefined } from "utils";
+import { isBoolean, isNumber, isObject, isString, isUndefined, sanitizeApplicationId } from "utils";
 
 describe("utils", function() {
   it("isObject validates correctly", function() {
@@ -76,5 +76,12 @@ describe("utils", function() {
     assert.strictEqual(isNumber(10), true);
     assert.strictEqual(isNumber(-10), true);
     assert.strictEqual(isNumber(new Number(10)), true);
+  });
+
+  it("sanitizeApplicationId works correctly", function() {
+    assert.strictEqual(sanitizeApplicationId("org.mozilla.test-app"), "org-mozilla-test-app");
+    assert.strictEqual(sanitizeApplicationId("org.mozilla..test---app"), "org-mozilla-test-app");
+    assert.strictEqual(sanitizeApplicationId("org-mozilla-test-app"), "org-mozilla-test-app");
+    assert.strictEqual(sanitizeApplicationId("org.mozilla.Test.App"), "org-mozilla-test-app");
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "strictNullChecks": true,
     "removeComments": true,
     "preserveConstEnums": true,
+    "resolveJsonModule": true,
     "typeRoots": [
       "node_modules/@types",
       "node_modules/web-ext-types"


### PR DESCRIPTION
This PR turned out to be bigger than I expected, there are many things interconnected. I tried to make it as lean as possible, but I can also break if off into two PRs, one for the pings database and another that relies on that for ping type and ping maker. Please let me know if you would like me to do that.

In Glean.js we can't just save pings in files, so I created the concept of a pings database, which is an abstraction over the underlying storage just like the metrics database.

