### PR TITLE
Bug 1687287 - Support setting a custom uploader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.7.0...main)
 
+* [#155](https://github.com/mozilla/glean.js/pull/155): Allow to define custom uploaders in the configuration.
+
 # v0.7.0 (2021-03-26)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.6.1...v0.7.0)

--- a/glean/src/core/config.ts
+++ b/glean/src/core/config.ts
@@ -5,6 +5,7 @@
 import { DEFAULT_TELEMETRY_ENDPOINT, GLEAN_MAX_SOURCE_TAGS } from "./constants.js";
 import Plugin from "../plugins/index.js";
 import { validateHeader, validateURL } from "./utils.js";
+import Uploader from "./upload/uploader.js";
 
 /**
  * Lists Glean's debug options.
@@ -32,6 +33,8 @@ export interface ConfigurationInterface {
   debug?: DebugOptions,
   // Optional list of plugins to include in current Glean instance.
   plugins?: Plugin[],
+  // The HTTP client implementation to use for uploading pings.
+  httpClient?: Uploader,
 }
 
 export class Configuration implements ConfigurationInterface {
@@ -43,6 +46,8 @@ export class Configuration implements ConfigurationInterface {
   readonly serverEndpoint: string;
   // Debug configuration.
   debug: DebugOptions;
+  // The HTTP client implementation to use for uploading pings.
+  readonly httpClient?: Uploader;
 
   constructor(config?: ConfigurationInterface) {
     this.appBuild = config?.appBuild;
@@ -56,6 +61,8 @@ export class Configuration implements ConfigurationInterface {
     }
     this.serverEndpoint = (config && config.serverEndpoint)
       ? config.serverEndpoint : DEFAULT_TELEMETRY_ENDPOINT;
+
+    this.httpClient = config?.httpClient;
   }
 
   static sanitizeDebugOptions(debug?: DebugOptions): DebugOptions {

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -30,8 +30,10 @@ class Glean {
   private _coreMetrics: CoreMetrics;
   // Instances of Glean's core pings.
   private _corePings: CorePings;
-  // The ping uploader.
-  private _pingUploader: PingUploader
+  // The ping uploader. Note that we need to use the definite assignment assertion
+  // because initialization will not happen in the constructor, but in the `initialize`
+  // method.
+  private _pingUploader!: PingUploader
   // A task dispatcher to help execute in order asynchronous external API calls.
   private _dispatcher: Dispatcher;
 
@@ -61,7 +63,6 @@ class Glean {
     }
 
     this._dispatcher = new Dispatcher();
-    this._pingUploader = new PingUploader();
     this._coreMetrics = new CoreMetrics();
     this._corePings = new CorePings();
     this._initialized = false;
@@ -221,16 +222,19 @@ class Glean {
       return;
     }
 
-    if (!Glean.instance._db) {
-      Glean.instance._db = {
-        metrics: new MetricsDatabase(Glean.platform.Storage),
-        events: new EventsDatabase(),
-        pings: new PingsDatabase(Glean.platform.Storage, Glean.pingUploader)
-      };
-    }
-
     // The configuration constructor will throw in case config has any incorrect prop.
     const correctConfig = new Configuration(config);
+
+    // Initialize the ping uploader with either the platform defaults or a custom
+    // provided uploader from the configuration object.
+    Glean.instance._pingUploader =
+      new PingUploader(correctConfig.httpClient ? correctConfig.httpClient : Glean.platform.uploader);
+
+    Glean.instance._db = {
+      metrics: new MetricsDatabase(Glean.platform.Storage),
+      events: new EventsDatabase(),
+      pings: new PingsDatabase(Glean.platform.Storage, Glean.pingUploader)
+    };
 
     if (config?.plugins) {
       for (const plugin of config.plugins) {
@@ -556,7 +560,11 @@ class Glean {
     await Glean.dispatcher.testUninitialize();
 
     // Stop ongoing jobs and clear pending pings queue.
-    await Glean.pingUploader.clearPendingPingsQueue();
+    if (Glean.pingUploader) {
+      // The first time tests run, before Glean is initialized, we are
+      // not guaranteed to have an uploader. Account for this.
+      await Glean.pingUploader.clearPendingPingsQueue();
+    }
   }
 
   /**

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -30,10 +30,6 @@ class Glean {
   private _coreMetrics: CoreMetrics;
   // Instances of Glean's core pings.
   private _corePings: CorePings;
-  // The ping uploader. Note that we need to use the definite assignment assertion
-  // because initialization will not happen in the constructor, but in the `initialize`
-  // method.
-  private _pingUploader!: PingUploader
   // A task dispatcher to help execute in order asynchronous external API calls.
   private _dispatcher: Dispatcher;
 
@@ -42,6 +38,10 @@ class Glean {
 
   // Properties that will only be set on `initialize`.
 
+  // The ping uploader. Note that we need to use the definite assignment assertion
+  // because initialization will not happen in the constructor, but in the `initialize`
+  // method.
+  private _pingUploader!: PingUploader
   // The application ID (will be sanitized during initialization).
   private _applicationId?: string;
   // Whether or not to record metrics.

--- a/glean/src/core/upload/index.ts
+++ b/glean/src/core/upload/index.ts
@@ -5,6 +5,7 @@
 import { GLEAN_VERSION } from "../constants.js";
 import { Observer as PingsDatabaseObserver, PingInternalRepresentation } from "../pings/database.js";
 import Glean from "../glean.js";
+import { UploadResult, UploadResultStatus } from "./uploader.js";
 
 interface QueuedPing extends PingInternalRepresentation {
   identifier: string
@@ -20,36 +21,6 @@ const enum PingUploaderStatus {
   Uploading,
   // Currently processing a signal to stop uploading pings.
   Cancelling,
-}
-
-/**
- * The resulting status of an attempted ping upload.
- */
-export const enum UploadResultStatus {
-  // A recoverable failure.
-  //
-  // During upload something went wrong,
-  // e.g. the network connection failed.
-  // The upload should be retried at a later time.
-  RecoverableFailure,
-  // An unrecoverable upload failure.
-  //
-  // A possible cause might be a malformed URL.
-  UnrecoverableFailure,
-  // Request was successfull.
-  //
-  // This can still indicate an error, depending on the status code.
-  Success,
-}
-
-/**
- * The result of an attempted ping upload.
- */
-export interface UploadResult {
-  // The status is only present if `result` is UploadResultStatus.Success
-  status?: number,
-  // The status of an upload attempt
-  result: UploadResultStatus
 }
 
 /**

--- a/glean/src/core/upload/index.ts
+++ b/glean/src/core/upload/index.ts
@@ -5,7 +5,7 @@
 import { GLEAN_VERSION } from "../constants.js";
 import { Observer as PingsDatabaseObserver, PingInternalRepresentation } from "../pings/database.js";
 import Glean from "../glean.js";
-import { UploadResult, UploadResultStatus } from "./uploader.js";
+import Uploader, { UploadResult, UploadResultStatus } from "./uploader.js";
 
 interface QueuedPing extends PingInternalRepresentation {
   identifier: string
@@ -42,10 +42,13 @@ class PingUploader implements PingsDatabaseObserver {
   // A promise that represents the current uploading job.
   // This is `undefined` in case there is no current uploading job.
   private currentJob?: Promise<void>;
+  // The object that concretely handles the ping transmission.
+  private readonly uploader: Uploader;
 
-  constructor() {
+  constructor(uploader: Uploader) {
     this.queue = [];
     this.status = PingUploaderStatus.Idle;
+    this.uploader = uploader;
   }
 
   /**
@@ -125,7 +128,7 @@ class PingUploader implements PingsDatabaseObserver {
     }
 
     const finalPing = await this.preparePingForUpload(ping);
-    const result = await Glean.platform.uploader.post(
+    const result = await this.uploader.post(
       // We are sure that the applicationId is not `undefined` at this point,
       // this function is only called when submitting a ping
       // and that function return early when Glean is not initialized.

--- a/glean/src/core/upload/uploader.ts
+++ b/glean/src/core/upload/uploader.ts
@@ -4,13 +4,13 @@
 
 import { UploadResult } from "../upload/index.js";
 
+// The timeout, in milliseconds, to use for all operations with the server.
+export const DEFAULT_UPLOAD_TIMEOUT_MS = 10_000;
+
 /**
  * Uploader interface, actualy uploading logic varies per platform.
  */
-export abstract class Uploader {
-  // The timeout, in seconds, to use for all operations with the server.
-  protected defaultTimeout = 10_000;
-
+export interface Uploader {
   /**
    * Makes a POST request to a given url, with the given headers and body.
    *
@@ -20,7 +20,7 @@ export abstract class Uploader {
    *
    * @returns The status code of the response.
    */
-  abstract post(url: string, body: string, headers?: Record<string, string>): Promise<UploadResult>;
+  post(url: string, body: string, headers?: Record<string, string>): Promise<UploadResult>;
 }
 
 export default Uploader;

--- a/glean/src/core/upload/uploader.ts
+++ b/glean/src/core/upload/uploader.ts
@@ -2,10 +2,38 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { UploadResult } from "../upload/index.js";
-
 // The timeout, in milliseconds, to use for all operations with the server.
 export const DEFAULT_UPLOAD_TIMEOUT_MS = 10_000;
+
+/**
+ * The resulting status of an attempted ping upload.
+ */
+export const enum UploadResultStatus {
+  // A recoverable failure.
+  //
+  // During upload something went wrong,
+  // e.g. the network connection failed.
+  // The upload should be retried at a later time.
+  RecoverableFailure,
+  // An unrecoverable upload failure.
+  //
+  // A possible cause might be a malformed URL.
+  UnrecoverableFailure,
+  // Request was successfull.
+  //
+  // This can still indicate an error, depending on the status code.
+  Success,
+}
+
+/**
+ * The result of an attempted ping upload.
+ */
+export interface UploadResult {
+  // The status is only present if `result` is UploadResultStatus.Success
+  status?: number,
+  // The status of an upload attempt
+  result: UploadResultStatus
+}
 
 /**
  * Uploader interface, actualy uploading logic varies per platform.

--- a/glean/src/platform/test/index.ts
+++ b/glean/src/platform/test/index.ts
@@ -8,7 +8,7 @@ import PlatformInfo, { KnownOperatingSystems } from "../../core/platform_info.js
 import Uploader from "../../core/upload/uploader.js";
 import Platform from "../index.js";
 
-class MockUploader extends Uploader {
+class MockUploader implements Uploader {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   post(_url: string, _body: string, _headers?: Record<string, string>): Promise<UploadResult> {
     const result: UploadResult = {

--- a/glean/src/platform/test/index.ts
+++ b/glean/src/platform/test/index.ts
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import MockStorage from "../test/storage.js";
-import { UploadResult, UploadResultStatus } from "../../core/upload/index.js";
 import PlatformInfo, { KnownOperatingSystems } from "../../core/platform_info.js";
-import Uploader from "../../core/upload/uploader.js";
+import Uploader, { UploadResult, UploadResultStatus } from "../../core/upload/uploader.js";
 import Platform from "../index.js";
 
 class MockUploader implements Uploader {

--- a/glean/src/platform/test/storage.ts
+++ b/glean/src/platform/test/storage.ts
@@ -6,7 +6,7 @@ import Store, { StorageIndex } from "../../core/storage/index.js";
 import { updateNestedObject, getValueFromNestedObject, deleteKeyFromNestedObject } from "../../core/storage/utils.js";
 import { JSONObject, JSONValue } from "../../core/utils.js";
 
-// Enable storing the data outside of `WeakStore` instances to simulate the
+// Enable storing the data outside of `MockStore` instances to simulate the
 // behaviour of the other persistent storages.
 let globalStore: JSONObject = {};
 
@@ -16,7 +16,7 @@ let globalStore: JSONObject = {};
  * This means the data saved in this store does not persist throughout application runs.
  * However, data can be shared across two instances of the store.
  */
-class WeakStore implements Store {
+class MockStore implements Store {
   private rootKey: string;
 
   constructor(rootKey: string) {
@@ -58,4 +58,4 @@ class WeakStore implements Store {
     return Promise.resolve();
   }
 }
-export default WeakStore;
+export default MockStore;

--- a/glean/src/platform/test/storage.ts
+++ b/glean/src/platform/test/storage.ts
@@ -5,25 +5,32 @@
 import Store, { StorageIndex } from "../../core/storage/index.js";
 import { updateNestedObject, getValueFromNestedObject, deleteKeyFromNestedObject } from "../../core/storage/utils.js";
 import { JSONObject, JSONValue } from "../../core/utils.js";
+
+// Enable storing the data outside of `WeakStore` instances to simulate the
+// behaviour of the other persistent storages.
+let globalStore: JSONObject = {};
+
 /**
  * A weak implementation for the Store interface.
  *
  * This means the data saved in this store does not persist throughout application runs.
+ * However, data can be shared across two instances of the store.
  */
 class WeakStore implements Store {
-  private store: JSONObject;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  constructor(_store: string) {
-    this.store = {};
+  private rootKey: string;
+
+  constructor(rootKey: string) {
+    this.rootKey = rootKey;
   }
 
   _getWholeStore(): Promise<JSONObject> {
-    return Promise.resolve(this.store);
+    const result: JSONObject = (globalStore[this.rootKey] as JSONObject) || {};
+    return Promise.resolve(result);
   }
 
   get(index: StorageIndex): Promise<JSONValue | undefined> {
     try {
-      const value = getValueFromNestedObject(this.store, index);
+      const value = getValueFromNestedObject(globalStore, [ this.rootKey, ...index ]);
       return Promise.resolve(value);
     } catch(e) {
       return Promise.reject(e);
@@ -35,7 +42,7 @@ class WeakStore implements Store {
     transformFn: (v?: JSONValue) => JSONValue
   ): Promise<void> {
     try {
-      this.store = updateNestedObject(this.store, index, transformFn);
+      globalStore = updateNestedObject(globalStore, [ this.rootKey, ...index ], transformFn);
       return Promise.resolve();
     } catch(e) {
       return Promise.reject(e);
@@ -44,7 +51,7 @@ class WeakStore implements Store {
 
   delete(index: StorageIndex): Promise<void> {
     try {
-      this.store = deleteKeyFromNestedObject(this.store, index);
+      globalStore = deleteKeyFromNestedObject(globalStore, [ this.rootKey, ...index ]);
     } catch (e) {
       console.warn((e as Error).message, "Ignoring.");
     }

--- a/glean/src/platform/webext/uploader.ts
+++ b/glean/src/platform/webext/uploader.ts
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Uploader from "../../core/upload/uploader.js";
+import Uploader, { DEFAULT_UPLOAD_TIMEOUT_MS } from "../../core/upload/uploader.js";
 import { UploadResult, UploadResultStatus } from "../../core/upload/index.js";
 
-class BrowserUploader extends Uploader {
+class BrowserUploader implements Uploader {
   async post(url: string, body: string, headers: Record<string, string> = {}): Promise<UploadResult> {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.defaultTimeout);
+    const timeout = setTimeout(() => controller.abort(), DEFAULT_UPLOAD_TIMEOUT_MS);
 
     let response;
     try {

--- a/glean/src/platform/webext/uploader.ts
+++ b/glean/src/platform/webext/uploader.ts
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Uploader, { DEFAULT_UPLOAD_TIMEOUT_MS } from "../../core/upload/uploader.js";
-import { UploadResult, UploadResultStatus } from "../../core/upload/index.js";
+import Uploader, { DEFAULT_UPLOAD_TIMEOUT_MS, UploadResult, UploadResultStatus } from "../../core/upload/uploader.js";
 
 class BrowserUploader implements Uploader {
   async post(url: string, body: string, headers: Record<string, string> = {}): Promise<UploadResult> {

--- a/glean/tests/core/upload/index.spec.ts
+++ b/glean/tests/core/upload/index.spec.ts
@@ -9,7 +9,8 @@ import { v4 as UUIDv4 } from "uuid";
 import Glean from "../../../src/core/glean";
 import PingType from "../../../src/core/pings";
 import collectAndStorePing from "../../../src/core/pings/maker";
-import PingUploader, { UploadResultStatus } from "../../../src/core/upload";
+import PingUploader from "../../../src/core/upload";
+import { UploadResultStatus } from "../../../src/core/upload/uploader";
 
 const sandbox = sinon.createSandbox();
 

--- a/glean/tests/core/upload/index.spec.ts
+++ b/glean/tests/core/upload/index.spec.ts
@@ -70,7 +70,7 @@ describe("PingUploader", function() {
     disableGleanUploader();
     await fillUpPingsDatabase(10);
 
-    const uploader = new PingUploader();
+    const uploader = new PingUploader(Glean.platform.uploader);
     await uploader.scanPendingPings();
     assert.strictEqual(uploader["queue"].length, 10);
   });
@@ -85,7 +85,7 @@ describe("PingUploader", function() {
     disableGleanUploader();
     await fillUpPingsDatabase(10);
 
-    const uploader = new PingUploader();
+    const uploader = new PingUploader(Glean.platform.uploader);
     await uploader.scanPendingPings();
     assert.strictEqual(uploader["queue"].length, 10);
 
@@ -105,7 +105,7 @@ describe("PingUploader", function() {
     disableGleanUploader();
     await fillUpPingsDatabase(10);
 
-    const uploader = new PingUploader();
+    const uploader = new PingUploader(Glean.platform.uploader);
     await uploader.scanPendingPings();
 
     // Trigger uploading, but don't wait for it to finish,
@@ -157,7 +157,7 @@ describe("PingUploader", function() {
   });
 
   it("duplicates are not enqueued", function() {
-    const uploader = new PingUploader();
+    const uploader = new PingUploader(Glean.platform.uploader);
     for (let i = 0; i < 10; i++) {
       uploader["enqueuePing"]({
         identifier: "id",

--- a/glean/tests/platform/uploader.spec.ts
+++ b/glean/tests/platform/uploader.spec.ts
@@ -6,9 +6,9 @@ import "jsdom-global/register";
 import assert from "assert";
 import sinon from "sinon";
 
-import { UploadResultStatus } from "../../src/core/upload";
 import BrowserUploader from "../../src/platform/webext/uploader";
 import { JSONObject } from "../../src/core/utils";
+import { UploadResultStatus } from "../../src/core/upload/uploader";
 
 const sandbox = sinon.createSandbox();
 


### PR DESCRIPTION
This PR ended up being bigger than anticipated, sorry. It does:

- Make `Uploader` a proper interface rather than an abstract class.
- Inject instances of the uploader to `PingsDatabase` rather than having it directly call `Glean.platform.uploader`.
- Fixes `WeakStore` to behave like other stores.
- Adds `httpClient` as a configuration option (the naming is consistent with the other bindings).

See the individual commit messages for more information.