### PR TITLE
[ALTERNATE] Bug 1689547 -  Create plugin / events infrastructure and define `afterPingCollection` event

### DIFF
--- a/glean/src/core/config.ts
+++ b/glean/src/core/config.ts
@@ -26,7 +26,7 @@ export interface ConfigurationInterface {
   readonly serverEndpoint?: string,
   // Debug configuration.
   debug?: DebugOptions,
-  // Optional list of plugins to instrument the current Glean instance.
+  // Optional list of plugins to include in current Glean instance.
   plugins?: Plugin[],
 }
 

--- a/glean/src/core/config.ts
+++ b/glean/src/core/config.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { DEFAULT_TELEMETRY_ENDPOINT } from "./constants";
+import Plugin from "../plugins";
 import { validateURL } from "./utils";
 
 /**
@@ -25,6 +26,8 @@ export interface ConfigurationInterface {
   readonly serverEndpoint?: string,
   // Debug configuration.
   debug?: DebugOptions,
+  // Optional list of plugins to instrument the current Glean instance.
+  plugins?: Plugin[],
 }
 
 export class Configuration implements ConfigurationInterface {
@@ -36,7 +39,7 @@ export class Configuration implements ConfigurationInterface {
   readonly serverEndpoint: string;
   // Debug configuration.
   debug?: DebugOptions;
- 
+
   constructor(config?: ConfigurationInterface) {
     this.appBuild = config?.appBuild;
     this.appDisplayVersion = config?.appDisplayVersion;

--- a/glean/src/core/events/index.ts
+++ b/glean/src/core/events/index.ts
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import CoreEvents from "../../../dist/webext/types/core/events";
+import Plugin from "../../plugins";
+
+import { PingPayload } from "../pings/database";
+import { JSONObject } from "../utils";
+
+export class CoreEvent<
+   // An array of arguments that the event will provide as context to the plugin action.
+   Context extends unknown[] = unknown[],
+   // The expected type of the action result. To be returned by the plugin.
+   Result extends unknown = unknown
+ > {
+   // The plugin to be triggered eveytime this even occurs.
+   private plugin?: Plugin<CoreEvent<Context, Result>>;
+
+   constructor(readonly name: string) {}
+
+   /**
+    * Registers a plugin that listens to this event.
+    *
+    * @param plugin The plugin to register.
+    */
+   registerPlugin(plugin: Plugin<CoreEvent<Context, Result>>): void {
+     if (this.plugin) {
+       console.error(
+         `Attempted to register plugin '${plugin.name}', which listens to the event '${plugin.event}'.`,
+         `That event is already watched by plugin '${this.plugin.name}'`,
+         `Plugin '${plugin.name}' will be ignored.`
+       );
+       return;
+     }
+ 
+     this.plugin = plugin;
+   }
+ 
+   /**
+    * Deregisters the currently registered plugin.
+    *
+    * If no plugin is currently registered this is a no-op.
+    */
+   deregisterPlugin(): void {
+     this.plugin = undefined;
+   }
+
+   /**
+    * Triggers this event.
+    *
+    * Will execute the action of the registered plugin, if there is any.
+    *
+    * @param args The arguments to be passed as context to the registered plugin.
+    *
+    * @returns The result from the plugin execution.
+    */
+   trigger(...args: Context): Result | void {
+     if (this.plugin) {
+       return this.plugin.action(...args);
+     }
+   }
+}
+
+/**
+ * Glean internal events.
+ */
+const CoreEvents: {
+  afterPingCollection: CoreEvent<[PingPayload], Promise<JSONObject>>,
+  [unused: string]: CoreEvent
+} = {
+  // Event that is triggered immediatelly after a ping is collect and before it is recorded.
+  //
+  //  - Context: The `PingPayload` of the recently collected ping.
+  //  - Result: The modified payload as a JSON object.
+  afterPingCollection: new CoreEvent<[PingPayload], Promise<JSONObject>>("afterPingCollection")
+};
+
+export default CoreEvents;

--- a/glean/src/core/events/index.ts
+++ b/glean/src/core/events/index.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import CoreEvents from "../../../dist/webext/types/core/events";
 import Plugin from "../../plugins";
 
 import { PingPayload } from "../pings/database";

