### PR TITLE
Bug 1687644 - Use the new external API on the web ext sample

### DIFF
--- a/samples/web-extension/generatedMetrics.js
+++ b/samples/web-extension/generatedMetrics.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+import Glean from "glean";
+
+export const webExtStarted = new Glean._private.DatetimeMetricType({
+  category: "sample",
+  name: "webext_installed",
+  sendInPings: ["sample"],
+  lifetime: "ping",
+  disabled: false
+}, "millisecond");
+
+export const popupOpened = new Glean._private.CounterMetricType({
+  category: "sample",
+  name: "popup_opened",
+  sendInPings: ["sample"],
+  lifetime: "ping",
+  disabled: false
+}, "millisecond");

--- a/samples/web-extension/generatedPings.js
+++ b/samples/web-extension/generatedPings.js
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+import Glean from "glean";
+
+export const samplePing = new Glean._private.PingType("sample", true, false);

--- a/samples/web-extension/index.js
+++ b/samples/web-extension/index.js
@@ -5,25 +5,11 @@
 "use strict";
 
 import Glean from "glean";
+import { samplePing } from "./generatedPings";
+import { webExtStarted, popupOpened } from "./generatedMetrics";
 
-// TODO: Once we have glean_parser generating pings and metrics,
-// remove this code.
-const samplePing = new Glean._private.PingType("sample", true, false);
-const webExtStarted = new Glean._private.DatetimeMetricType({
-  category: "sample",
-  name: "webext_installed",
-  sendInPings: ["sample"],
-  lifetime: "ping",
-  disabled: false
-}, "millisecond");
-const popupOpened = new Glean._private.CounterMetricType({
-  category: "sample",
-  name: "popup_opened",
-  sendInPings: ["sample"],
-  lifetime: "ping",
-  disabled: false
-}, "millisecond");
-
+// TODO: Do not wait for Glean to be initialized before recording metrics
+// once Bug 1687491 is resolved.
 Glean.initialize("web-extension", true)
   .then(() => {
     console.log("Glean has been succesfully initialized.");

--- a/samples/web-extension/index.js
+++ b/samples/web-extension/index.js
@@ -6,4 +6,46 @@
 
 import Glean from "glean";
 
-Glean.initialize("web-extension", true);
+// TODO: Once we have glean_parser generating pings and metrics,
+// remove this code.
+const samplePing = new Glean._private.PingType("sample", true, false);
+const webExtStarted = new Glean._private.DatetimeMetricType({
+  category: "sample",
+  name: "webext_installed",
+  sendInPings: ["sample"],
+  lifetime: "ping",
+  disabled: false
+}, "millisecond");
+const popupOpened = new Glean._private.CounterMetricType({
+  category: "sample",
+  name: "popup_opened",
+  sendInPings: ["sample"],
+  lifetime: "ping",
+  disabled: false
+}, "millisecond");
+
+Glean.initialize("web-extension", true)
+  .then(() => {
+    console.log("Glean has been succesfully initialized.");
+    webExtStarted.set()
+      .then(() => console.log("`webext-installed` was succesfully set."));
+  });
+
+// Listen for messages from the popup.
+browser.runtime.onMessage.addListener(msg => {
+  console.log(`New message received! ${msg}`);
+
+  if (msg === "popup-opened") {
+    popupOpened.add()
+      .then(() => console.log("`popup-opened` was succesfully added."));
+  }
+
+  if (msg === "send-ping") {
+    samplePing.submit()
+      .then(wasSubmitted => {
+        console.log(
+          `Attempted to send ping "${samplePing.name}". Was the ping sent? ${wasSubmitted}`);
+      });
+  }
+});
+

--- a/samples/web-extension/manifest.json
+++ b/samples/web-extension/manifest.json
@@ -6,9 +6,14 @@
   "version": "0.0.1",
   "background": {
     "scripts": [
+      "node_modules/webextension-polyfill/dist/browser-polyfill.min.js",
       "./dist/bundle.js"
     ]
   },
+  "permissions": [
+    "storage",
+    "https://incoming.telemetry.mozilla.org/"
+  ],
   "browser_action": {
     "browser_style": true,
     "default_icon": {

--- a/samples/web-extension/package-lock.json
+++ b/samples/web-extension/package-lock.json
@@ -554,6 +554,9 @@
     },
     "glean": {
       "version": "file:../..",
+      "requires": {
+        "uuid": "^8.3.2"
+      },
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.10.4",
@@ -2756,6 +2759,11 @@
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
         "v8-compile-cache": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
@@ -3585,6 +3593,11 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
+    },
+    "webextension-polyfill": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
+      "integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw=="
     },
     "webpack": {
       "version": "5.4.0",

--- a/samples/web-extension/package.json
+++ b/samples/web-extension/package.json
@@ -10,7 +10,8 @@
   "author": "The Glean Team <glean-team@mozilla.com>",
   "license": "MPL-2.0",
   "dependencies": {
-    "glean": "file://../../"
+    "glean": "file://../../",
+    "webextension-polyfill": "^0.7.0"
   },
   "devDependencies": {
     "webpack": "^5.4.0",

--- a/samples/web-extension/popup.html
+++ b/samples/web-extension/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-
+  <script type="text/javascript" src="node_modules/webextension-polyfill/dist/browser-polyfill.js"></script>
 </head>
 <body>
   <p style="margin: 2rem; text-align:center; min-width: 200px;">

--- a/samples/web-extension/popup.html
+++ b/samples/web-extension/popup.html
@@ -2,11 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <script type="text/javascript" src="popup.js"></script>
+
 </head>
 <body>
-  <p style="margin: 2rem;">
-    Now, inspect this web extension.
+  <p style="margin: 2rem; text-align:center; min-width: 200px;">
+    Everytime this pop-up is opened a counter metric ("popup_opened") is incremented :D
+    <br /><br />
+    <button id="send-ping">Send a ping!</button>
   </p>
+  <script type="text/javascript" src="popup.js"></script>
 </body>
 </html>

--- a/samples/web-extension/popup.js
+++ b/samples/web-extension/popup.js
@@ -4,4 +4,14 @@
 
 "use strict";
 
-console.info("Nothing will happen. Glean.js is not yet implemented.");
+const env = (typeof browser !== "undefined")
+  ? browser : (typeof chrome !== "undefined" ? chrome : null);
+
+// Let the background script know the pop up has been opened.
+env.runtime.sendMessage("popup-opened");
+
+const sendAPingButton = document.getElementById("send-ping");
+sendAPingButton.addEventListener("click", async () => {
+  // Tell the background script to upload a ping
+  env.runtime.sendMessage("send-ping");
+}, { passive: true });

--- a/samples/web-extension/popup.js
+++ b/samples/web-extension/popup.js
@@ -4,14 +4,11 @@
 
 "use strict";
 
-const env = (typeof browser !== "undefined")
-  ? browser : (typeof chrome !== "undefined" ? chrome : null);
-
 // Let the background script know the pop up has been opened.
-env.runtime.sendMessage("popup-opened");
+browser.runtime.sendMessage("popup-opened");
 
 const sendAPingButton = document.getElementById("send-ping");
 sendAPingButton.addEventListener("click", async () => {
   // Tell the background script to upload a ping
-  env.runtime.sendMessage("send-ping");
+  browser.runtime.sendMessage("send-ping");
 }, { passive: true });

--- a/samples/web-extension/webpack.config.js
+++ b/samples/web-extension/webpack.config.js
@@ -8,7 +8,7 @@ const path = require("path");
 
 module.exports = {
   entry: "./index.js",
-  devtool: "cheap-module-source-map",
+  devtool: "inline-source-map",
   output: {
     filename: "bundle.js",
     path: path.resolve(__dirname, "dist"),

--- a/src/glean.ts
+++ b/src/glean.ts
@@ -228,18 +228,10 @@ class Glean {
   }
 
   static get applicationId(): string | undefined {
-    if (!Glean.instance._initialized) {
-      console.warn("Attempted to access the Glean.applicationId before Glean was initialized.");
-    }
-
     return Glean.instance._applicationId;
   }
 
   static get serverEndpoint(): string | undefined {
-    if (!Glean.instance._initialized) {
-      console.warn("Attempted to access the Glean.serverEndpoint before Glean was initialized.");
-    }
-
     return Glean.instance._serverEndpoint;
   }
 
@@ -251,10 +243,6 @@ class Glean {
    * @returns Whether upload is enabled.
    */
   static isUploadEnabled(): boolean {
-    if (!Glean.instance._initialized) {
-      console.warn("Attempted to access the Glean.uploadEnabled before Glean was initialized.");
-    }
-
     return Glean.uploadEnabled;
   }
 

--- a/src/upload/uploader/browser.ts
+++ b/src/upload/uploader/browser.ts
@@ -46,7 +46,7 @@ class BrowserUploader extends Uploader {
     clearTimeout(timeout);
     return {
       result: UploadResultStatus.Success,
-      status: (await response.json()).status
+      status: response.status
     };
   }
 }


### PR DESCRIPTION
This is a continuation of #27.

Glean.js works :) See the pings sent from the sample: https://glean-debug-view-dev-237806.firebaseapp.com/pings/glean.js-test. Chrome and Firefox, but you'll need to take my word for it, that information is not in the metrics yet.

I did encounter some bugs upon testing in Chrome, which were not major so I fixed them. I think it will be important to have a kinda real testing playground for the next task I'll tackle which is [Bug 1687491](https://bugzilla.mozilla.org/show_bug.cgi?id=1687491).

It is also clear that in the future we will need to have automated testing in both browsers, the errors I fixed in the storage I only found because I tested in Chrome.