### PR TITLE
Bug 1687491 - Provide a way to test dispatched recording functions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,11 @@ interface Configuration {
   // The user visible version string fro the application running Glean.js.
   readonly appDisplayVersion?: string,
   // The server pings are sent to.
-  readonly serverEndpoint?: string
+  readonly serverEndpoint?: string,
+  // Whether or not Glean should be started in testing mode.
+  //
+  // This unlocks features that allows dispatcher tasks to be waited on.
+  readonly testing?: boolean
 }
 
 export default Configuration;

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -28,7 +28,7 @@ const enum Commands {
 }
 
 // A task the dispatcher knows how to execute.
-type Task = () => Promise<void>;
+export type Task = () => Promise<void>;
 
 // An executable command.
 type Command = {
@@ -109,7 +109,8 @@ class Dispatcher {
    *
    * # Note
    *
-   * Will not enqueue in case the dispatcher has not been initialized yet and the queues length exceeds `maxPreInitQueueSize`.
+   * Will not enqueue in case the dispatcher has not been initialized yet
+   * and the queues length exceeds `maxPreInitQueueSize`.
    *
    * @param task The task to enqueue.
    */
@@ -198,6 +199,23 @@ class Dispatcher {
   async testUninitialize(): Promise<void> {
     await this.clear();
     this.state = DispatcherState.Uninitialized;
+  }
+
+  /**
+   * Launches a task in test mode.
+   *
+   * @param task The task to launch.
+   *
+   * @returns A promise that resolves once the task is processed.
+   */
+  async testLaunch(task: Task): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return new Promise(resolve => {
+      this.launch(async () => {
+        await task();
+        resolve();
+      });
+    });
   }
 }
 

--- a/src/glean.ts
+++ b/src/glean.ts
@@ -39,6 +39,8 @@ class Glean {
   private _serverEndpoint?: string;
   // Whether or not to record metrics.
   private _uploadEnabled?: boolean;
+  // Whether or this Glean instance is in testing mode.
+  private _testing?: boolean;
 
   private constructor() {
     if (!isUndefined(Glean._instance)) {
@@ -185,6 +187,10 @@ class Glean {
       return;
     }
 
+    if (config?.testing) {
+      Glean.instance._testing = true;
+    }
+
     if (applicationId.length === 0) {
       throw new Error("Unable to initialize Glean, applicationId cannot be an empty string.");
     }
@@ -267,6 +273,15 @@ class Glean {
   }
 
   /**
+   * Whether or not Glean is currently in testing mode.
+   *
+   * @returns Whether or not Glean is currently in testing mode.
+   */
+  static get testing(): boolean {
+    return Glean.instance._testing || false;
+  }
+
+  /**
    * Determines whether upload is enabled.
    *
    * When upload is disabled, no data will be recorded.
@@ -346,7 +361,10 @@ class Glean {
     await Glean.pingsDatabase.clearAll();
 
     // Re-Initialize Glean.
-    await Glean.initialize(applicationId, uploadEnabled, config);
+    await Glean.initialize(applicationId, uploadEnabled, {
+      ...config,
+      testing: true,
+    });
   }
 }
 

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -4,6 +4,7 @@
 
 import { JSONValue } from "utils";
 import Glean from "glean";
+import { Task } from "dispatcher";
 
 /**
  * The Metric class describes the shared behaviour amongst concrete metrics.
@@ -115,6 +116,11 @@ export abstract class MetricType implements CommonMetricData {
   readonly lifetime: Lifetime;
   readonly disabled: boolean;
 
+  // Private list of ongoing dispatched recording tasks.
+  //
+  // This array will only be filled in testing mode.
+  #recording: Promise<void>[];
+
   constructor(type: string, meta: CommonMetricData) {
     this.type = type;
 
@@ -126,6 +132,8 @@ export abstract class MetricType implements CommonMetricData {
     if (meta.category) {
       this.category = meta.category;
     }
+
+    this.#recording = [];
   }
 
   /**
@@ -148,5 +156,39 @@ export abstract class MetricType implements CommonMetricData {
    */
   shouldRecord(): boolean {
     return (Glean.isUploadEnabled() && !this.disabled);
+  }
+
+  /**
+   * Dispatches a recording task to be performed asynchronously.
+   *
+   * If Glean is currently in testing mode the tasks are launched in canary mode
+   * and it's possible to use `testWaitOnRecordingTasks` to wait on them being completed.
+   *
+   * @param task The recording task.
+   */
+  dispatchRecordingTask(task: Task): void {
+    if (Glean.testing) {
+      const recordingTask = Glean.dispatcher.testLaunch(task);
+      this.#recording.push(recordingTask);
+      return;
+    }
+
+    Glean.dispatcher.launch(task);
+  }
+
+  /**
+   * **Test-only API**
+   *
+   * Allows the caller to block until all recording tasks related to this metric are completed.
+   *
+   * @returns A promise that returns once all ongoing recording tasks are completed.
+   */
+  async testBlockOnRecordingTasks(): Promise<void> {
+    if (!Glean.testing) {
+      console.error("Attempted to call a testing API, but Glean is not in testing mode.");
+      return;
+    }
+
+    await Promise.all(this.#recording);
   }
 }

--- a/src/metrics/types/boolean.ts
+++ b/src/metrics/types/boolean.ts
@@ -14,6 +14,7 @@ export class BooleanMetric extends Metric<boolean, boolean> {
   validate(v: unknown): v is boolean {
     return isBoolean(v);
   }
+
   payload(): boolean {
     return this._inner;
   }
@@ -34,13 +35,13 @@ class BooleanMetricType extends MetricType {
    *
    * @param value the value to set.
    */
-  async set(value: boolean): Promise<void> {
+  set(value: boolean): void {
     if (!this.shouldRecord()) {
       return;
     }
 
     const metric = new BooleanMetric(value);
-    await Glean.metricsDatabase.record(this, metric);
+    this.dispatchRecordingTask(() => Glean.metricsDatabase.record(this, metric));
   }
 
   /**
@@ -57,6 +58,7 @@ class BooleanMetricType extends MetricType {
    * @returns The value found in storage or `undefined` if nothing was found.
    */
   async testGetValue(ping: string): Promise<boolean | undefined> {
+    await this.testBlockOnRecordingTasks();
     return Glean.metricsDatabase.getMetric<boolean>(ping, this);
   }
 }

--- a/tests/metrics/boolean.spec.ts
+++ b/tests/metrics/boolean.spec.ts
@@ -3,14 +3,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import assert from "assert";
+import sinon from "sinon";
 
 import Glean from "glean";
 import BooleanMetricType from "metrics/types/boolean";
 import { Lifetime } from "metrics";
 
+const sandbox = sinon.createSandbox();
+
 describe("BooleanMetric", function() {
   beforeEach(async function() {
     await Glean.testResetGlean("something something");
+  });
+
+  afterEach(function () {
+    sandbox.restore();
   });
 
   it("attemping to get the value of a metric that hasn't been recorded doesn't error", async function() {
@@ -73,5 +80,23 @@ describe("BooleanMetric", function() {
     assert.strictEqual(await metric.testGetValue("aPing"), true);
     assert.strictEqual(await metric.testGetValue("twoPing"), true);
     assert.strictEqual(await metric.testGetValue("threePing"), true);
+  });
+
+  it("works fine when Glean is not in testing mode", async function() {
+    Glean["instance"]["_testing"] = false;
+
+    const metric = new BooleanMetricType({
+      category: "aCategory",
+      name: "aBooleanMetric",
+      sendInPings: ["aPing", "twoPing", "threePing"],
+      lifetime: Lifetime.Ping,
+      disabled: false
+    });
+
+    const spy = sandbox.spy(Glean.dispatcher, "launch");
+    metric.set(true);
+    assert.strictEqual(spy.callCount, 1);
+    await Glean.dispatcher.testBlockOnQueue();
+    assert.strictEqual(await metric.testGetValue("aPing"), true);
   });
 });


### PR DESCRIPTION
A different approach for using and testing dispatched functions, taking into account what we discussed offline eariler today.

This is a draft because I want to get feeback on the approach before using it on the other metrics.