### PR TITLE
Bug 1693298 - Remove requires and update regex from ci release script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
       - run:
           name: Publish to npm
-          command: export PATH=.:$PATH && (cd glean && npm publish)
+          command: export PATH=.:$PATH && (cd glean && npm publish --access public)
 
 workflows:
   version: 2
@@ -88,14 +88,11 @@ workflows:
       - unit-tests
       - check-qt-js
       - publish:
-          requires:
-            - lint
-            - unit-tests
           filters:
             branches:
-              only: release
+              ignore: /.*/
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: /^v.*/
       # Comment this job away until Bug 1681899 is resolved.
       # - check-size:
       #     filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           command: npm --prefix ./glean install
       - run:
           name: NPM Authentication
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > glean/.npmrc
       - run:
           name: Publish to npm
           command: export PATH=.:$PATH && (cd glean && npm publish --access public)


### PR DESCRIPTION
What made the publishing job not run on the last release were the requires, we were requiting jobs that don't run on tags. 

Anyways I removed those requires, in the docs we already tell people to wait for CI to go green before tagging.

I also updated the regex to match exactly [what we do on the Glean SDK repository](https://github.com/mozilla/glean/blob/main/.circleci/config.yml#L13-L18). The initial regex was not wrong, but I thought it would probably be best to just make it exactly tthe same.