### PR TITLE
Bug 1687491 - Use the dispatcher on the boolean metric type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import Configuration from "config";
 
 // Private Glean types to export.
 import PingType from "pings";
-import BooleanMetricType from "metrics/types/boolean";
+import { BooleanMetricTypeExternal as BooleanMetricType } from "metrics/types/boolean";
 import CounterMetricType from "metrics/types/counter";
 import DatetimeMetricType from "metrics/types/datetime";
 import StringMetricType from "metrics/types/string";

--- a/src/metrics/types/boolean.ts
+++ b/src/metrics/types/boolean.ts
@@ -81,9 +81,7 @@ export class BooleanMetricTypeInternal extends BooleanMetricType {
       recordingAction = Glean.metricsDatabase.record(this, metric);
     });
 
-    if (recordingAction) {
-      await recordingAction;
-    }
+    await recordingAction;
   }
 }
 

--- a/tests/metrics/boolean.spec.ts
+++ b/tests/metrics/boolean.spec.ts
@@ -94,7 +94,7 @@ describe("BooleanMetric", function() {
     const spy = sandbox.spy(Glean.dispatcher, "launch");
     metric.set(true);
     assert.strictEqual(spy.callCount, 1);
-    await Glean.dispatcher.blockOnQueue();
+    await Glean.dispatcher.testBlockOnQueue();
     assert.strictEqual(await metric.testGetValue("aPing"), true);
   });
 });


### PR DESCRIPTION
Opening this as a draft as I would like some feedback before using the pattern chosen here on all the other metrics :)

Note to self: Interestingly enough the boolean metric type is _not_ used by Glean internally. Good candidate for a future metric type plugin test.