### PR TITLE
Bug 1685718 - Add support for debug view and source tags setting 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.3.0...main)
 
 * [#92](https://github.com/mozilla/glean.js/pull/92): Remove `web-ext-types` from `peerDependencies` list.
+* [#98](https://github.com/mozilla/glean.js/pull/98): Add external APIs for setting the Debug View Tag and Source Tags.
 * [#99](https://github.com/mozilla/glean.js/pull/99): BUGFIX: Add a default ping value in the testing APIs.
 
 # v0.3.0 (2021-02-24)

--- a/glean/src/core/config.ts
+++ b/glean/src/core/config.ts
@@ -8,17 +8,6 @@ import { validateHeader, validateURL } from "./utils";
 
 /**
  * Lists Glean's debug options.
- *
- * The debug options for Glean may be set by calling one of the `set*` functions
- * or by setting the below properties on the configuration passed to `Glean.initialize`.
- *
- * The debugging features available out of the box are:
- *
- * * **Ping logging** - logging the contents of ping requests that are correctly assembled;
- * * **Debug tagging** - Adding the X-Debug-ID header to every ping request,
- *   allowing these tagged pings to be sent to the ["Ping Debug Viewer"](https://debug-ping-preview.firebaseapp.com/);
- * * **Source tagging** - Adding the X-Source-Tags header to every ping request,
- *   allowing pings to be tagged with custom labels.
  */
 interface DebugOptions {
   // Whether or not lot log pings when they are collected.

--- a/glean/src/core/config.ts
+++ b/glean/src/core/config.ts
@@ -2,16 +2,31 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { DEFAULT_TELEMETRY_ENDPOINT } from "./constants";
+import { DEFAULT_TELEMETRY_ENDPOINT, GLEAN_MAX_SOURCE_TAGS } from "./constants";
 import Plugin from "../plugins";
-import { validateURL } from "./utils";
+import { validateHeader, validateURL } from "./utils";
 
 /**
  * Lists Glean's debug options.
+ *
+ * The debug options for Glean may be set by calling one of the `set*` functions
+ * or by setting the below properties on the configuration passed to `Glean.initialize`.
+ *
+ * The debugging features available out of the box are:
+ *
+ * * **Ping logging** - logging the contents of ping requests that are correctly assembled;
+ * * **Debug tagging** - Adding the X-Debug-ID header to every ping request,
+ *   allowing these tagged pings to be sent to the ["Ping Debug Viewer"](https://debug-ping-preview.firebaseapp.com/);
+ * * **Source tagging** - Adding the X-Source-Tags header to every ping request,
+ *   allowing pings to be tagged with custom labels.
  */
 interface DebugOptions {
   // Whether or not lot log pings when they are collected.
   logPings?: boolean,
+  // The value of the X-Debug-ID header to be included in every ping.
+  debugViewTag?: string,
+  // The value of the X-Source-Tags header to be included in every ping.
+  sourceTags?: string[],
 }
 
 /**
@@ -38,12 +53,13 @@ export class Configuration implements ConfigurationInterface {
   // The server pings are sent to.
   readonly serverEndpoint: string;
   // Debug configuration.
-  debug?: DebugOptions;
+  debug: DebugOptions;
 
   constructor(config?: ConfigurationInterface) {
     this.appBuild = config?.appBuild;
     this.appDisplayVersion = config?.appDisplayVersion;
-    this.debug = config?.debug;
+
+    this.debug = Configuration.sanitizeDebugOptions(config?.debug);
 
     if (config?.serverEndpoint && !validateURL(config.serverEndpoint)) {
       throw new Error(
@@ -51,5 +67,47 @@ export class Configuration implements ConfigurationInterface {
     }
     this.serverEndpoint = (config && config.serverEndpoint)
       ? config.serverEndpoint : DEFAULT_TELEMETRY_ENDPOINT;
+  }
+
+  static sanitizeDebugOptions(debug?: DebugOptions): DebugOptions {
+    const correctedDebugOptions: DebugOptions = debug || {};
+    if (!Configuration.validateDebugViewTag(debug?.debugViewTag || "")) {
+      delete correctedDebugOptions["debugViewTag"];
+    }
+    if (!Configuration.validateSourceTags(debug?.sourceTags || [])) {
+      delete correctedDebugOptions["sourceTags"];
+    }
+    return correctedDebugOptions;
+  }
+
+  static validateDebugViewTag(tag: string): boolean {
+    const validation = validateHeader(tag);
+    if (!validation) {
+      console.error(
+        `"${tag}" is not a valid \`debugViewTag\` value.`,
+        "Please make sure the value passed satisfies the regex `^[a-zA-Z0-9-]{1,20}$`."
+      );
+    }
+    return validation;
+  }
+
+  static validateSourceTags(tags: string[]): boolean {
+    if (tags.length < 1 || tags.length > GLEAN_MAX_SOURCE_TAGS) {
+      console.error(`A list of tags cannot contain more than ${GLEAN_MAX_SOURCE_TAGS} elements.`);
+      return false;
+    }
+
+    for (const tag of tags) {
+      if (tag.startsWith("glean")) {
+        console.error("Tags starting with `glean` are reserved and must not be used.");
+        return false;
+      }
+
+      if (!validateHeader(tag)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/glean/src/core/constants.ts
+++ b/glean/src/core/constants.ts
@@ -36,3 +36,6 @@ export const DEFAULT_TELEMETRY_ENDPOINT = "https://incoming.telemetry.mozilla.or
 
 // The name of the deletion-request ping.
 export const DELETION_REQUEST_PING_NAME = "deletion-request";
+
+// The maximum amount of source tags a user can set.
+export const GLEAN_MAX_SOURCE_TAGS = 5;

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -426,7 +426,7 @@ class Glean {
   /**
    * Sets the `debugViewTag` debug option.
    *
-   * When this property is set, all subsequent outgoing pings will include the `X-Debug-Id` header
+   * When this property is set, all subsequent outgoing pings will include the `X-Debug-ID` header
    * which will redirect them to the ["Ping Debug Viewer"](https://debug-ping-preview.firebaseapp.com/).
    *
    * To unset the `debugViewTag` call `Glean.unsetDebugViewTag();

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -340,6 +340,14 @@ class Glean {
     return Glean.instance._config?.debug?.logPings || false;
   }
 
+  static get debugViewTag(): string | undefined {
+    return Glean.instance._config?.debug.debugViewTag;
+  }
+
+  static get sourceTags(): string | undefined {
+    return Glean.instance._config?.debug.sourceTags?.toString();
+  }
+
   static get dispatcher(): Dispatcher {
     return Glean.instance._dispatcher;
   }
@@ -399,7 +407,7 @@ class Glean {
   }
 
   /**
-   * Sets the `logPings` flag.
+   * Sets the `logPings` debug option.
    *
    * When this flag is `true` pings will be logged to the console right before they are collected.
    *
@@ -407,19 +415,89 @@ class Glean {
    */
   static setLogPings(flag: boolean): void {
     Glean.dispatcher.launch(() => {
-      // It is guaranteed that _config will have a value here.
-      //
-      // All dispatched tasks are guaranteed to be run after initialize.
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      if (!Glean.instance._config!.debug) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        Glean.instance._config!.debug = {};
-      }
-
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       Glean.instance._config!.debug.logPings = flag;
 
       // The dispatcher requires that dispatched functions return promises.
+      return Promise.resolve();
+    });
+  }
+
+  /**
+   * Sets the `debugViewTag` debug option.
+   *
+   * When this property is set, all subsequent outgoing pings will include the `X-Debug-Id` header
+   * allowing all outgoing pings to be redirected to the ["Ping Debug Viewer"](https://debug-ping-preview.firebaseapp.com/).
+   *
+   * To unset the `debugViewTag` call `Glean.unsetDebugViewTag();
+   *
+   * @param value The value of the header.
+   *              This value must satify the regex `^[a-zA-Z0-9-]{1,20}$` otherwise it will be ignored.
+   */
+  static setDebugViewTag(value: string): void {
+    if (!Configuration.validateDebugViewTag(value)) {
+      console.error(`Invalid \`debugViewTag\` ${value}. Ignoring.`);
+      return;
+    }
+
+    Glean.dispatcher.launch(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      Glean.instance._config!.debug.debugViewTag = value;
+
+      // The dispatcher requires that dispatched functions return promises.
+      return Promise.resolve();
+    });
+  }
+
+  /**
+   * Unsets the `debugViewTag` debug option.
+   *
+   * This is a no-op is case there is no `debugViewTag` set at the moment.
+   */
+  static unsetDebugViewTag(): void {
+    Glean.dispatcher.launch(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      delete Glean.instance._config!.debug.debugViewTag;
+      return Promise.resolve();
+    });
+  }
+
+  /**
+   * Sets the `sourceTags` debug option.
+   *
+   * Ping tags will show in the destination datasets, after ingestion.
+   *
+   * **Note** Setting `sourceTags` will override all previously set tags.
+   *
+   * To unset the `sourceTags` call `Glean.unsetSourceTags();
+   *
+   * @param value A vector of at most 5 valid HTTP header values.
+   *        Individual tags must match the regex: "[a-zA-Z0-9-]{1,20}".
+   */
+  static setSourceTags(value: string[]): void {
+    if (!Configuration.validateSourceTags(value)) {
+      console.error(`Invalid \`sourceTags\` ${value.toString()}. Ignoring.`);
+      return;
+    }
+
+    Glean.dispatcher.launch(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      Glean.instance._config!.debug.sourceTags = value;
+
+      // The dispatcher requires that dispatched functions return promises.
+      return Promise.resolve();
+    });
+  }
+
+  /**
+   * Unsets the `sourceTags` debug option.
+   *
+   * This is a no-op is case there are no `sourceTags` set at the moment.
+   */
+  static unsetSourceTags(): void {
+    Glean.dispatcher.launch(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      delete Glean.instance._config!.debug.sourceTags;
       return Promise.resolve();
     });
   }

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -427,12 +427,12 @@ class Glean {
    * Sets the `debugViewTag` debug option.
    *
    * When this property is set, all subsequent outgoing pings will include the `X-Debug-Id` header
-   * allowing all outgoing pings to be redirected to the ["Ping Debug Viewer"](https://debug-ping-preview.firebaseapp.com/).
+   * which will redirect them to the ["Ping Debug Viewer"](https://debug-ping-preview.firebaseapp.com/).
    *
    * To unset the `debugViewTag` call `Glean.unsetDebugViewTag();
    *
    * @param value The value of the header.
-   *              This value must satify the regex `^[a-zA-Z0-9-]{1,20}$` otherwise it will be ignored.
+   *        This value must satify the regex `^[a-zA-Z0-9-]{1,20}$` otherwise it will be ignored.
    */
   static setDebugViewTag(value: string): void {
     if (!Configuration.validateDebugViewTag(value)) {

--- a/glean/src/core/pings/maker.ts
+++ b/glean/src/core/pings/maker.ts
@@ -148,7 +148,7 @@ export async function buildClientInfoSection(ping: PingType): Promise<ClientInfo
  * ping submission will still contain the desired headers.
  *
  * The current headers gathered here are:
- * - [X-Debug-Id]
+ * - [X-Debug-ID]
  * - [X-Source-Tags]
  *
  * @returns An object containing all the headers and their values
@@ -158,7 +158,7 @@ export function getPingHeaders(): Record<string, string> | undefined {
   const headers: Record<string, string> = {};
 
   if (Glean.debugViewTag) {
-    headers["X-Debug-Id"] = Glean.debugViewTag;
+    headers["X-Debug-ID"] = Glean.debugViewTag;
   }
 
   if (Glean.sourceTags) {

--- a/glean/src/core/pings/maker.ts
+++ b/glean/src/core/pings/maker.ts
@@ -150,10 +150,24 @@ export async function buildClientInfoSection(ping: PingType): Promise<ClientInfo
  * The current headers gathered here are:
  * - [X-Debug-Id]
  * - [X-Source-Tags]
+ *
+ * @returns An object containing all the headers and their values
+ *          or `undefined` in case no custom headers were set.
  */
 export function getPingHeaders(): Record<string, string> | undefined {
-  // TODO: Returning nothing for now until Bug 1685718 is resolved.
-  return;
+  const headers: Record<string, string> = {};
+
+  if (Glean.debugViewTag) {
+    headers["X-Debug-Id"] = Glean.debugViewTag;
+  }
+
+  if (Glean.sourceTags) {
+    headers["X-Source-Tags"] = Glean.sourceTags;
+  }
+
+  if (Object.keys(headers).length > 0) {
+    return headers;
+  }
 }
 
 /**

--- a/glean/src/core/utils.ts
+++ b/glean/src/core/utils.ts
@@ -124,6 +124,17 @@ export function validateURL(v: string): boolean {
 }
 
 /**
+ * Validates whether or not a given value is an acceptable HTTP header for outgoing pings.
+ *
+ * @param v The value to validate.
+ *
+ * @returns Whether or not the given value is a valid HTTP header value.
+ */
+export function validateHeader(v: string): boolean {
+  return /^[a-z0-9-]{1,20}$/i.test(v);
+}
+
+/**
  * Generates a UUIDv4.
  *
  * Will provide a fallback in case `crypto` is not available,

--- a/glean/src/index/qt.ts
+++ b/glean/src/index/qt.ts
@@ -74,6 +74,55 @@ export default {
     Glean.setLogPings(flag);
   },
 
+  /**
+   * Sets the `debugViewTag` debug option.
+   *
+   * When this property is set, all subsequent outgoing pings will include the `X-Debug-Id` header
+   * which will redirect them to the ["Ping Debug Viewer"](https://debug-ping-preview.firebaseapp.com/).
+   *
+   * To unset the `debugViewTag` call `Glean.unsetDebugViewTag();
+   *
+   * @param value The value of the header.
+   *        This value must satify the regex `^[a-zA-Z0-9-]{1,20}$` otherwise it will be ignored.
+   */
+  setDebugViewTag(value: string): void {
+    Glean.setDebugViewTag(value);
+  },
+
+  /**
+   * Unsets the `debugViewTag` debug option.
+   *
+   * This is a no-op is case there is no `debugViewTag` set at the moment.
+   */
+  unsetDebugViewTag(): void {
+    Glean.unsetDebugViewTag();
+  },
+
+  /**
+   * Sets the `sourceTags` debug option.
+   *
+   * Ping tags will show in the destination datasets, after ingestion.
+   *
+   * **Note** Setting `sourceTags` will override all previously set tags.
+   *
+   * To unset the `sourceTags` call `Glean.unsetSourceTags();
+   *
+   * @param value A vector of at most 5 valid HTTP header values.
+   *        Individual tags must match the regex: "[a-zA-Z0-9-]{1,20}".
+   */
+  setSourceTags(value: string[]): void {
+    Glean.setSourceTags(value);
+  },
+
+  /**
+   * Unsets the `sourceTags` debug option.
+   *
+   * This is a no-op is case there are no `sourceTags` set at the moment.
+   */
+  unsetSourceTags(): void {
+    Glean.unsetSourceTags();
+  },
+
   _private: {
     PingType,
     BooleanMetricType,

--- a/glean/src/index/qt.ts
+++ b/glean/src/index/qt.ts
@@ -77,7 +77,7 @@ export default {
   /**
    * Sets the `debugViewTag` debug option.
    *
-   * When this property is set, all subsequent outgoing pings will include the `X-Debug-Id` header
+   * When this property is set, all subsequent outgoing pings will include the `X-Debug-ID` header
    * which will redirect them to the ["Ping Debug Viewer"](https://debug-ping-preview.firebaseapp.com/).
    *
    * To unset the `debugViewTag` call `Glean.unsetDebugViewTag();

--- a/glean/src/index/webext.ts
+++ b/glean/src/index/webext.ts
@@ -54,7 +54,7 @@ export default {
   },
 
   /**
-   * Sets the `logPings` flag.
+   * Sets the `logPings` debug option.
    *
    * When this flag is `true` pings will be logged
    * to the console right before they are collected.
@@ -63,5 +63,54 @@ export default {
    */
   setLogPings(flag: boolean): void {
     Glean.setLogPings(flag);
-  }
+  },
+
+  /**
+   * Sets the `debugViewTag` debug option.
+   *
+   * When this property is set, all subsequent outgoing pings will include the `X-Debug-Id` header
+   * which will redirect them to the ["Ping Debug Viewer"](https://debug-ping-preview.firebaseapp.com/).
+   *
+   * To unset the `debugViewTag` call `Glean.unsetDebugViewTag();
+   *
+   * @param value The value of the header.
+   *        This value must satify the regex `^[a-zA-Z0-9-]{1,20}$` otherwise it will be ignored.
+   */
+  setDebugViewTag(value: string): void {
+    Glean.setDebugViewTag(value);
+  },
+
+  /**
+   * Unsets the `debugViewTag` debug option.
+   *
+   * This is a no-op is case there is no `debugViewTag` set at the moment.
+   */
+  unsetDebugViewTag(): void {
+    Glean.unsetDebugViewTag();
+  },
+
+  /**
+   * Sets the `sourceTags` debug option.
+   *
+   * Ping tags will show in the destination datasets, after ingestion.
+   *
+   * **Note** Setting `sourceTags` will override all previously set tags.
+   *
+   * To unset the `sourceTags` call `Glean.unsetSourceTags();
+   *
+   * @param value A vector of at most 5 valid HTTP header values.
+   *        Individual tags must match the regex: "[a-zA-Z0-9-]{1,20}".
+   */
+  setSourceTags(value: string[]): void {
+    Glean.setSourceTags(value);
+  },
+
+  /**
+   * Unsets the `sourceTags` debug option.
+   *
+   * This is a no-op is case there are no `sourceTags` set at the moment.
+   */
+  unsetSourceTags(): void {
+    Glean.unsetSourceTags();
+  },
 };

--- a/glean/src/index/webext.ts
+++ b/glean/src/index/webext.ts
@@ -68,7 +68,7 @@ export default {
   /**
    * Sets the `debugViewTag` debug option.
    *
-   * When this property is set, all subsequent outgoing pings will include the `X-Debug-Id` header
+   * When this property is set, all subsequent outgoing pings will include the `X-Debug-ID` header
    * which will redirect them to the ["Ping Debug Viewer"](https://debug-ping-preview.firebaseapp.com/).
    *
    * To unset the `debugViewTag` call `Glean.unsetDebugViewTag();

--- a/glean/tests/core/config.spec.ts
+++ b/glean/tests/core/config.spec.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import assert from "assert";
+
+import { Configuration } from "../../src/core/config";
+
+describe("config", function() {
+  it("validateSourceTags works correctly", function () {
+    // Invalid values
+    assert.ok(!Configuration.validateSourceTags([]));
+    assert.ok(!Configuration.validateSourceTags([""]));
+    assert.ok(!Configuration.validateSourceTags(["1", "2", "3", "4", "5", "6"]));
+    assert.ok(!Configuration.validateSourceTags(["!nv@lid-val*e"]));
+    assert.ok(!Configuration.validateSourceTags(["glean-test1", "test2"]));
+
+    // Valid values
+    assert.ok(Configuration.validateSourceTags(["5"]));
+  });
+
+  it("sanitizeDebugOptions works correctly", function() {
+    // Invalid values
+    assert.deepStrictEqual(Configuration.sanitizeDebugOptions({
+      debugViewTag: ""
+    }), {});
+    assert.deepStrictEqual(Configuration.sanitizeDebugOptions({
+      sourceTags: []
+    }), {});
+    assert.deepStrictEqual(Configuration.sanitizeDebugOptions({
+      debugViewTag: "",
+      sourceTags: ["ok"]
+    }), { sourceTags: ["ok"] });
+    assert.deepStrictEqual(Configuration.sanitizeDebugOptions({
+      debugViewTag: "",
+      logPings: true,
+      sourceTags: ["ok"]
+    }), { sourceTags: ["ok"], logPings: true });
+
+    // Valid values
+    assert.deepStrictEqual(Configuration.sanitizeDebugOptions({}), {});
+    assert.deepStrictEqual(
+      Configuration.sanitizeDebugOptions({ logPings: true }),
+      { logPings: true }
+    );
+    assert.deepStrictEqual(
+      Configuration.sanitizeDebugOptions({ debugViewTag: "ok" }),
+      { debugViewTag: "ok" }
+    );
+    assert.deepStrictEqual(
+      Configuration.sanitizeDebugOptions({ sourceTags: ["ok"] }),
+      { sourceTags: ["ok"] }
+    );
+  });
+});

--- a/glean/tests/core/pings/database.spec.ts
+++ b/glean/tests/core/pings/database.spec.ts
@@ -32,7 +32,7 @@ describe("PingsDatabase", function() {
         path, payload
       });
   
-      const headers = { "X-Debug-Id": "test" };
+      const headers = { "X-Debug-ID": "test" };
       const otherIdentifier = "THE OTHER IDENTIFIER";
       await db.recordPing(path, otherIdentifier, payload, headers);
       assert.deepStrictEqual(await db["store"].get([otherIdentifier]), {

--- a/glean/tests/core/pings/maker.spec.ts
+++ b/glean/tests/core/pings/maker.spec.ts
@@ -117,7 +117,7 @@ describe("PingMaker", function() {
     await Glean.dispatcher.testBlockOnQueue();
 
     assert.deepStrictEqual({
-      "X-Debug-Id": "test",
+      "X-Debug-ID": "test",
       "X-Source-Tags": "tag1,tag2,tag3"
     }, PingMaker.getPingHeaders());
 

--- a/glean/tests/core/pings/maker.spec.ts
+++ b/glean/tests/core/pings/maker.spec.ts
@@ -111,6 +111,22 @@ describe("PingMaker", function() {
     assert.strictEqual(await PingMaker.getSequenceNumber(ping1), 13);
   });
 
+  it("getPingHeaders returns headers when custom headers are set", async function () {
+    Glean.setDebugViewTag("test");
+    Glean.setSourceTags(["tag1", "tag2", "tag3"]);
+    await Glean.dispatcher.testBlockOnQueue();
+
+    assert.deepStrictEqual({
+      "X-Debug-Id": "test",
+      "X-Source-Tags": "tag1,tag2,tag3"
+    }, PingMaker.getPingHeaders());
+
+    Glean.unsetDebugViewTag();
+    Glean.unsetSourceTags();
+    await Glean.dispatcher.testBlockOnQueue();
+    assert.strictEqual(PingMaker.getPingHeaders(), undefined);
+  });
+
   it("collect and store triggers the AfterPingCollection and deals with possible result correctly", async function () {
     // Disable ping uploading for it not to interfere with this tests.
     sandbox.stub(Glean["pingUploader"], "triggerUpload").callsFake(() => Promise.resolve());

--- a/glean/tests/core/utils.spec.ts
+++ b/glean/tests/core/utils.spec.ts
@@ -99,4 +99,17 @@ describe("utils", function() {
     assert.strictEqual(utils.validateURL("https://incoming.telemetry.mozilla.org"), true);
     assert.strictEqual(utils.validateURL("https://localhost:3000/"), true);
   });
+
+  it("validateHeader works correctly", function () {
+    // Invalid values
+    assert.strictEqual(utils.validateHeader(""), false);
+    assert.strictEqual(utils.validateHeader("invalid_value"), false);
+    assert.strictEqual(utils.validateHeader("invalid value"), false);
+    assert.strictEqual(utils.validateHeader("!nv@lid-val*e"), false);
+    assert.strictEqual(utils.validateHeader("invalid-value-because-way-too-long"), false);
+
+    // Valid values
+    assert.strictEqual(utils.validateHeader("valid-value"), true);
+    assert.strictEqual(utils.validateHeader("-also-valid-value"), true);
+  });
 });


### PR DESCRIPTION
Left the API to "unset" the tags because I had already written the code before realizing glean-core doesn't support it. I can remove it, to wait for a response on [Bug 1697198](https://bugzilla.mozilla.org/show_bug.cgi?id=1697198),  but I'd rather not since it seems like a no brainer.

Also, I tested it in the sample webext and 🎉 https://debug-ping-preview.firebaseapp.com/pings/ts-webext-test