### PR TITLE
Add labeled metric types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#101](https://github.com/mozilla/glean.js/pull/101): BUGFIX: Only validate Debug View Tag and Source Tags when they are present.
 * [#101](https://github.com/mozilla/glean.js/pull/101): BUGFIX: Only validate Debug View Tag and Source Tags when they are present.
 * [#102](https://github.com/mozilla/glean.js/pull/102): BUGFIX: Include a Glean User-Agent header in all pings.
+* [#97](https://github.com/mozilla/glean.js/pull/97): Add support for labelled metric types (string, boolean and counter).
 
 # v0.4.0 (2021-03-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * [#101](https://github.com/mozilla/glean.js/pull/101): BUGFIX: Only validate Debug View Tag and Source Tags when they are present.
 * [#101](https://github.com/mozilla/glean.js/pull/101): BUGFIX: Only validate Debug View Tag and Source Tags when they are present.
 * [#102](https://github.com/mozilla/glean.js/pull/102): BUGFIX: Include a Glean User-Agent header in all pings.
-* [#97](https://github.com/mozilla/glean.js/pull/97): Add support for labelled metric types (string, boolean and counter).
+* [#97](https://github.com/mozilla/glean.js/pull/97): Add support for labeled metric types (string, boolean and counter).
 
 # v0.4.0 (2021-03-10)
 

--- a/glean/src/core/metrics/database.ts
+++ b/glean/src/core/metrics/database.ts
@@ -133,7 +133,7 @@ class MetricsDatabase {
     }
 
     const store = this._chooseStore(metric.lifetime);
-    const storageKey = await metric.getAsyncIdentifier();
+    const storageKey = await metric.identifier();
     for (const ping of metric.sendInPings) {
       const finalTransformFn = (v?: JSONValue): JSONValue => transformFn(v).get();
       await store.update([ping, metric.type, storageKey], finalTransformFn);
@@ -205,7 +205,7 @@ class MetricsDatabase {
     metric: MetricType
   ): Promise<T | undefined> {
     const store = this._chooseStore(metric.lifetime);
-    const storageKey = await metric.getAsyncIdentifier();
+    const storageKey = await metric.identifier();
     const value = await store.get([ping, metric.type, storageKey]);
     if (!isUndefined(value) && !validateMetricInternalRepresentation<T>(metric.type, value)) {
       console.error(`Unexpected value found for metric ${storageKey}: ${JSON.stringify(value)}. Clearing.`);

--- a/glean/src/core/metrics/index.ts
+++ b/glean/src/core/metrics/index.ts
@@ -155,11 +155,11 @@ export abstract class MetricType implements CommonMetricData {
    * @returns The generated identifier. If `category` is empty, it's ommitted. Otherwise,
    *          it's the combination of the metric's `category`, `name` and `label`.
    */
-  async getAsyncIdentifier(): Promise<string> {
+  async identifier(): Promise<string> {
     const baseIdentifier = this.baseIdentifier();
 
     // We need to use `isUndefined` and cannot use `(this.dynamicLabel)` because we want
-    // empty strings to propagate as a dynamic labels, so that erros are potentially recorded.
+    // empty strings to propagate as dynamic labels, so that erros are potentially recorded.
     if (!isUndefined(this.dynamicLabel)) {
       return await LabeledMetricType.getValidDynamicLabel(this);
     } else {
@@ -178,7 +178,7 @@ export abstract class MetricType implements CommonMetricData {
 }
 
 /**
- * This is no-op internal metric representation.
+ * This is a no-op internal metric representation.
  *
  * This can be used to instruct the validators to simply report
  * whatever is stored internally, without performing any specific

--- a/glean/src/core/metrics/index.ts
+++ b/glean/src/core/metrics/index.ts
@@ -178,13 +178,16 @@ export abstract class MetricType implements CommonMetricData {
 }
 
 /**
- * This is a no-op internal metric representation.
+ * This is an internal metric representation for labeled metrics.
  *
  * This can be used to instruct the validators to simply report
  * whatever is stored internally, without performing any specific
  * validation.
+ *
+ * This needs to live here, instead of labeled.ts, in order to avoid
+ * a cyclic dependency.
  */
-export class PassthroughMetric extends Metric<JSONValue, JSONValue> {
+export class LabeledMetric extends Metric<JSONValue, JSONValue> {
   constructor(v: unknown) {
     super(v);
   }

--- a/glean/src/core/metrics/types/labeled.ts
+++ b/glean/src/core/metrics/types/labeled.ts
@@ -1,0 +1,174 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CommonMetricData, MetricType } from "..";
+import Glean from "../../glean";
+import CounterMetricType from "./counter";
+import BooleanMetricType from "./boolean";
+import StringMetricType from "./string";
+
+const MAX_LABELS = 16;
+const OTHER_LABEL = "__other__";
+const MAX_LABEL_LENGTH = 61;
+
+// ** IMPORTANT **
+// When changing this documentation or the regex, be sure to change the same code
+// in the Glean SDK repository as well.
+//
+// This regex is used for matching against labels and should allow for dots,
+// underscores, and/or hyphens. Labels are also limited to starting with either
+// a letter or an underscore character.
+//
+// Some examples of good and bad labels:
+//
+// Good:
+// * `this.is.fine`
+// * `this_is_fine_too`
+// * `this.is_still_fine`
+// * `thisisfine`
+// * `_.is_fine`
+// * `this.is-fine`
+// * `this-is-fine`
+// Bad:
+// * `this.is.not_fine_due_tu_the_length_being_too_long_i_thing.i.guess`
+// * `1.not_fine`
+// * `this.$isnotfine`
+// * `-.not_fine`
+const LABEL_REGEX = /^[a-z_][a-z0-9_-]{0,29}(\.[a-z_][a-z0-9_-]{0,29})*$/;
+
+type SupportedLabeledTypes = CounterMetricType | BooleanMetricType | StringMetricType;
+
+class LabeledMetricType<T extends SupportedLabeledTypes> {
+  // Define an index signature to make the Proxy aware of the expected return type.
+  // Note that this is required because TypeScript does not allow different input and
+  // output types in Proxy (https://github.com/microsoft/TypeScript/issues/20846). 
+  [label: string]: T;
+
+  constructor(
+    meta: CommonMetricData,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    submetric: new (...args: any) => T,
+    labels?: string[],
+  ) {
+    return new Proxy(this, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      get: (_target: LabeledMetricType<T>, label: string): any => {
+        if (labels) {
+          return LabeledMetricType.createFromStaticLabel<typeof submetric>(meta, submetric, labels, label);
+        }
+
+        return LabeledMetricType.createFromDynamicLabel<typeof submetric>(meta, submetric, label);
+      }
+    });
+  }
+
+  /**
+   * Combines a metric's base identifier and label.
+   *
+   * @param metricName the metric base identifier
+   * @param label the label
+   *
+   * @returns a string representing the complete metric id including the label.
+   */
+  private static combineIdentifierAndLabel(
+    metricName: string,
+    label: string
+  ): string {
+    return `${metricName}/${label}`;
+  }
+
+  /**
+   * Create an instance of the submetric type for the provided static label.
+   *
+   * @param meta the `CommonMetricData` information for the metric.
+   * @param submetricClass the class type for the submetric.
+   * @param allowedLabels the array of allowed labels.
+   * @param label the desired label to record to.
+   *
+   * @returns an instance of the submetric class type that allows to record data.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private static createFromStaticLabel<T extends new (...args: any) => InstanceType<T>>(
+    meta: CommonMetricData,
+    submetricClass: T,
+    allowedLabels: string[],
+    label: string
+  ): T {
+    // If the label was provided in the registry file, then use it. Otherwise,
+    // store data in the `OTHER_LABEL`.
+    const adjustedLabel = allowedLabels.includes(label) ? label : OTHER_LABEL;
+    const newMeta: CommonMetricData = {
+      ...meta,
+      name: LabeledMetricType.combineIdentifierAndLabel(meta.name, adjustedLabel)
+    };
+    return new submetricClass(newMeta);
+  }
+
+  /**
+   * Create an instance of the submetric type for the provided dynamic label.
+   *
+   * @param meta the `CommonMetricData` information for the metric.
+   * @param submetricClass the class type for the submetric.
+   * @param label the desired label to record to.
+   *
+   * @returns an instance of the submetric class type that allows to record data.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private static createFromDynamicLabel<T extends new (...args: any) => InstanceType<T>>(
+    meta: CommonMetricData,
+    submetricClass: T,
+    label: string
+  ): T {
+    const newMeta: CommonMetricData = {
+      ...meta,
+      dynamicLabel: label
+    };
+    return new submetricClass(newMeta);
+  }
+
+  static async getValidDynamicLabel(metric: MetricType): Promise<string> {
+    // Note that we assume `metric.dynamicLabel` to always be available within this function.
+    // This is a safe assumptions because we should only call `getValidDynamicLabel` if we have
+    // a dynamic label.
+    if (metric.dynamicLabel === undefined) {
+      throw new Error("This point should never be reached.");
+    }
+
+    const key = LabeledMetricType.combineIdentifierAndLabel(metric.baseIdentifier(), metric.dynamicLabel);
+
+    for (const ping of metric.sendInPings) {
+      if (await Glean.metricsDatabase.hasMetric(metric.lifetime, ping, metric.type, key)) {
+        return key;
+      }
+    }
+
+    let numUsedKeys = 0;
+    for (const ping of metric.sendInPings) {
+      numUsedKeys += await Glean.metricsDatabase.countByBaseIdentifier(
+        metric.lifetime,
+        ping,
+        metric.type,
+        metric.baseIdentifier());
+    }
+
+    let hitError = false;
+    if (numUsedKeys >= MAX_LABELS) {
+      hitError = true;
+    } else if (metric.dynamicLabel.length > MAX_LABEL_LENGTH) {
+      console.error(`label length ${metric.dynamicLabel.length} exceeds maximum of ${MAX_LABEL_LENGTH}`);
+      hitError = true;
+      // TODO: record error in bug 1682574
+    } else if (!LABEL_REGEX.test(metric.dynamicLabel)) {
+      console.error(`label must be snake_case, got '${metric.dynamicLabel}'`);
+      hitError = true;
+      // TODO: record error in bug 1682574
+    }
+
+    return (hitError)
+      ? LabeledMetricType.combineIdentifierAndLabel(metric.baseIdentifier(), OTHER_LABEL)
+      : key;
+  }
+}
+
+export default LabeledMetricType;

--- a/glean/src/core/metrics/utils.ts
+++ b/glean/src/core/metrics/utils.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Metric } from "./index";
+import { Metric, PassthroughMetric } from "./index";
 import { JSONValue } from "../utils";
 
 import { BooleanMetric } from "./types/boolean";
@@ -20,6 +20,7 @@ const METRIC_MAP: {
   "boolean": BooleanMetric,
   "counter": CounterMetric,
   "datetime": DatetimeMetric,
+  "labeled_counter": PassthroughMetric,
   "string": StringMetric,
   "uuid": UUIDMetric,
 });

--- a/glean/src/core/metrics/utils.ts
+++ b/glean/src/core/metrics/utils.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Metric, PassthroughMetric } from "./index";
+import { Metric, LabeledMetric } from "./index";
 import { JSONValue } from "../utils";
 
 import { BooleanMetric } from "./types/boolean";
@@ -20,7 +20,7 @@ const METRIC_MAP: {
   "boolean": BooleanMetric,
   "counter": CounterMetric,
   "datetime": DatetimeMetric,
-  "labeled_counter": PassthroughMetric,
+  "labeled_counter": LabeledMetric,
   "string": StringMetric,
   "uuid": UUIDMetric,
 });

--- a/glean/tests/core/metrics/labeled.spec.ts
+++ b/glean/tests/core/metrics/labeled.spec.ts
@@ -17,8 +17,10 @@ import PingType from "../../../src/core/pings";
 const sandbox = sinon.createSandbox();
 
 describe("LabeledMetric", function() {
+  const testAppId = `gleanjs.test.${this.title}`;
+
   beforeEach(async function() {
-    await Glean.testResetGlean("gleanjs.unit.test");
+    await Glean.testResetGlean(testAppId);
     // Disable ping uploading for it not to interfere with this tests.
     sandbox.stub(Glean["pingUploader"], "triggerUpload").callsFake(() => Promise.resolve());
   });
@@ -34,7 +36,7 @@ describe("LabeledMetric", function() {
       sendIfEmpty: false,
     });
 
-    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+    const labeledCounterMetric = new LabeledMetricType(
       {
         category: "telemetry",
         name: "labeled_counter_metric",
@@ -79,7 +81,7 @@ describe("LabeledMetric", function() {
       sendIfEmpty: false,
     });
 
-    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+    const labeledCounterMetric = new LabeledMetricType(
       {
         category: "telemetry",
         name: "labeled_counter_metric",
@@ -126,7 +128,7 @@ describe("LabeledMetric", function() {
   });
 
   it("test __other__ label without predefined labels", async function() {
-    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+    const labeledCounterMetric = new LabeledMetricType(
       {
         category: "telemetry",
         name: "labeled_counter_metric",
@@ -151,7 +153,7 @@ describe("LabeledMetric", function() {
   });
 
   it("test __other__ label without predefined labels before Glean initialization", async function() {
-    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+    const labeledCounterMetric = new LabeledMetricType(
       {
         category: "telemetry",
         name: "labeled_counter_metric",
@@ -181,7 +183,7 @@ describe("LabeledMetric", function() {
   });
 
   it("Ensure invalid labels on labeled counter go to __other__", async function() {
-    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+    const labeledCounterMetric = new LabeledMetricType(
       {
         category: "telemetry",
         name: "labeled_counter_metric",
@@ -203,7 +205,7 @@ describe("LabeledMetric", function() {
   });
 
   it("Ensure invalid labels on labeled boolean go to __other__", async function() {
-    const labeledBooleanMetric = new LabeledMetricType<BooleanMetricType>(
+    const labeledBooleanMetric = new LabeledMetricType(
       {
         category: "telemetry",
         name: "labeled_boolean_metric",
@@ -225,7 +227,7 @@ describe("LabeledMetric", function() {
   });
 
   it("Ensure invalid labels on labeled string go to __other__", async function() {
-    const labeledStringMetric = new LabeledMetricType<StringMetricType>(
+    const labeledStringMetric = new LabeledMetricType(
       {
         category: "telemetry",
         name: "labeled_string_metric",
@@ -247,7 +249,7 @@ describe("LabeledMetric", function() {
   });
 
   it("test labeled string metric type", async function() {
-    const labeledStringMetric = new LabeledMetricType<StringMetricType>(
+    const labeledStringMetric = new LabeledMetricType(
       {
         category: "telemetry",
         name: "labeled_string_metric",
@@ -269,7 +271,7 @@ describe("LabeledMetric", function() {
   });
 
   it("test labeled boolean metric type", async function() {
-    const metric = new LabeledMetricType<BooleanMetricType>(
+    const metric = new LabeledMetricType(
       {
         category: "telemetry",
         name: "labeled_bool",
@@ -291,7 +293,7 @@ describe("LabeledMetric", function() {
   });
 
   it("dynamic labels regex mismatch", async function() {
-    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+    const labeledCounterMetric = new LabeledMetricType(
       {
         category: "telemetry",
         name: "labeled_counter_metric",
@@ -320,7 +322,7 @@ describe("LabeledMetric", function() {
   });
 
   it("dynamic labels regex allowed", async function() {
-    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+    const labeledCounterMetric = new LabeledMetricType(
       {
         category: "telemetry",
         name: "labeled_counter_metric",
@@ -350,7 +352,7 @@ describe("LabeledMetric", function() {
   });
 
   it("seen labels get reloaded across initializations", async function() {
-    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+    const labeledCounterMetric = new LabeledMetricType(
       {
         category: "telemetry",
         name: "labeled_metric",

--- a/glean/tests/core/metrics/labeled.spec.ts
+++ b/glean/tests/core/metrics/labeled.spec.ts
@@ -1,0 +1,384 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import assert from "assert";
+import sinon from "sinon";
+import { JSONObject } from "../../../dist/webext/types/core/utils";
+
+import Glean from "../../../src/core/glean";
+import { Lifetime } from "../../../src/core/metrics";
+import BooleanMetricType from "../../../src/core/metrics/types/boolean";
+import CounterMetricType from "../../../src/core/metrics/types/counter";
+import LabeledMetricType from "../../../src/core/metrics/types/labeled";
+import StringMetricType from "../../../src/core/metrics/types/string";
+import PingType from "../../../src/core/pings";
+
+const sandbox = sinon.createSandbox();
+
+describe("LabeledMetric", function() {
+  beforeEach(async function() {
+    await Glean.testResetGlean("gleanjs.unit.test");
+    // Disable ping uploading for it not to interfere with this tests.
+    sandbox.stub(Glean["pingUploader"], "triggerUpload").callsFake(() => Promise.resolve());
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("test labeled counter type", async function() {
+    const ping = new PingType({
+      name: "test",
+      includeClientId: true,
+      sendIfEmpty: false,
+    });
+
+    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+      {
+        category: "telemetry",
+        name: "labeled_counter_metric",
+        sendInPings: ["test"],
+        lifetime: Lifetime.Ping,
+        disabled: false
+      },
+      CounterMetricType
+    );
+
+    labeledCounterMetric["label1"].add(1);
+    labeledCounterMetric["label2"].add(2);
+
+    assert.strictEqual(await labeledCounterMetric["label1"].testGetValue(), 1);
+    assert.strictEqual(await labeledCounterMetric["label2"].testGetValue(), 2);
+
+    // TODO: bug 1691033 will allow us to change the code below this point,
+    // once a custom uploader for testing will be available.
+    ping.submit();
+    await Glean.dispatcher.testBlockOnQueue();
+    
+    const storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    assert.strictEqual(Object.keys(storedPings).length, 1);
+
+    // TODO: bug 1682282 will validate the payload schema.
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const stored: JSONObject = storedPings[Object.keys(storedPings)[0]] as JSONObject;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const payloadAsString = JSON.stringify(stored.payload);
+
+    // Do the same checks again on the JSON structure
+    assert.strict(
+      payloadAsString.includes("\"labeled_counter\":{\"telemetry.labeled_counter_metric\":{\"label1\":1,\"label2\":2}}}")
+    );
+  });
+
+  it("test __other__ label with predefined labels", async function() {
+    const ping = new PingType({
+      name: "test",
+      includeClientId: true,
+      sendIfEmpty: false,
+    });
+
+    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+      {
+        category: "telemetry",
+        name: "labeled_counter_metric",
+        sendInPings: ["test"],
+        lifetime: Lifetime.Ping,
+        disabled: false
+      },
+      CounterMetricType,
+      ["foo", "bar", "baz"]
+    );
+
+    labeledCounterMetric["foo"].add(1);
+    labeledCounterMetric["foo"].add(2);
+    labeledCounterMetric["bar"].add(1);
+    labeledCounterMetric["not_there"].add(1);
+    labeledCounterMetric["also_not_there"].add(1);
+    labeledCounterMetric["not_me"].add(1);
+
+    assert.strictEqual(await labeledCounterMetric["foo"].testGetValue(), 3);
+    assert.strictEqual(await labeledCounterMetric["bar"].testGetValue(), 1);
+    assert.strictEqual(await labeledCounterMetric["baz"].testGetValue(), undefined);
+    // The rest all lands in the __other__ bucket
+    assert.strictEqual(await labeledCounterMetric["not_there"].testGetValue(), 3);
+
+    // TODO: bug 1691033 will allow us to change the code below this point,
+    // once a custom uploader for testing will be available.
+    ping.submit();
+    await Glean.dispatcher.testBlockOnQueue();
+
+    const storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    assert.strictEqual(Object.keys(storedPings).length, 1);
+
+    // TODO: bug 1682282 will validate the payload schema.
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const stored: JSONObject = storedPings[Object.keys(storedPings)[0]] as JSONObject;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const payloadAsString = JSON.stringify(stored.payload);
+
+    // Do the same checks again on the JSON structure
+    assert.strict(
+      payloadAsString.includes("\"labeled_counter\":{\"telemetry.labeled_counter_metric\":{\"foo\":3,\"bar\":1,\"__other__\":3}}}")
+    );
+  });
+
+  it("test __other__ label without predefined labels", async function() {
+    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+      {
+        category: "telemetry",
+        name: "labeled_counter_metric",
+        sendInPings: ["test"],
+        lifetime: Lifetime.Ping,
+        disabled: false
+      },
+      CounterMetricType
+    );
+
+    for (let i = 0; i <= 20; i++) {
+      labeledCounterMetric[`label_${i}`].add(1);
+    }
+    // Go back and record in one of the real labels again.
+    labeledCounterMetric["label_0"].add(1);
+
+    assert.strictEqual(await labeledCounterMetric["label_0"].testGetValue(), 2);
+    for (let i = 1; i <= 15; i++) {
+      assert.strictEqual(await labeledCounterMetric[`label_${i}`].testGetValue(), 1);
+    }
+    assert.strictEqual(await labeledCounterMetric["__other__"].testGetValue(), 5);
+  });
+
+  it("test __other__ label without predefined labels before Glean initialization", async function() {
+    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+      {
+        category: "telemetry",
+        name: "labeled_counter_metric",
+        sendInPings: ["metrics"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      },
+      CounterMetricType
+    );
+
+    // Make sure Glean isn't initialized, so that tasks get enqueued.
+    await Glean.testUninitialize();
+
+    for (let i = 0; i <= 20; i++) {
+      labeledCounterMetric[`label_${i}`].add(1);
+    }
+    // Go back and record in one of the real labels again.
+    labeledCounterMetric["label_0"].add(1);
+
+    await Glean.testInitialize("gleanjs.unit.test", true);
+
+    assert.strictEqual(await labeledCounterMetric["label_0"].testGetValue(), 2);
+    for (let i = 1; i <= 15; i++) {
+      assert.strictEqual(await labeledCounterMetric[`label_${i}`].testGetValue(), 1);
+    }
+    assert.strictEqual(await labeledCounterMetric["__other__"].testGetValue(), 5);
+  });
+
+  it("Ensure invalid labels on labeled counter go to __other__", async function() {
+    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+      {
+        category: "telemetry",
+        name: "labeled_counter_metric",
+        sendInPings: ["metrics"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      },
+      CounterMetricType
+    );
+
+    labeledCounterMetric["notSnakeCase"].add(1);
+    labeledCounterMetric[""].add(1);
+    labeledCounterMetric["with/slash"].add(1);
+    labeledCounterMetric["this_string_has_more_than_thirty_characters"].add(1);
+
+    // TODO: test error recording in bug 1682574
+
+    assert.strictEqual(await labeledCounterMetric["__other__"].testGetValue(), 4);
+  });
+
+  it("Ensure invalid labels on labeled boolean go to __other__", async function() {
+    const labeledBooleanMetric = new LabeledMetricType<BooleanMetricType>(
+      {
+        category: "telemetry",
+        name: "labeled_boolean_metric",
+        sendInPings: ["metrics"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      },
+      BooleanMetricType
+    );
+
+    labeledBooleanMetric["notSnakeCase"].set(true);
+    labeledBooleanMetric[""].set(true);
+    labeledBooleanMetric["with/slash"].set(true);
+    labeledBooleanMetric["this_string_has_more_than_thirty_characters"].set(true);
+
+    // TODO: test error recording in bug 1682574
+
+    assert.strictEqual(await labeledBooleanMetric["__other__"].testGetValue(), true);
+  });
+
+  it("Ensure invalid labels on labeled string go to __other__", async function() {
+    const labeledStringMetric = new LabeledMetricType<StringMetricType>(
+      {
+        category: "telemetry",
+        name: "labeled_string_metric",
+        sendInPings: ["metrics"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      },
+      StringMetricType
+    );
+
+    labeledStringMetric["notSnakeCase"].set("foo");
+    labeledStringMetric[""].set("foo");
+    labeledStringMetric["with/slash"].set("foo");
+    labeledStringMetric["this_string_has_more_than_thirty_characters"].set("foo");
+
+    // TODO: test error recording in bug 1682574
+
+    assert.strictEqual(await labeledStringMetric["__other__"].testGetValue(), "foo");
+  });
+
+  it("test labeled string metric type", async function() {
+    const labeledStringMetric = new LabeledMetricType<StringMetricType>(
+      {
+        category: "telemetry",
+        name: "labeled_string_metric",
+        sendInPings: ["metrics"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      },
+      StringMetricType
+    );
+
+    labeledStringMetric["label1"].set("foo");
+    labeledStringMetric["label2"].set("bar");
+
+    // TODO: test error recording in bug 1682574
+
+    assert.strictEqual(await labeledStringMetric["label1"].testGetValue(), "foo");
+    assert.strictEqual(await labeledStringMetric["label2"].testGetValue(), "bar");
+    assert.strictEqual(await labeledStringMetric["__other__"].testGetValue(), undefined);
+  });
+
+  it("test labeled boolean metric type", async function() {
+    const metric = new LabeledMetricType<BooleanMetricType>(
+      {
+        category: "telemetry",
+        name: "labeled_bool",
+        sendInPings: ["metrics"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      },
+      BooleanMetricType
+    );
+
+    metric["label1"].set(false);
+    metric["label2"].set(true);
+
+    let value = await metric["label1"].testGetValue();
+    assert.strictEqual(value, false);
+    
+    value = await metric["label2"].testGetValue();
+    assert.strictEqual(value, true);
+  });
+
+  it("dynamic labels regex mismatch", async function() {
+    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+      {
+        category: "telemetry",
+        name: "labeled_counter_metric",
+        sendInPings: ["metrics"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      },
+      CounterMetricType
+    );
+
+    const labelsNotMatching = [
+      "notSnakeCase",
+      "",
+      "with/slash",
+      "1.not_fine",
+      "this.$isnotfine",
+      "-.not_fine",
+      "this.is_not_fine.2",
+    ];
+
+    for (const label of labelsNotMatching) {
+      labeledCounterMetric[label].add(1);
+    }
+
+    assert.strictEqual(await labeledCounterMetric["__other__"].testGetValue(), labelsNotMatching.length);
+  });
+
+  it("dynamic labels regex allowed", async function() {
+    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+      {
+        category: "telemetry",
+        name: "labeled_counter_metric",
+        sendInPings: ["metrics"],
+        lifetime: Lifetime.Application,
+        disabled: false
+      },
+      CounterMetricType
+    );
+
+    const labelsMatching = [
+      "this.is.fine",
+      "this_is_fine_too",
+      "this.is_still_fine",
+      "thisisfine",
+      "_.is_fine",
+      "this.is-fine",
+      "this-is-fine",
+    ];
+
+    for (const label of labelsMatching) {
+      labeledCounterMetric[label].add(1);
+      assert.strictEqual(await labeledCounterMetric[label].testGetValue(), 1);
+    }
+
+    assert.strictEqual(await labeledCounterMetric["__other__"].testGetValue(), undefined);
+  });
+
+  it("seen labels get reloaded across initializations", async function() {
+    const labeledCounterMetric = new LabeledMetricType<CounterMetricType>(
+      {
+        category: "telemetry",
+        name: "labeled_metric",
+        sendInPings: ["metrics"],
+        lifetime: Lifetime.Ping,
+        disabled: false
+      },
+      CounterMetricType
+    );
+
+    for (let i = 1; i <= 16; i++) {
+      const label = `label_${i}`;
+      labeledCounterMetric[label].add(1);
+      assert.strictEqual(await labeledCounterMetric[label].testGetValue(), 1);
+    }
+
+    // Reset glean without clearing the storage.
+    await Glean.testUninitialize();
+    await Glean.testInitialize("gleanjs.unit.test", true);
+
+    // Try to store another label.
+    labeledCounterMetric["new_label"].add(40);
+
+    // Check that the old data is still there.
+    for (let i = 1; i <= 16; i++) {
+      assert.strictEqual(await labeledCounterMetric[`label_${i}`].testGetValue(), 1);
+    }
+    // The new label lands in the __other__ bucket, due to too many labels.
+    assert.strictEqual(await labeledCounterMetric["__other__"].testGetValue(), 40);
+  });
+});


### PR DESCRIPTION
This introduces the labelled metric types for string, boolean and counter types. The implementation closely follows what's in the Glean SDK, with no major deviation.

Note that this required adding a couple more functions to the database.

TODO:

- [x] Port test coverage.
- [x] Enable dynamic labels.
- [ ] Add documentation.
- [x] Enforce label limits.
- [x] Enable different labelled metric types (instead of hardcoding)