### PR TITLE
Bug 1701578 (Part 1) - Remove some circular dependencies

### DIFF
--- a/glean/src/core/events/index.ts
+++ b/glean/src/core/events/index.ts
@@ -4,7 +4,7 @@
 
 import Plugin from "../../plugins/index.js";
 
-import { PingPayload } from "../pings/database.js";
+import { PingPayload } from "../pings/ping_payload.js";
 import { JSONObject } from "../utils.js";
 
 export class CoreEvent<

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -232,7 +232,7 @@ class Glean {
 
     Glean.instance._db = {
       metrics: new MetricsDatabase(Glean.platform.Storage),
-      events: new EventsDatabase(),
+      events: new EventsDatabase(Glean.platform.Storage),
       pings: new PingsDatabase(Glean.platform.Storage, Glean.pingUploader)
     };
 

--- a/glean/src/core/metrics/database.ts
+++ b/glean/src/core/metrics/database.ts
@@ -8,12 +8,7 @@ import { Metric } from "./metric.js";
 import { createMetric, validateMetricInternalRepresentation } from "./utils.js";
 import { isObject, isUndefined, JSONObject, JSONValue } from "../utils.js";
 import { StorageBuilder } from "../../platform/index.js";
-
-export interface Metrics {
-  [aMetricType: string]: {
-    [aMetricIdentifier: string]: JSONValue
-  }
-}
+import { Metrics } from "./metrics_interface";
 
 /**
  * Verifies if a given value is a valid Metrics object.

--- a/glean/src/core/metrics/database.ts
+++ b/glean/src/core/metrics/database.ts
@@ -3,7 +3,8 @@
 //  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Store from "../storage/index.js";
-import { MetricType, Lifetime, Metric } from "./index.js";
+import { MetricType, Lifetime } from "./index.js";
+import { Metric } from "./metric.js";
 import { createMetric, validateMetricInternalRepresentation } from "./utils.js";
 import { isObject, isUndefined, JSONObject, JSONValue } from "../utils.js";
 import { StorageBuilder } from "../../platform/index.js";

--- a/glean/src/core/metrics/events_database.ts
+++ b/glean/src/core/metrics/events_database.ts
@@ -7,12 +7,6 @@ import { isUndefined, JSONArray, JSONObject, JSONValue } from "../utils.js";
 import EventMetricType from "./types/event.js";
 import { StorageBuilder } from "../../platform/index.js";
 
-export interface Metrics {
-  [aMetricType: string]: {
-    [aMetricIdentifier: string]: JSONValue
-  }
-}
-
 // An helper type for the 'extra' map.
 export type ExtraMap = Record<string, string>;
 

--- a/glean/src/core/metrics/events_database.ts
+++ b/glean/src/core/metrics/events_database.ts
@@ -5,7 +5,7 @@
 import Store from "../storage/index.js";
 import { isUndefined, JSONArray, JSONObject, JSONValue } from "../utils.js";
 import EventMetricType from "./types/event.js";
-import Glean from "../glean.js";
+import { StorageBuilder } from "../../platform/index.js";
 
 export interface Metrics {
   [aMetricType: string]: {
@@ -80,8 +80,8 @@ export class RecordedEvent {
 class EventsDatabase {
   private eventsStore: Store;
 
-  constructor() {
-    this.eventsStore = new Glean.platform.Storage("events");
+  constructor(storage: StorageBuilder) {
+    this.eventsStore = new storage("events");
   }
 
   /**

--- a/glean/src/core/metrics/index.ts
+++ b/glean/src/core/metrics/index.ts
@@ -5,75 +5,7 @@
 import { isUndefined, JSONValue } from "../utils.js";
 import Glean from "../glean.js";
 import LabeledMetricType from "./types/labeled.js";
-
-/**
- * The Metric class describes the shared behaviour amongst concrete metrics.
- *
- * A concrete metric will always have two possible representations:
- *
- * - `InternalRepresentation`
- *    - Is the format in which this metric will be stored in memory.
- *    - This format may contain extra metadata, in order to allow deserializing of this data for testing purposes.
- * - `PayloadRepresentation`
- *    - Is the format in which this metric will be represented in the ping payload.
- *    - This format must be the exact same as described in [the Glean schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/glean/glean/glean.1.schema.json).
- */
-export abstract class Metric<
-  InternalRepresentation extends JSONValue,
-  PayloadRepresentation extends JSONValue
-> {
-  protected _inner: InternalRepresentation;
-
-  constructor(v: unknown) {
-    if (!this.validate(v)) {
-      throw new Error("Unable to create new Metric instance, values is in unexpected format.");
-    }
-
-    this._inner = v;
-  }
-
-  /**
-   * Gets this metrics value in its internal representation.
-   *
-   * @returns The metric value.
-   */
-  get(): InternalRepresentation {
-    return this._inner;
-  }
-
-  /**
-   * Sets this metrics value.
-   *
-   * @param v The value to set, must be in the exact internal representation of this metric.
-   *
-   * @throws In case the metric is not in the expected format.
-   */
-  set(v: unknown): void {
-    if (!this.validate(v)) {
-      console.error(`Unable to set metric to ${JSON.stringify(v)}. Value is in unexpected format. Ignoring.`);
-      return;
-    }
-
-    this._inner = v;
-  }
-
-  /**
-   * Validates that a given value is in the correct format for this metrics internal representation.
-   *
-   * @param v The value to verify.
-   *
-   * @returns A special Typescript value (which compiles down to a boolean)
-   *          stating whether `v` is of the correct type.
-   */
-  abstract validate(v: unknown): v is InternalRepresentation;
-
-  /**
-   * Gets this metrics value in its payload representation.
-   *
-   * @returns The metric value.
-   */
-  abstract payload(): PayloadRepresentation;
-}
+import { Metric } from "./metric.js";
 
 /**
  * An enum representing the possible metric lifetimes.

--- a/glean/src/core/metrics/metric.ts
+++ b/glean/src/core/metrics/metric.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { JSONValue } from "../utils.js";
+
+/**
+ * The Metric class describes the shared behaviour amongst concrete metrics.
+ *
+ * A concrete metric will always have two possible representations:
+ *
+ * - `InternalRepresentation`
+ *    - Is the format in which this metric will be stored in memory.
+ *    - This format may contain extra metadata, in order to allow deserializing of this data for testing purposes.
+ * - `PayloadRepresentation`
+ *    - Is the format in which this metric will be represented in the ping payload.
+ *    - This format must be the exact same as described in [the Glean schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/glean/glean/glean.1.schema.json).
+ */
+
+export abstract class Metric<
+  InternalRepresentation extends JSONValue,
+  PayloadRepresentation extends JSONValue
+  > {
+  protected _inner: InternalRepresentation;
+
+  constructor(v: unknown) {
+    if (!this.validate(v)) {
+      throw new Error("Unable to create new Metric instance, values is in unexpected format.");
+    }
+
+    this._inner = v;
+  }
+
+  /**
+   * Gets this metrics value in its internal representation.
+   *
+   * @returns The metric value.
+   */
+  get(): InternalRepresentation {
+    return this._inner;
+  }
+
+  /**
+   * Sets this metrics value.
+   *
+   * @param v The value to set, must be in the exact internal representation of this metric.
+   *
+   * @throws In case the metric is not in the expected format.
+   */
+  set(v: unknown): void {
+    if (!this.validate(v)) {
+      console.error(`Unable to set metric to ${JSON.stringify(v)}. Value is in unexpected format. Ignoring.`);
+      return;
+    }
+
+    this._inner = v;
+  }
+
+  /**
+   * Validates that a given value is in the correct format for this metrics internal representation.
+   *
+   * @param v The value to verify.
+   *
+   * @returns A special Typescript value (which compiles down to a boolean)
+   *          stating whether `v` is of the correct type.
+   */
+  abstract validate(v: unknown): v is InternalRepresentation;
+
+  /**
+   * Gets this metrics value in its payload representation.
+   *
+   * @returns The metric value.
+   */
+  abstract payload(): PayloadRepresentation;
+}

--- a/glean/src/core/metrics/metrics_interface.ts
+++ b/glean/src/core/metrics/metrics_interface.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { JSONValue } from "../utils.js";
+
+export interface Metrics {
+  [aMetricType: string]: {
+    [aMetricIdentifier: string]: JSONValue;
+  };
+}

--- a/glean/src/core/metrics/types/boolean.ts
+++ b/glean/src/core/metrics/types/boolean.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Metric, MetricType, CommonMetricData } from "../index.js";
+import { MetricType, CommonMetricData } from "../index.js";
+import { Metric } from "../metric.js";
 import { isBoolean } from "../../utils.js";
 import Glean from "../../glean.js";
 