--- a/glean/src/core/events/utils.ts
+++ b/glean/src/core/events/utils.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import CoreEvents, { CoreEvent } from "./index";
+import Plugin from "../../plugins";
+
+/**
+ * Registers a plugin to the desired Glean event.
+ *
+ * If the plugin is attempting to listen to an unknown event it will be ignored.
+ *
+ * @param plugin The plugin to register.
+ */
+export function registerPluginToEvent<E extends CoreEvent>(plugin: Plugin<E>): void {
+  const eventName = plugin.event;
+  if (eventName in CoreEvents) {
+    const event = CoreEvents[eventName];
+    event.registerPlugin(plugin);
+    return;
+  }
+
+  console.error(
+    `Attempted to register plugin '${plugin.name}', which listens to the event '${plugin.event}'.`,
+    "That is not a valid Glean event. Ignoring"
+  );
+}
+
+/**
+ * **Test-only API**
+ *
+ * Deregister plugins registered to all Glean events.
+ */
+export function testResetEvents(): void {
+  for (const event in CoreEvents) {
+    CoreEvents[event].deregisterPlugin();
+  }
+}
+
+
+
+

--- a/glean/src/core/events/utils.ts
+++ b/glean/src/core/events/utils.ts
@@ -36,7 +36,3 @@ export function testResetEvents(): void {
     CoreEvents[event].deregisterPlugin();
   }
 }
-
-
-
-

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -442,7 +442,11 @@ class Glean {
    *        first_run_date) are cleared. Default to `true`.
    * @param config Glean configuration options.
    */
