### PR TITLE
Bug 1693297 - Copy README.md on prepublish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased changes
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.1.0...main)
+
+* [#77](https://github.com/mozilla/glean.js/pull/77): Include README.md file in `@mozilla/glean` package bundle.
+
 # v0.1.0 (2021-02-17)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/46f028fb4ea7b8f312daf4666904c81d0a3eb171...v0.1.0)

--- a/glean/package.json
+++ b/glean/package.json
@@ -21,7 +21,8 @@
     "fix": "eslint . --ext .ts,.js,.json --fix",
     "build": "webpack --config webpack.config.js --mode production",
     "dev": "webpack --watch --config webpack.config.js --mode development --devtool inline-source-map",
-    "prepare": "npm run build"
+    "prepublishOnly": "cp ../README.md ./README.md && npm run build",
+    "postpublish": "rm ./README.md"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
If the README.md is not in the glean package folder, it will not be included in the final package and as a consequence will not show up on the package npm page.