--- a/glean/src/core/metrics/types/counter.ts
+++ b/glean/src/core/metrics/types/counter.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Metric, MetricType, CommonMetricData } from "../index.js";
+import { MetricType, CommonMetricData } from "../index.js";
+import { Metric } from "../metric.js";
 import { isNumber, isUndefined, JSONValue } from "../../utils.js";
 import Glean from "../../glean.js";
 

--- a/glean/src/core/metrics/types/datetime.ts
+++ b/glean/src/core/metrics/types/datetime.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Metric, MetricType, CommonMetricData } from "../index.js";
+import { MetricType, CommonMetricData } from "../index.js";
+import { Metric } from "../metric.js";
 import TimeUnit from "../../metrics/time_unit.js";
 import Glean from "../../glean.js";
 import { isNumber, isObject, isString } from "../../utils.js";

--- a/glean/src/core/metrics/types/string.ts
+++ b/glean/src/core/metrics/types/string.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Metric, MetricType, CommonMetricData } from "../index.js";
+import { MetricType, CommonMetricData } from "../index.js";
+import { Metric } from "../metric.js";
 import { isString } from "../../utils.js";
 import Glean from "../../glean.js";
 

--- a/glean/src/core/metrics/types/uuid.ts
+++ b/glean/src/core/metrics/types/uuid.ts
@@ -5,7 +5,8 @@
 import { validate as UUIDvalidate } from "uuid";
 
 import { KNOWN_CLIENT_ID } from "../../constants.js";
