### PR TITLE
Bug 1686678 - Prepare Glean.js to publish for web extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ workflows:
       - publish-webext:
           requires:
             - lint
-            - unit tests
+            - unit-tests
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,21 @@ jobs:
           name: Verify no Javascript errors found in Qt
           command: bin/qt-js-check.sh
 
+  publish-webext:
+    docker:
+      - image: cimg/node:14.13.1
+    steps:
+      - checkout
+      - run:
+          name: Install Javascript dependencies
+          command: npm install
+      - run:
+          name: NPM Authentication
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+      - run:
+          name: Publish to npm
+          command: export PATH=.:$PATH && npm run publish:webext
+
 
 workflows:
   version: 2
@@ -73,6 +88,15 @@ workflows:
       - lint
       - unit-tests
       - check-qt-js
+      - publish-webext:
+          requires:
+            - lint
+            - unit tests
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
       # Comment this job away until Bug 1681899 is resolved.
       # - check-size:
       #     filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Unreleased changes
+
+[Full changelog](https://github.com/mozilla/glean.js/compare/v0.1.0...main)
+
+* [#48](https://github.com/mozilla/glean.js/pull/48): Add this changelog file.
+* [#42](https://github.com/mozilla/glean.js/pull/42): Implement the `deletion-request` ping.
+* [#41](https://github.com/mozilla/glean.js/pull/41): Implement the `logPings` debug tool.
+  * When `logPings` is enabled, pings are logged upon collection.
+* [#40](https://github.com/mozilla/glean.js/pull/40): Use the dispatcher in all Glean external API functions. Namely:
+  * Metric recording functions;
+  * Ping submission;
+  * `initialize` and `setUploadEnabled`.
+* [#36](https://github.com/mozilla/glean.js/pull/36): Implement the event metric type.
+* [#31](https://github.com/mozilla/glean.js/pull/31): Implement a task Dispatcher to help in executing Promises in a deterministic order.
+* [#26](https://github.com/mozilla/glean.js/pull/26): Implement the setUploadEnable API.
+* [#25](https://github.com/mozilla/glean.js/pull/25): Implement an adapter that leverages browser APIs to upload pings.
+* [#24](https://github.com/mozilla/glean.js/pull/24): Implement a ping upload manager.
+* [#23](https://github.com/mozilla/glean.js/pull/23): Implement the initialize API and glean internal metrics.
+* [#22](https://github.com/mozilla/glean.js/pull/22): Implement the PingType structure and a ping maker.
+* [#20](https://github.com/mozilla/glean.js/pull/20): Implement the datetime metric type.
+* [#17](https://github.com/mozilla/glean.js/pull/17): Implement the UUID metric type.
+* [#14](https://github.com/mozilla/glean.js/pull/14): Implement the counter metric type.
+* [#13](https://github.com/mozilla/glean.js/pull/13): Implement the string metric type.
+* [#11](https://github.com/mozilla/glean.js/pull/11): Implement the boolean metric type.
+* [#9](https://github.com/mozilla/glean.js/pull/9): Implement a metrics database module.
+* [#8](https://github.com/mozilla/glean.js/pull/8): Implement a web extension version of the underlying storage module.
+* [#6](https://github.com/mozilla/glean.js/pull/6): Implement an abstract underlying storage module.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,4 @@
 {
-  "name": "glean",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -2186,6 +2185,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
       "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
+      "dev": true
+    },
+    "json": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/json/-/json-10.0.0.tgz",
+      "integrity": "sha512-iK7tAZtpoghibjdB1ncCWykeBMmke3JThUe+rnkD4qkZaglOIQ70Pw7r5UJ4lyUT+7gnw7ehmmLUHDuhqzQD+g==",
       "dev": true
     },
     "json-parse-better-errors": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "glean",
   "version": "0.1.0",
   "description": "An implementation of the Glean SDK, a modern cross-platform telemetry client, for Javascript environments.",
   "main": "./dist/glean.js",
@@ -13,11 +12,14 @@
     "dev:webext": "webpack --watch --config webpack.config.webext.js --mode development --devtool inline-source-map",
     "build:qt": "webpack --config webpack.config.qt.js --mode production",
     "dev:qt": "webpack --watch --config webpack.config.qt.js --mode development  --devtool inline-source-map",
-    "build:test-webext": "cd tests/utils/webext/sample/ && npm install && npm run build:xpi"
+    "build:test-webext": "cd tests/utils/webext/sample/ && npm install && npm run build:xpi",
+    "prepublish:webext": "npm run build:webext && json -I -f package.json -e \"this.name=\\\"@mozilla/glean-webext\\\"\"",
+    "publish:webext": "npm run prepublish:webext && npm publish",
+    "postpublish": "json -I -f package.json -e \"delete this.name\""
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/brizental/glean.js.git"
+    "url": "git+https://github.com/mozilla/glean.js.git"
   },
   "keywords": [
     "telemetry",
@@ -26,9 +28,9 @@
   "author": "The Glean Team <glean-team@mozilla.com>",
   "license": "MPL-2.0",
   "bugs": {
-    "url": "https://github.com/brizental/glean.js/issues"
+    "url": "https://bugzilla.mozilla.org/buglist.cgi?product=Data%20Platform%20and%20Tools&component=Glean.js&bug_status=__open__&list_id=15591291"
   },
-  "homepage": "https://github.com/brizental/glean.js#readme",
+  "homepage": "https://github.com/mozilla/glean.js#readme",
   "devDependencies": {
     "@types/assert": "^1.5.2",
     "@types/mocha": "^8.0.3",
@@ -45,6 +47,7 @@
     "geckodriver": "^1.21.0",
     "jsdom": "16.4.0",
     "jsdom-global": "3.0.2",
+    "json": "^10.0.0",
     "mocha": "^8.2.1",
     "selenium-webdriver": "^4.0.0-alpha.8",
     "sinon": "^9.2.2",
@@ -58,5 +61,11 @@
   },
   "dependencies": {
     "uuid": "^8.3.2"
-  }
+  },
+  "files": [
+    "README.md",
+    "package.json",
+    "src",
+    "dist"
+  ]
 }


### PR DESCRIPTION
For the Glean.js web extension package I could only think of the name `@mozilla/glean-webext`, but I don't like it.

Pls, help.

For reference, these are the logs of a publishing dry-run that I tested using the `npm run publish:webext` command:

```
npm notice 
npm notice 📦  @mozilla/glean-webext@0.1.0
npm notice === Tarball Contents === 
npm notice 16.7kB LICENSE                         
npm notice 58.4kB dist/glean.js                   
npm notice 2.8kB  package.json                    
npm notice 2.1kB  CHANGELOG.md                    
npm notice 1.2kB  README.md                       
npm notice 1.8kB  src/metrics/types/boolean.ts    
npm notice 2.1kB  src/upload/uploader/browser.ts  
npm notice 1.8kB  src/config.ts                   
npm notice 1.6kB  src/constants.ts                
npm notice 3.6kB  src/metrics/types/counter.ts    
npm notice 9.1kB  src/metrics/database.ts         
npm notice 5.3kB  src/pings/database.ts           
npm notice 10.0kB src/metrics/types/datetime.ts   
npm notice 12.3kB src/dispatcher.ts               
npm notice 3.3kB  src/metrics/types/event.ts      
npm notice 5.9kB  src/metrics/events_database.ts  
npm notice 14.9kB src/glean.ts                    
npm notice 2.7kB  src/index.ts                    
npm notice 4.3kB  src/metrics/index.ts            
npm notice 2.8kB  src/pings/index.ts              
npm notice 1.7kB  src/platform_info/index.ts      
npm notice 2.5kB  src/storage/index.ts            
npm notice 496B   src/storage/persistent/index.ts 
npm notice 10.1kB src/upload/index.ts             
npm notice 1.8kB  src/upload/uploader/index.ts    
npm notice 5.3kB  src/internal_metrics.ts         
npm notice 938B   src/internal_pings.ts           
npm notice 7.7kB  src/pings/maker.ts              
npm notice 2.9kB  src/metrics/types/string.ts     
npm notice 764B   src/metrics/time_unit.ts        
npm notice 1.9kB  src/metrics/utils.ts            
npm notice 3.7kB  src/storage/utils.ts            
npm notice 4.5kB  src/utils.ts                    
npm notice 3.2kB  src/metrics/types/uuid.ts       
npm notice 1.6kB  src/storage/weak.ts             
npm notice 1.7kB  src/platform_info/webext.ts     
npm notice 5.0kB  src/storage/persistent/webext.ts
npm notice 8.2kB  src/metrics.yaml                
npm notice 1.0kB  src/pings.yaml                  
npm notice === Tarball Details === 
npm notice name:          @mozilla/glean-webext                   
npm notice version:       0.1.0                                   
npm notice package size:  56.7 kB                                 
npm notice unpacked size: 227.8 kB                                
npm notice shasum:        b820d0120e8528e89469453d1d349916534ee42d
npm notice integrity:     sha512-5lQG+ZyKRmPJX[...]Fe4bFVF0mCrVw==
npm notice total files:   39                                      
npm notice 
```