### PR TITLE
Add a default ping name for the testing APIs

### DIFF
--- a/glean/src/core/metrics/types/boolean.ts
+++ b/glean/src/core/metrics/types/boolean.ts
@@ -55,10 +55,11 @@ class BooleanMetricType extends MetricType {
    * TODO: Only allow this function to be called on test mode (depends on Bug 1682771).
    *
    * @param ping the ping from which we want to retrieve this metrics value from.
+   *             Defaults to the first value in `sendInPings`.
    *
    * @returns The value found in storage or `undefined` if nothing was found.
    */
-  async testGetValue(ping: string): Promise<boolean | undefined> {
+  async testGetValue(ping: string = this.sendInPings[0]): Promise<boolean | undefined> {
     let metric: boolean | undefined;
     await Glean.dispatcher.testLaunch(async () => {
       metric = await Glean.metricsDatabase.getMetric<boolean>(ping, this);

--- a/glean/src/core/metrics/types/counter.ts
+++ b/glean/src/core/metrics/types/counter.ts
@@ -116,10 +116,11 @@ class CounterMetricType extends MetricType {
    * TODO: Only allow this function to be called on test mode (depends on Bug 1682771).
    *
    * @param ping the ping from which we want to retrieve this metrics value from.
+   *             Defaults to the first value in `sendInPings`.
    *
    * @returns The value found in storage or `undefined` if nothing was found.
    */
-  async testGetValue(ping: string): Promise<number | undefined> {
+  async testGetValue(ping: string = this.sendInPings[0]): Promise<number | undefined> {
     let metric: number | undefined;
     await Glean.dispatcher.testLaunch(async () => {
       metric = await Glean.metricsDatabase.getMetric<number>(ping, this);

--- a/glean/src/core/metrics/types/datetime.ts
+++ b/glean/src/core/metrics/types/datetime.ts
@@ -236,10 +236,11 @@ class DatetimeMetricType extends MetricType {
    * TODO: Only allow this function to be called on test mode (depends on Bug 1682771).
    *
    * @param ping the ping from which we want to retrieve this metrics value from.
+   *             Defaults to the first value in `sendInPings`.
    *
    * @returns The value found in storage or `undefined` if nothing was found.
    */
-  private async testGetValueAsDatetimeMetric(ping: string): Promise<DatetimeMetric | undefined> {
+  private async testGetValueAsDatetimeMetric(ping: string = this.sendInPings[0]): Promise<DatetimeMetric | undefined> {
     let value: DatetimeInternalRepresentation | undefined;
     await Glean.dispatcher.testLaunch(async () => {
       value = await Glean.metricsDatabase.getMetric<DatetimeInternalRepresentation>(ping, this);
@@ -259,10 +260,11 @@ class DatetimeMetricType extends MetricType {
    * TODO: Only allow this function to be called on   test mode (depends on Bug 1682771).
    *
    * @param ping the ping from which we want to retrieve this metrics value from.
+   *             Defaults to the first value in `sendInPings`.
    *
    * @returns The value found in storage or `undefined` if nothing was found.
    */
-  async testGetValueAsString(ping: string): Promise<string | undefined> {
+  async testGetValueAsString(ping: string = this.sendInPings[0]): Promise<string | undefined> {
     const metric = await this.testGetValueAsDatetimeMetric(ping);
     return metric ? metric.payload() : undefined;
   }
@@ -284,10 +286,11 @@ class DatetimeMetricType extends MetricType {
    * TODO: Only allow this function to be called on test mode (depends on Bug 1682771).
    *
    * @param ping the ping from which we want to retrieve this metrics value from.
+   *             Defaults to the first value in `sendInPings`.
    *
    * @returns The value found in storage or `undefined` if nothing was found.
    */
-  async testGetValue(ping: string): Promise<Date | undefined> {
+  async testGetValue(ping: string = this.sendInPings[0]): Promise<Date | undefined> {
     const metric = await this.testGetValueAsDatetimeMetric(ping);
     return metric ? metric.date : undefined;
   }

--- a/glean/src/core/metrics/types/event.ts
+++ b/glean/src/core/metrics/types/event.ts
@@ -87,14 +87,14 @@ class EventMetricType extends MetricType {
    * TODO: Only allow this function to be called on test mode (depends on Bug 1682771).
    *
    * @param ping the ping from which we want to retrieve this metrics value from.
+   *             Defaults to the first value in `sendInPings`.
    *
    * @returns The value found in storage or `undefined` if nothing was found.
    */
-  async testGetValue(ping?: string): Promise<RecordedEvent[] | undefined> {
-    const pingToQuery = ping ?? this.sendInPings[0];
+  async testGetValue(ping: string = this.sendInPings[0]): Promise<RecordedEvent[] | undefined> {
     let events: RecordedEvent[] | undefined;
     await Glean.dispatcher.testLaunch(async () => {
-      events = await Glean.eventsDatabase.getEvents(pingToQuery, this);
+      events = await Glean.eventsDatabase.getEvents(ping, this);
     });
     return events;
   }

--- a/glean/src/core/metrics/types/string.ts
+++ b/glean/src/core/metrics/types/string.ts
@@ -91,10 +91,11 @@ class StringMetricType extends MetricType {
    * TODO: Only allow this function to be called on test mode (depends on Bug 1682771).
    *
    * @param ping the ping from which we want to retrieve this metrics value from.
+   *             Defaults to the first value in `sendInPings`.
    *
    * @returns The value found in storage or `undefined` if nothing was found.
    */
-  async testGetValue(ping: string): Promise<string | undefined> {
+  async testGetValue(ping: string = this.sendInPings[0]): Promise<string | undefined> {
     let metric: string | undefined;
     await Glean.dispatcher.testLaunch(async () => {
       metric = await Glean.metricsDatabase.getMetric<string>(ping, this);

--- a/glean/src/core/metrics/types/uuid.ts
+++ b/glean/src/core/metrics/types/uuid.ts
@@ -111,10 +111,11 @@ class UUIDMetricType extends MetricType {
    * TODO: Only allow this function to be called on test mode (depends on Bug 1682771).
    *
    * @param ping the ping from which we want to retrieve this metrics value from.
+   *             Defaults to the first value in `sendInPings`.
    *
    * @returns The value found in storage or `undefined` if nothing was found.
    */
-  async testGetValue(ping: string): Promise<string | undefined> {
+  async testGetValue(ping: string = this.sendInPings[0]): Promise<string | undefined> {
     let metric: string | undefined;
     await Glean.dispatcher.testLaunch(async () => {
       metric = await Glean.metricsDatabase.getMetric<string>(ping, this);


### PR DESCRIPTION
The Glean testing APIs are designed so that when user calls `testGetValue` they are not required to
explicitly specify the name of the ping, unless they want to.
This fixes the existing testing APIs to stick to that convention.