-import { Metric, MetricType, CommonMetricData } from "../index.js";
+import { MetricType, CommonMetricData } from "../index.js";
+import { Metric } from "../metric.js";
 import { isString, generateUUIDv4 } from "../../utils.js";
 import Glean from "../../glean.js";
 

--- a/glean/src/core/metrics/utils.ts
+++ b/glean/src/core/metrics/utils.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Metric, LabeledMetric } from "./index.js";
+import { LabeledMetric } from "./index.js";
+import { Metric } from "./metric.js";
 import { JSONValue } from "../utils.js";
 
 import { BooleanMetric } from "./types/boolean.js";

--- a/glean/src/core/pings/database.ts
+++ b/glean/src/core/pings/database.ts
@@ -3,45 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Store from "../storage/index.js";
-import { Metrics as MetricsPayload } from "../metrics/database.js";
-import { isObject, isJSONValue, JSONObject, isString, JSONArray } from "../utils.js";
+import { isObject, isJSONValue, JSONObject, isString } from "../utils.js";
 import { StorageBuilder } from "../../platform/index.js";
 
-export interface PingInfo extends JSONObject {
-  seq: number,
-  start_time: string,
-  end_time: string,
-  reason?: string,
-}
-
-export interface ClientInfo extends JSONObject {
-  client_id?: string,
-  locale?: string,
-  device_model?: string,
-  device_manufacturer?: string,
-  app_channel?: string,
-  // Even though all the next fields are required by the schema
-  // we can't guarantee that they will be present.
-  // Active discussion about this is happening on Bug 1685705.
-  app_build?: string,
-  app_display_version?: string,
-  architecture?: string,
-  first_run_date?: string,
-  os?: string,
-  os_version?: string,
-  telemetry_sdk_build: string
-}
-
-/**
- * This definition must be in sync with
- * the Glean ping [schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/glean/glean/glean.1.schema.json)
- */
-export interface PingPayload extends JSONObject {
-  ping_info: PingInfo,
-  client_info: ClientInfo,
-  metrics?: MetricsPayload,
-  events?: JSONArray,
-}
 export interface PingInternalRepresentation extends JSONObject {
   path: string,
   payload: JSONObject,

--- a/glean/src/core/pings/maker.ts
+++ b/glean/src/core/pings/maker.ts
@@ -7,7 +7,7 @@ import CounterMetricType, { CounterMetric } from "../metrics/types/counter.js";
 import DatetimeMetricType, { DatetimeMetric } from "../metrics/types/datetime.js";
 import { Lifetime } from "../metrics/index.js";
 import TimeUnit from "../metrics/time_unit.js";
-import { ClientInfo, PingInfo, PingPayload } from "../pings/database.js";
+import { ClientInfo, PingInfo, PingPayload } from "../pings/ping_payload.js";
 import PingType from "../pings/index.js";
 import Glean from "../glean.js";
 import CoreEvents from "../events/index.js";

--- a/glean/src/core/pings/ping_payload.ts
+++ b/glean/src/core/pings/ping_payload.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Metrics } from "../metrics/metrics_interface.js";
+import { JSONObject, JSONArray } from "../utils.js";
+
+export interface PingInfo extends JSONObject {
+  seq: number,
+  start_time: string,
+  end_time: string,
+  reason?: string,
+}
+
+export interface ClientInfo extends JSONObject {
+  client_id?: string,
+  locale?: string,
+  device_model?: string,
+  device_manufacturer?: string,
+  app_channel?: string,
+  // Even though all the next fields are required by the schema
+  // we can't guarantee that they will be present.
+  // Active discussion about this is happening on Bug 1685705.
+  app_build?: string,
+  app_display_version?: string,
+  architecture?: string,
+  first_run_date?: string,
+  os?: string,
+  os_version?: string,
+  telemetry_sdk_build: string
+}
+
+/**
+ * This definition must be in sync with
+ * the Glean ping [schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/glean/glean/glean.1.schema.json)
+ */
+export interface PingPayload extends JSONObject {
+  ping_info: PingInfo,
+  client_info: ClientInfo,
+  metrics?: Metrics,
+  events?: JSONArray,
+}

