### PR TITLE
Bug 1686685 -  Implement the deletion request ping

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,3 +35,6 @@ export const KNOWN_CLIENT_ID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
 
 // The default server pings are sent to.
 export const DEFAULT_TELEMETRY_ENDPOINT = "https://incoming.telemetry.mozilla.org";
+
+// The name of the deletion-request ping.
+export const DELETION_REQUEST_PING_NAME = "deletion-request";

--- a/src/glean.ts
+++ b/src/glean.ts
@@ -236,7 +236,7 @@ class Glean {
       // otherwise we will not be able to submit deletion-request pings if necessary.
       //
       // This is fine, we are inside a dispatched task that is guaranteed to run before any
-      // other task. Nothing will be executed before this function is over.
+      // other task. No external API call will be executed before we leave this task.
       Glean.instance._initialized = true;
   
       // The upload enabled flag may have changed since the last run, for

--- a/src/glean.ts
+++ b/src/glean.ts
@@ -263,75 +263,34 @@ class Glean {
     });
   }
 
-  /**
-   * Gets this Glean's instance metrics database.
-   *
-   * @returns This Glean's instance metrics database.
-   */
   static get metricsDatabase(): MetricsDatabase {
     return Glean.instance._db.metrics;
   }
 
-  /**
-   * Gets this Glean's instance events database.
-   *
-   * @returns This Glean's instance events database.
-   */
   static get eventsDatabase(): EventsDatabase {
     return Glean.instance._db.events;
   }
 
-
-  /**
-   * Gets this Glean's instance pings database.
-   *
-   * @returns This Glean's instance pings database.
-   */
   static get pingsDatabase(): PingsDatabase {
     return Glean.instance._db.pings;
   }
 
-  /**
-   * Gets this Glean's instance initialization status.
-   *
-   * @returns Whether or not the Glean singleton has been initialized.
-   */
   static get initialized(): boolean {
     return Glean.instance._initialized;
   }
 
-  /**
-   * Gets this Glean's instance application id.
-   *
-   * @returns The application id or `undefined` in case Glean has not been initialized yet.
-   */
   static get applicationId(): string | undefined {
     return Glean.instance._applicationId;
   }
 
-  /**
-   * Gets this Glean's instance server endpoint.
-   *
-   * @returns The server endpoint or `undefined` in case Glean has not been initialized yet.
-   */
   static get serverEndpoint(): string | undefined {
     return Glean.instance._config?.serverEndpoint;
   }
 
-  /**
-   * Whether or not to log pings upon collection.
-   *
-   * @returns Whether or not to log pings upon collection.
-   */
   static get logPings(): boolean {
     return Glean.instance._config?.debug?.logPings || false;
   }
 
-  /**
-   * Gets this Gleans's instance dispatcher.
-   *
-   * @returns The dispatcher instance.
-   */
   static get dispatcher(): Dispatcher {
     return Glean.instance._dispatcher;
   }

--- a/src/internal_pings.ts
+++ b/src/internal_pings.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { DELETION_REQUEST_PING_NAME } from "./constants";
+import PingType from "pings";
+
+/**
+ * Glean-provided pings, all enabled by default.
+ *
+ * Pings initialized here should be defined in `pings.yaml`
+ * and for now manually translated into JS code.
+ *
+ * TODO: This file should be auto-generated once Bug 1691365 is resolved.
+ */
+class CorePings {
+  // This ping is intended to communicate to the Data Pipeline
+  // that the user wishes to have their reported Telemetry data deleted.
+  // As such it attempts to send itself at the moment the user opts out of data collection.
+  readonly deletionRequest: PingType;
+
+  constructor() {
+    this.deletionRequest = new PingType(
+      DELETION_REQUEST_PING_NAME,
+      /* include client id */ true,
+      /* send if empty */ true
+    );
+  }
+}
+
+export default CorePings;

--- a/src/pings/index.ts
+++ b/src/pings/index.ts
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
-import collectAndStorePing from "pings/maker";
+import { DELETION_REQUEST_PING_NAME } from "../constants";
 import { generateUUIDv4 } from "utils";
+import collectAndStorePing from "pings/maker";
 import Glean from "glean";
 
 /**
@@ -21,14 +21,18 @@ class PingType {
    * @param name  The name of the ping.
    * @param includeClientId Whether to include the client ID in the assembled ping when submitting.
    * @param sendIfEmtpy Whether the ping should be sent empty or not.
-   * @param reasonCodes The valid reason codes for this ping.
+   * @param reasonCodes Optional. The valid reason codes for this ping.
    */
   constructor (
     readonly name: string,
     readonly includeClientId: boolean,
     readonly sendIfEmtpy: boolean,
-    readonly reasonCodes: string[]
+    readonly reasonCodes: string[] = []
   ) {}
+
+  private isDeletionRequest(): boolean {
+    return this.name === DELETION_REQUEST_PING_NAME;
+  }
 
   /**
    * Collects and submits a ping for eventual uploading.
@@ -48,9 +52,9 @@ class PingType {
         console.info("Glean must be initialized before submitting pings.");
         return;
       }
-  
-      if (!Glean.isUploadEnabled()) {
-        console.info("Glean disabled: not submitting any pings.");
+
+      if (!Glean.isUploadEnabled() && !this.isDeletionRequest()) {
+        console.info("Glean disabled: not submitting pings. Glean may still submit the deletion-request ping.");
         return;
       }
   

--- a/src/upload/index.ts
+++ b/src/upload/index.ts
@@ -148,7 +148,7 @@ class PingUploader implements PingsDatabaseObserver {
    * @returns The status number of the response or `undefined` if unable to attempt upload.
    */
   private async attemptPingUpload(ping: QueuedPing): Promise<UploadResult> {
-    if (!Glean.initialize) {
+    if (!Glean.initialized) {
       console.warn("Attempted to upload a ping, but Glean is not initialized yet. Ignoring.");
       return { result: UploadResultStatus.RecoverableFailure };
     }


### PR DESCRIPTION
The approach here is a bit different than the approach in glean-core.

I ported all the tests I found from the core and the android bindings and they all passed. 

**What's different?**

I skipped having a different storage for deletion requests and instead treat them as any other ping. I also added a special case, so that the deletion-request ping is sent even if upload is disabled.