### PR TITLE
Bug 1697208 - Include a Glean User-Agent header in all pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.4.0...main)
 
 * [#101](https://github.com/mozilla/glean.js/pull/101): BUGFIX: Only validate Debug View Tag and Source Tags when they are present.
+* [#102](https://github.com/mozilla/glean.js/pull/102): BUGFIX: Include a Glean User-Agent header in all pings.
 
 # v0.4.0 (2021-03-10)
 

--- a/glean/src/core/upload/index.ts
+++ b/glean/src/core/upload/index.ts
@@ -117,10 +117,10 @@ class PingUploader implements PingsDatabaseObserver {
    *
    * @returns The updated ping.
    */
-  private preparePingForUpload(ping: QueuedPing): {
+  private async preparePingForUpload(ping: QueuedPing): Promise<{
     headers: Record<string, string>,
     payload: string
-  } {
+  }> {
     const stringifiedBody = JSON.stringify(ping.payload);
 
     let headers = ping.headers || {};
@@ -131,6 +131,7 @@ class PingUploader implements PingsDatabaseObserver {
       "Date": (new Date()).toISOString(),
       "X-Client-Type": "Glean.js",
       "X-Client-Version": GLEAN_VERSION,
+      "User-Agent": `Glean/${GLEAN_VERSION} (JS on ${await Glean.platform.info.os()})`
     };
 
     return {
@@ -152,7 +153,7 @@ class PingUploader implements PingsDatabaseObserver {
       return { result: UploadResultStatus.RecoverableFailure };
     }
 
-    const finalPing = this.preparePingForUpload(ping);
+    const finalPing = await this.preparePingForUpload(ping);
     const result = await Glean.platform.uploader.post(
       // We are sure that the applicationId is not `undefined` at this point,
       // this function is only called when submitting a ping

--- a/glean/tests/core/upload/index.spec.ts
+++ b/glean/tests/core/upload/index.spec.ts
@@ -10,7 +10,6 @@ import Glean from "../../../src/core/glean";
 import PingType from "../../../src/core/pings";
 import collectAndStorePing from "../../../src/core/pings/maker";
 import PingUploader, { UploadResultStatus } from "../../../src/core/upload";
-import { JSONObject } from "../../../dist/webext/types/core/utils";
 
 const sandbox = sinon.createSandbox();
 
@@ -196,7 +195,7 @@ describe("PingUploader", function() {
 
     const url = postSpy.firstCall.args[0].split("/");
     const documentId = url[url.length - 1];
-    const headers = postSpy.firstCall.args[2] as JSONObject;
+    const headers = postSpy.firstCall.args[2] || {};
 
     assert.strictEqual(documentId, expectedDocumentId);
 


### PR DESCRIPTION
Example header sent from our web extension sample `Glean/0.4.0 (JS on Darwin)`.