-  static async testInitialize(applicationId: string, uploadEnabled = true, config?: Configuration): Promise<void> {
+  static async testInitialize(
+    applicationId: string,
+    uploadEnabled = true,
+    config?: ConfigurationInterface
+  ): Promise<void> {
     Glean.setPlatform(TestPlatform);
     Glean.initialize(applicationId, uploadEnabled, config);
 
@@ -480,7 +484,11 @@ class Glean {
    *        first_run_date) are cleared. Default to `true`.
    * @param config Glean configuration options.
    */
-  static async testResetGlean(applicationId: string, uploadEnabled = true, config?: Configuration): Promise<void> {
+  static async testResetGlean(
+    applicationId: string,
+    uploadEnabled = true,
+    config?: ConfigurationInterface
+  ): Promise<void> {
     await Glean.testUninitialize();
 
     // Clear the databases.

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -405,15 +405,15 @@ class Glean {
       // All dispatched tasks are guaranteed to be run after initialize.
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       if (!Glean.instance._config!.debug) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      Glean.instance._config!.debug = {};
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        Glean.instance._config!.debug = {};
       }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    Glean.instance._config!.debug.logPings = flag;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      Glean.instance._config!.debug.logPings = flag;
 
-    // The dispatcher requires that dispatched functions return promises.
-    return Promise.resolve();
+      // The dispatcher requires that dispatched functions return promises.
+      return Promise.resolve();
     });
   }
 

--- a/glean/src/core/pings/database.ts
+++ b/glean/src/core/pings/database.ts
@@ -42,10 +42,9 @@ export interface PingPayload extends JSONObject {
   metrics?: MetricsPayload,
   events?: JSONArray,
 }
-
 export interface PingInternalRepresentation extends JSONObject {
   path: string,
-  payload: PingPayload,
+  payload: JSONObject,
   headers?: Record<string, string>
 }
 
@@ -117,7 +116,7 @@ class PingsDatabase {
   async recordPing(
     path: string,
     identifier: string,
-    payload: PingPayload,
+    payload: JSONObject,
     headers?: Record<string, string>
   ): Promise<void> {
     const ping: PingInternalRepresentation = {

--- a/glean/src/core/pings/maker.ts
+++ b/glean/src/core/pings/maker.ts
@@ -10,6 +10,8 @@ import TimeUnit from "../metrics/time_unit";
 import { ClientInfo, PingInfo, PingPayload } from "../pings/database";
 import PingType from "../pings";
 import Glean from "../glean";
+import CoreEvents from "../events";
+import { JSONObject } from "../utils";
 
 // The moment the current Glean.js session started.
 const GLEAN_START_TIME = new Date();
@@ -206,6 +208,10 @@ function makePath(identifier: string, ping: PingType): string {
 /**
  * Collects and stores a ping on the pings database.
  *
+ * This function will trigger the `AfterPingCollection` event.
+ * This event is triggered **after** logging the ping, which happens if `logPings` is set.
+ * We will log the payload before it suffers any change by plugins instrumenting this event.
+ *
  * @param identifier The pings UUID identifier.
  * @param ping The ping to submit.
  * @param reason An optional reason code to include in the ping.
@@ -213,20 +219,24 @@ function makePath(identifier: string, ping: PingType): string {
  * @returns A promise that is resolved once collection and storing is done.
  */
 export async function collectAndStorePing(identifier: string, ping: PingType, reason?: string): Promise<void> {
-  const payload = await collectPing(ping, reason);
-  if (!payload) {
+  const collectedPayload = await collectPing(ping, reason);
+  if (!collectedPayload) {
     return;
   }
 
   if (Glean.logPings) {
-    console.info(JSON.stringify(payload, null, 2));
+    console.info(JSON.stringify(collectedPayload, null, 2));
   }
 
   const headers = getPingHeaders();
+
+  const modifiedPayload = await CoreEvents.afterPingCollection.trigger(collectedPayload);
+  const finalPayload = modifiedPayload ? modifiedPayload : collectedPayload;
+
   return Glean.pingsDatabase.recordPing(
     makePath(identifier, ping),
     identifier,
-    payload,
+    finalPayload,
     headers
   );
 }

--- a/glean/src/core/pings/maker.ts
+++ b/glean/src/core/pings/maker.ts
@@ -11,7 +11,6 @@ import { ClientInfo, PingInfo, PingPayload } from "../pings/database";
 import PingType from "../pings";
 import Glean from "../glean";
 import CoreEvents from "../events";
-import { JSONObject } from "../utils";
 
 // The moment the current Glean.js session started.
 const GLEAN_START_TIME = new Date();

--- a/glean/src/core/pings/maker.ts
+++ b/glean/src/core/pings/maker.ts
@@ -209,7 +209,7 @@ function makePath(identifier: string, ping: PingType): string {
  *
  * This function will trigger the `AfterPingCollection` event.
  * This event is triggered **after** logging the ping, which happens if `logPings` is set.
- * We will log the payload before it suffers any change by plugins instrumenting this event.
+ * We will log the payload before it suffers any change by plugins listening to this event.
  *
  * @param identifier The pings UUID identifier.
  * @param ping The ping to submit.

--- a/glean/src/plugins/index.ts
+++ b/glean/src/plugins/index.ts
@@ -23,13 +23,13 @@ abstract class Plugin<E extends CoreEvent = CoreEvent> {
   /**
    * Instantiates the Glean plugin.
    *
-   * @param event The name of the even this plugin instruments.
+   * @param event The name of the even this plugin listens to.
    * @param name The name of this plugin.
    */
   constructor(readonly event: string, readonly name: string) {}
 
  /**
-  * An action that will be triggered everytime the instrumented event occurs.
+  * An action that will be triggered everytime the listened to event occurs.
   *
   * @param args The arguments that are expected to be passed by this event.
   */

--- a/glean/src/plugins/index.ts
+++ b/glean/src/plugins/index.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CoreEvent } from "../core/events";
+
+// Helper type that extracts the type of the Context from a generic CoreEvent.
+export type EventContext<Context> = Context extends CoreEvent<infer InnerContext, unknown>
+ ? InnerContext
+ : undefined[];
+
+// Helper type that extracts the type of the Result from a generic CoreEvent.
+export type EventResult<Result> = Result extends CoreEvent<unknown[], infer InnerResult>
+ ? InnerResult
+ : void;
+
+/**
+ * Plugins can listen to events that happen during Glean's lifecycle.
+ *
+ * Every Glean plugin must extend this class.
+ */
+abstract class Plugin<E extends CoreEvent = CoreEvent> {
+  /**
+   * Instantiates the Glean plugin.
+   *
+   * @param event The name of the even this plugin instruments.
+   * @param name The name of this plugin.
+   */
+  constructor(readonly event: string, readonly name: string) {}
+
+ /**
+  * An action that will be triggered everytime the instrumented event occurs.
+  *
+  * @param args The arguments that are expected to be passed by this event.
+  */
+ abstract action(...args: EventContext<E>): EventResult<E>;
+}
+
+export default Plugin;

--- a/glean/tests/core/events.spec.ts
+++ b/glean/tests/core/events.spec.ts
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import assert from "assert";
+
+import CoreEvents, { CoreEvent } from "../../src/core/events";
+import { registerPluginToEvent } from "../../src/core/events/utils";
+import { JSONObject } from "../../src/core/utils";
+import Plugin from "../../src/plugins";
+
+const mockEvent = new CoreEvent<number[], number>("mockEvent");
+class MockPlugin extends Plugin<typeof mockEvent> {
+  constructor() {
+    super(mockEvent.name, "mockPlugin");
+  }
+
+  action(...numbers: number[]): number {
+    return numbers.reduce((sum, element) => element + sum, 0);
+  }
+}
+
+describe("events", function() {
+  afterEach(function () {
+    mockEvent.deregisterPlugin();
+  });
+
+  it("registering a plugin works as expected", function() {
+    const plugin = new MockPlugin();
+    mockEvent.registerPlugin(plugin);
+    assert.deepStrictEqual(mockEvent["plugin"], plugin);
+
+    // Registering twice should not error, but also should be ignored.
+    const pluginDuplicate = new MockPlugin();
+    mockEvent.registerPlugin(pluginDuplicate);
+    assert.deepStrictEqual(mockEvent["plugin"], plugin);
+  });
+
+  it("triggering an event works as expected", function() {
+    // Triggering an event with no attached plugin should not error.
+    assert.strictEqual(mockEvent.trigger(5, 5, 5, 5), undefined);
+
+    const plugin = new MockPlugin();
+    mockEvent.registerPlugin(plugin);
+
+    assert.strictEqual(mockEvent.trigger(5, 5, 5, 5), 20);
+  });
+
+  it("registerPluginToEvent works as expected", function() {
+    // The mock plugin is not going to get registered because mockEvent is not a real Glean event.
+    // Either way we put this here to check it does not throw.
+    registerPluginToEvent(new MockPlugin());
+
+    // Now we define a plugin that is attached to a real glean event.
+    class ValidMockPlugin extends Plugin<typeof CoreEvents["afterPingCollection"]> {
+      constructor() {
+        super(CoreEvents["afterPingCollection"].name, "mockPlugin");
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      action(): Promise<JSONObject> {
+        return Promise.resolve({ "you": "got mocked!" });
+      }
+    }
+    const validPlugin = new ValidMockPlugin();
+    registerPluginToEvent(validPlugin);
+    assert.deepStrictEqual(CoreEvents.afterPingCollection["plugin"], validPlugin);
+  });
+});

--- a/glean/tests/core/pings/maker.spec.ts
+++ b/glean/tests/core/pings/maker.spec.ts
@@ -10,7 +10,6 @@ import * as PingMaker from "../../../src/core/pings/maker";
 import Glean from "../../../src/core/glean";
 import CoreEvents from "../../../src/core/events";
 import Plugin from "../../../src/plugins";
-import { PingPayload } from "../../../src/core/pings/database";
 import { JSONObject } from "../../../src/core/utils";
 
 const sandbox = sinon.createSandbox();
@@ -121,8 +120,7 @@ describe("PingMaker", function() {
         super(CoreEvents["afterPingCollection"].name, "mockPlugin");
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      action(_payload: PingPayload): Promise<JSONObject> {
+      action(): Promise<JSONObject> {
         return Promise.resolve({ "you": "got mocked!" });
       }
     }


### PR DESCRIPTION
Different approach for #94 (and my preferred approach, 1) Less cleverness on the types 2) Less relying on the Glean singleton).

Based off of [this thread](https://github.com/mozilla/glean.js/pull/94#discussion_r586471152).