--- a/glean/src/plugins/encryption.ts
+++ b/glean/src/plugins/encryption.ts
@@ -8,7 +8,7 @@ import calculateThumbprint from "jose/jwk/thumbprint";
 import { JWK } from "jose/types";
 
 import Plugin from "./index.js";
-import { PingPayload } from "../core/pings/database.js";
+import { PingPayload } from "../core/pings/ping_payload.js";
 import { JSONObject } from "../core/utils.js";
 import CoreEvents from "../core/events/index.js";
 

--- a/glean/tests/core/metrics/events_database.spec.ts
+++ b/glean/tests/core/metrics/events_database.spec.ts
@@ -73,14 +73,14 @@ describe("EventsDatabase", function() {
   // reduce coupling across the components.
 
   it("getPingMetrics returns undefined if nothing is recorded", async function () {
-    const db = new EventsDatabase();
+    const db = new EventsDatabase(Glean.platform.Storage);
     const data = await db.getPingEvents("test-unknown-ping", true);
 
     assert.strictEqual(data, undefined);
   });
 
   it("getPingMetrics correctly clears the store", async function () {
-    const db = new EventsDatabase();
+    const db = new EventsDatabase(Glean.platform.Storage);
 
     const metric = new EventMetricType({
       category: "telemetry",
@@ -121,7 +121,7 @@ describe("EventsDatabase", function() {
   });
 
   it("getPingMetrics sorts the timestamps", async function () {
-    const db = new EventsDatabase();
+    const db = new EventsDatabase(Glean.platform.Storage);
 
     const metric = new EventMetricType({
       category: "telemetry",


### PR DESCRIPTION
This PR brings down the circular dependencies detected by `npm run lint:circular-deps` from 34 to 20.

These are the low hanging fruits. I'll follow up with other work next.