### PR TITLE
Bug 1701578 - Remove the final circular dependencies!

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
       - run:
           name: Run linter
           command: npm --prefix ./glean run lint
+      - run:
+          name: Run circular dependencies checker
+          command: npm --prefix ./glean run lint:circular-deps
 
   unit-tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,10 @@ jobs:
       - run:
           name: Run linter
           command: npm --prefix ./glean run lint
-      - run:
-          name: Run circular dependencies checker
-          command: npm --prefix ./glean run lint:circular-deps
+      # Disabled because of bug 1704794.
+      # - run:
+      #    name: Run circular dependencies checker
+      #    command: npm --prefix ./glean run lint:circular-deps
 
   unit-tests:
     docker:

--- a/glean/src/core/context.ts
+++ b/glean/src/core/context.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import type { DebugOptions } from "./debug_options";
 import type MetricsDatabase from "./metrics/database";
 import type EventsDatabase from "./metrics/events_database";
 import type PingsDatabase from "./pings/database";
@@ -17,6 +18,11 @@ export class Context {
   private _eventsDatabase!: EventsDatabase;
   private _pingsDatabase!: PingsDatabase;
 
+  private _applicationId!: string;
+  private _initialized!: boolean;
+
+  private _debugOptions!: DebugOptions;
+
   private constructor() {
     // Intentionally empty, exclusively defined to mark the
     // constructor as private.
@@ -28,6 +34,14 @@ export class Context {
     }
 
     return Context._instance;
+  }
+
+  get uploadEnabled(): boolean {
+    return this._uploadEnabled;
+  }
+
+  set uploadEnabled(upload: boolean) {
+    this._uploadEnabled = upload;
   }
 
   get metricsDatabase(): MetricsDatabase {
@@ -54,11 +68,27 @@ export class Context {
     this._pingsDatabase = db;
   }
 
-  get uploadEnabled(): boolean {
-    return this._uploadEnabled;
+  get applicatinId(): string {
+    return this._applicationId;
   }
 
-  set uploadEnabled(upload: boolean) {
-    this._uploadEnabled = upload;
+  set applicationId(id: string) {
+    this._applicationId = id;
+  }
+
+  get initialized(): boolean {
+    return this._initialized;
+  }
+
+  set initialized(init: boolean) {
+    this._initialized = init;
+  }
+
+  get debugOptions(): DebugOptions {
+    return this._debugOptions;
+  }
+
+  set debugOptions(options: DebugOptions) {
+    this._debugOptions = options;
   }
 }

--- a/glean/src/core/context.ts
+++ b/glean/src/core/context.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { DebugOptions } from "./debug_options";
+import type Dispatcher from "./dispatcher";
 import type MetricsDatabase from "./metrics/database";
 import type EventsDatabase from "./metrics/events_database";
 import type PingsDatabase from "./pings/database";
@@ -12,6 +13,8 @@ import type PingsDatabase from "./pings/database";
  */
 export class Context {
   private static _instance: Context;
+
+  private _dispatcher!: Dispatcher;
 
   private _uploadEnabled!: boolean;
   private _metricsDatabase!: MetricsDatabase;
@@ -36,59 +39,67 @@ export class Context {
     return Context._instance;
   }
 
-  get uploadEnabled(): boolean {
-    return this._uploadEnabled;
+  static get dispatcher(): Dispatcher {
+    return Context.instance._dispatcher;
   }
 
-  set uploadEnabled(upload: boolean) {
-    this._uploadEnabled = upload;
+  static set dispatcher(dispatcher: Dispatcher) {
+    Context.instance._dispatcher = dispatcher;
   }
 
-  get metricsDatabase(): MetricsDatabase {
-    return this._metricsDatabase;
+  static get uploadEnabled(): boolean {
+    return Context.instance._uploadEnabled;
   }
 
-  set metricsDatabase(db: MetricsDatabase) {
-    this._metricsDatabase = db;
+  static set uploadEnabled(upload: boolean) {
+    Context.instance._uploadEnabled = upload;
   }
 
-  get eventsDatabase(): EventsDatabase {
-    return this._eventsDatabase;
+  static get metricsDatabase(): MetricsDatabase {
+    return Context.instance._metricsDatabase;
   }
 
-  set eventsDatabase(db: EventsDatabase) {
-    this._eventsDatabase = db;
+  static set metricsDatabase(db: MetricsDatabase) {
+    Context.instance._metricsDatabase = db;
   }
 
-  get pingsDatabase(): PingsDatabase {
-    return this._pingsDatabase;
+  static get eventsDatabase(): EventsDatabase {
+    return Context.instance._eventsDatabase;
   }
 
-  set pingsDatabase(db: PingsDatabase) {
-    this._pingsDatabase = db;
+  static set eventsDatabase(db: EventsDatabase) {
+    Context.instance._eventsDatabase = db;
   }
 
-  get applicatinId(): string {
-    return this._applicationId;
+  static get pingsDatabase(): PingsDatabase {
+    return Context.instance._pingsDatabase;
   }
 
-  set applicationId(id: string) {
-    this._applicationId = id;
+  static set pingsDatabase(db: PingsDatabase) {
+    Context.instance._pingsDatabase = db;
   }
 
-  get initialized(): boolean {
-    return this._initialized;
+  static get applicatinId(): string {
+    return Context.instance._applicationId;
   }
 
-  set initialized(init: boolean) {
-    this._initialized = init;
+  static set applicationId(id: string) {
+    Context.instance._applicationId = id;
   }
 
-  get debugOptions(): DebugOptions {
-    return this._debugOptions;
+  static get initialized(): boolean {
+    return Context.instance._initialized;
   }
 
-  set debugOptions(options: DebugOptions) {
-    this._debugOptions = options;
+  static set initialized(init: boolean) {
+    Context.instance._initialized = init;
+  }
+
+  static get debugOptions(): DebugOptions {
+    return Context.instance._debugOptions;
+  }
+
+  static set debugOptions(options: DebugOptions) {
+    Context.instance._debugOptions = options;
   }
 }

--- a/glean/src/core/context.ts
+++ b/glean/src/core/context.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type MetricsDatabase from "./metrics/database";
+import type EventsDatabase from "./metrics/events_database";
+import type PingsDatabase from "./pings/database";
 
 /**
  * TODO: Why do we need this?
@@ -12,6 +14,8 @@ export class Context {
 
   private _uploadEnabled!: boolean;
   private _metricsDatabase!: MetricsDatabase;
+  private _eventsDatabase!: EventsDatabase;
+  private _pingsDatabase!: PingsDatabase;
 
   private constructor() {
     // Intentionally empty, exclusively defined to mark the
@@ -32,6 +36,22 @@ export class Context {
 
   set metricsDatabase(db: MetricsDatabase) {
     this._metricsDatabase = db;
+  }
+
+  get eventsDatabase(): EventsDatabase {
+    return this._eventsDatabase;
+  }
+
+  set eventsDatabase(db: EventsDatabase) {
+    this._eventsDatabase = db;
+  }
+
+  get pingsDatabase(): PingsDatabase {
+    return this._pingsDatabase;
+  }
+
+  set pingsDatabase(db: PingsDatabase) {
+    this._pingsDatabase = db;
   }
 
   get uploadEnabled(): boolean {

--- a/glean/src/core/context.ts
+++ b/glean/src/core/context.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type MetricsDatabase from "./metrics/database";
+
+/**
+ * TODO: Why do we need this?
+ */
+export class Context {
+  private static _instance: Context;
+
+  private _uploadEnabled!: boolean;
+  private _metricsDatabase!: MetricsDatabase;
+
+  private constructor() {
+    // Intentionally empty, exclusively defined to mark the
+    // constructor as private.
+  }
+
+  static get instance(): Context {
+    if (!Context._instance) {
+      Context._instance = new Context();
+    }
+
+    return Context._instance;
+  }
+
+  get metricsDatabase(): MetricsDatabase {
+    return this._metricsDatabase;
+  }
+
+  set metricsDatabase(db: MetricsDatabase) {
+    this._metricsDatabase = db;
+  }
+
+  get uploadEnabled(): boolean {
+    return this._uploadEnabled;
+  }
+
+  set uploadEnabled(upload: boolean) {
+    this._uploadEnabled = upload;
+  }
+}

--- a/glean/src/core/dispatcher.ts
+++ b/glean/src/core/dispatcher.ts
@@ -79,10 +79,22 @@ class Dispatcher {
   // This is private, because we only expect `testLaunch` to attach observers as of yet.
   private observers: DispatcherObserver[];
 
+  private static _instance: Dispatcher;
+
+  // While this constructor should be private to prevent direct instantiation,
+  // it's left as public in order to make testing simpler.
   constructor(readonly maxPreInitQueueSize = 100) {
     this.observers = [];
     this.queue = [];
     this.state = DispatcherState.Uninitialized;
+  }
+
+  static get instance(): Dispatcher {
+    if (!Dispatcher._instance) {
+      Dispatcher._instance = new Dispatcher();
+    }
+
+    return Dispatcher._instance;
   }
 
   /**

--- a/glean/src/core/dispatcher.ts
+++ b/glean/src/core/dispatcher.ts
@@ -79,22 +79,10 @@ class Dispatcher {
   // This is private, because we only expect `testLaunch` to attach observers as of yet.
   private observers: DispatcherObserver[];
 
-  private static _instance: Dispatcher;
-
-  // While this constructor should be private to prevent direct instantiation,
-  // it's left as public in order to make testing simpler.
   constructor(readonly maxPreInitQueueSize = 100) {
     this.observers = [];
     this.queue = [];
     this.state = DispatcherState.Uninitialized;
-  }
-
-  static get instance(): Dispatcher {
-    if (!Dispatcher._instance) {
-      Dispatcher._instance = new Dispatcher();
-    }
-
-    return Dispatcher._instance;
   }
 
   /**

--- a/glean/src/core/metrics/types/boolean.ts
+++ b/glean/src/core/metrics/types/boolean.ts
@@ -5,7 +5,6 @@
 import type { CommonMetricData } from "../index.js";
 import { MetricType } from "../index.js";
 import { BooleanMetric } from "./boolean_metric.js";
-import Dispatcher from "../../dispatcher.js";
 import { Context } from "../../context.js";
 
 /**
@@ -24,13 +23,13 @@ class BooleanMetricType extends MetricType {
    * @param value the value to set.
    */
   set(value: boolean): void {
-    Dispatcher.instance.launch(async () => {
-      if (!this.shouldRecord(Context.instance.uploadEnabled)) {
+    Context.dispatcher.launch(async () => {
+      if (!this.shouldRecord(Context.uploadEnabled)) {
         return;
       }
 
       const metric = new BooleanMetric(value);
-      await Context.instance.metricsDatabase.record(this, metric);
+      await Context.metricsDatabase.record(this, metric);
     });
   }
 
@@ -50,8 +49,8 @@ class BooleanMetricType extends MetricType {
    */
   async testGetValue(ping: string = this.sendInPings[0]): Promise<boolean | undefined> {
     let metric: boolean | undefined;
-    await Dispatcher.instance.testLaunch(async () => {
-      metric = await Context.instance.metricsDatabase.getMetric<boolean>(ping, this);
+    await Context.dispatcher.testLaunch(async () => {
+      metric = await Context.metricsDatabase.getMetric<boolean>(ping, this);
     });
     return metric;
   }

--- a/glean/src/core/metrics/types/boolean.ts
+++ b/glean/src/core/metrics/types/boolean.ts
@@ -4,9 +4,9 @@
 
 import type { CommonMetricData } from "../index.js";
 import { MetricType } from "../index.js";
-import Glean from "../../glean.js";
 import { BooleanMetric } from "./boolean_metric.js";
 import Dispatcher from "../../dispatcher.js";
+import { Context } from "../../context.js";
 
 /**
  *  A boolean metric.
@@ -25,12 +25,12 @@ class BooleanMetricType extends MetricType {
    */
   set(value: boolean): void {
     Dispatcher.instance.launch(async () => {
-      if (!this.shouldRecord(Glean.isUploadEnabled())) {
+      if (!this.shouldRecord(Context.instance.uploadEnabled)) {
         return;
       }
 
       const metric = new BooleanMetric(value);
-      await Glean.metricsDatabase.record(this, metric);
+      await Context.instance.metricsDatabase.record(this, metric);
     });
   }
 
@@ -51,7 +51,7 @@ class BooleanMetricType extends MetricType {
   async testGetValue(ping: string = this.sendInPings[0]): Promise<boolean | undefined> {
     let metric: boolean | undefined;
     await Dispatcher.instance.testLaunch(async () => {
-      metric = await Glean.metricsDatabase.getMetric<boolean>(ping, this);
+      metric = await Context.instance.metricsDatabase.getMetric<boolean>(ping, this);
     });
     return metric;
   }

--- a/glean/src/core/metrics/types/boolean.ts
+++ b/glean/src/core/metrics/types/boolean.ts
@@ -6,6 +6,7 @@ import type { CommonMetricData } from "../index.js";
 import { MetricType } from "../index.js";
 import Glean from "../../glean.js";
 import { BooleanMetric } from "./boolean_metric.js";
+import Dispatcher from "../../dispatcher.js";
 
 /**
  *  A boolean metric.
@@ -23,7 +24,7 @@ class BooleanMetricType extends MetricType {
    * @param value the value to set.
    */
   set(value: boolean): void {
-    Glean.dispatcher.launch(async () => {
+    Dispatcher.instance.launch(async () => {
       if (!this.shouldRecord(Glean.isUploadEnabled())) {
         return;
       }
@@ -49,7 +50,7 @@ class BooleanMetricType extends MetricType {
    */
   async testGetValue(ping: string = this.sendInPings[0]): Promise<boolean | undefined> {
     let metric: boolean | undefined;
-    await Glean.dispatcher.testLaunch(async () => {
+    await Dispatcher.instance.testLaunch(async () => {
       metric = await Glean.metricsDatabase.getMetric<boolean>(ping, this);
     });
     return metric;

--- a/glean/src/core/metrics/types/counter.ts
+++ b/glean/src/core/metrics/types/counter.ts
@@ -6,9 +6,9 @@ import type { CommonMetricData } from "../index.js";
 import { MetricType } from "../index.js";
 import type { JSONValue } from "../../utils.js";
 import { isUndefined } from "../../utils.js";
-import Glean from "../../glean.js";
 import { CounterMetric } from "./counter_metric.js";
 import Dispatcher from "../../dispatcher.js";
+import { Context } from "../../context.js";
 
 /**
  * A counter metric.
@@ -34,7 +34,7 @@ class CounterMetricType extends MetricType {
    * @param amount The amount we want to add.
    */
   static async _private_addUndispatched(instance: CounterMetricType, amount?: number): Promise<void> {
-    if (!instance.shouldRecord(Glean.isUploadEnabled())) {
+    if (!instance.shouldRecord(Context.instance.uploadEnabled)) {
       return;
     }
 
@@ -69,7 +69,7 @@ class CounterMetricType extends MetricType {
       };
     })(amount);
 
-    await Glean.metricsDatabase.transform(instance, transformFn);
+    await Context.instance.metricsDatabase.transform(instance, transformFn);
   }
 
   /**
@@ -105,7 +105,7 @@ class CounterMetricType extends MetricType {
   async testGetValue(ping: string = this.sendInPings[0]): Promise<number | undefined> {
     let metric: number | undefined;
     await Dispatcher.instance.testLaunch(async () => {
-      metric = await Glean.metricsDatabase.getMetric<number>(ping, this);
+      metric = await Context.instance.metricsDatabase.getMetric<number>(ping, this);
     });
     return metric;
   }

--- a/glean/src/core/metrics/types/counter.ts
+++ b/glean/src/core/metrics/types/counter.ts
@@ -7,7 +7,6 @@ import { MetricType } from "../index.js";
 import type { JSONValue } from "../../utils.js";
 import { isUndefined } from "../../utils.js";
 import { CounterMetric } from "./counter_metric.js";
-import Dispatcher from "../../dispatcher.js";
 import { Context } from "../../context.js";
 
 /**
@@ -34,7 +33,7 @@ class CounterMetricType extends MetricType {
    * @param amount The amount we want to add.
    */
   static async _private_addUndispatched(instance: CounterMetricType, amount?: number): Promise<void> {
-    if (!instance.shouldRecord(Context.instance.uploadEnabled)) {
+    if (!instance.shouldRecord(Context.uploadEnabled)) {
       return;
     }
 
@@ -69,7 +68,7 @@ class CounterMetricType extends MetricType {
       };
     })(amount);
 
-    await Context.instance.metricsDatabase.transform(instance, transformFn);
+    await Context.metricsDatabase.transform(instance, transformFn);
   }
 
   /**
@@ -85,7 +84,7 @@ class CounterMetricType extends MetricType {
    *               If not provided will default to `1`.
    */
   add(amount?: number): void {
-    Dispatcher.instance.launch(async () => CounterMetricType._private_addUndispatched(this, amount));
+    Context.dispatcher.launch(async () => CounterMetricType._private_addUndispatched(this, amount));
   }
 
   /**
@@ -104,8 +103,8 @@ class CounterMetricType extends MetricType {
    */
   async testGetValue(ping: string = this.sendInPings[0]): Promise<number | undefined> {
     let metric: number | undefined;
-    await Dispatcher.instance.testLaunch(async () => {
-      metric = await Context.instance.metricsDatabase.getMetric<number>(ping, this);
+    await Context.dispatcher.testLaunch(async () => {
+      metric = await Context.metricsDatabase.getMetric<number>(ping, this);
     });
     return metric;
   }

--- a/glean/src/core/metrics/types/counter.ts
+++ b/glean/src/core/metrics/types/counter.ts
@@ -8,6 +8,7 @@ import type { JSONValue } from "../../utils.js";
 import { isUndefined } from "../../utils.js";
 import Glean from "../../glean.js";
 import { CounterMetric } from "./counter_metric.js";
+import Dispatcher from "../../dispatcher.js";
 
 /**
  * A counter metric.
@@ -84,7 +85,7 @@ class CounterMetricType extends MetricType {
    *               If not provided will default to `1`.
    */
   add(amount?: number): void {
-    Glean.dispatcher.launch(async () => CounterMetricType._private_addUndispatched(this, amount));
+    Dispatcher.instance.launch(async () => CounterMetricType._private_addUndispatched(this, amount));
   }
 
   /**
@@ -103,7 +104,7 @@ class CounterMetricType extends MetricType {
    */
   async testGetValue(ping: string = this.sendInPings[0]): Promise<number | undefined> {
     let metric: number | undefined;
-    await Glean.dispatcher.testLaunch(async () => {
+    await Dispatcher.instance.testLaunch(async () => {
       metric = await Glean.metricsDatabase.getMetric<number>(ping, this);
     });
     return metric;

--- a/glean/src/core/metrics/types/datetime.ts
+++ b/glean/src/core/metrics/types/datetime.ts
@@ -8,6 +8,7 @@ import TimeUnit from "../../metrics/time_unit.js";
 import Glean from "../../glean.js";
 import type { DatetimeInternalRepresentation} from "./datetime_metric.js";
 import { DatetimeMetric } from "./datetime_metric.js";
+import Dispatcher from "../../dispatcher.js";
 
 /**
  * A datetime metric.
@@ -77,7 +78,7 @@ class DatetimeMetricType extends MetricType {
    * @param value The Date value to set. If not provided, will record the current time.
    */
   set(value?: Date): void {
-    Glean.dispatcher.launch(() => DatetimeMetricType._private_setUndispatched(this, value));
+    Dispatcher.instance.launch(() => DatetimeMetricType._private_setUndispatched(this, value));
   }
 
   /**
@@ -95,7 +96,7 @@ class DatetimeMetricType extends MetricType {
    */
   private async testGetValueAsDatetimeMetric(ping: string): Promise<DatetimeMetric | undefined> {
     let value: DatetimeInternalRepresentation | undefined;
-    await Glean.dispatcher.testLaunch(async () => {
+    await Dispatcher.instance.testLaunch(async () => {
       value = await Glean.metricsDatabase.getMetric<DatetimeInternalRepresentation>(ping, this);
     });
     if (value) {

--- a/glean/src/core/metrics/types/datetime.ts
+++ b/glean/src/core/metrics/types/datetime.ts
@@ -5,10 +5,10 @@
 import type { CommonMetricData } from "../index.js";
 import { MetricType } from "../index.js";
 import TimeUnit from "../../metrics/time_unit.js";
-import Glean from "../../glean.js";
 import type { DatetimeInternalRepresentation} from "./datetime_metric.js";
 import { DatetimeMetric } from "./datetime_metric.js";
 import Dispatcher from "../../dispatcher.js";
+import { Context } from "../../context.js";
 
 /**
  * A datetime metric.
@@ -37,7 +37,7 @@ class DatetimeMetricType extends MetricType {
    * @param value The date we want to set to.
    */
   static async _private_setUndispatched(instance: DatetimeMetricType, value?: Date): Promise<void> {
-    if (!instance.shouldRecord(Glean.isUploadEnabled())) {
+    if (!instance.shouldRecord(Context.instance.uploadEnabled)) {
       return;
     }
 
@@ -69,7 +69,7 @@ class DatetimeMetricType extends MetricType {
     }
 
     const metric = DatetimeMetric.fromDate(value, instance.timeUnit);
-    await Glean.metricsDatabase.record(instance, metric);
+    await Context.instance.metricsDatabase.record(instance, metric);
   }
 
   /**
@@ -97,7 +97,7 @@ class DatetimeMetricType extends MetricType {
   private async testGetValueAsDatetimeMetric(ping: string): Promise<DatetimeMetric | undefined> {
     let value: DatetimeInternalRepresentation | undefined;
     await Dispatcher.instance.testLaunch(async () => {
-      value = await Glean.metricsDatabase.getMetric<DatetimeInternalRepresentation>(ping, this);
+      value = await Context.instance.metricsDatabase.getMetric<DatetimeInternalRepresentation>(ping, this);
     });
     if (value) {
       return new DatetimeMetric(value);

--- a/glean/src/core/metrics/types/datetime.ts
+++ b/glean/src/core/metrics/types/datetime.ts
@@ -7,7 +7,6 @@ import { MetricType } from "../index.js";
 import TimeUnit from "../../metrics/time_unit.js";
 import type { DatetimeInternalRepresentation} from "./datetime_metric.js";
 import { DatetimeMetric } from "./datetime_metric.js";
-import Dispatcher from "../../dispatcher.js";
 import { Context } from "../../context.js";
 
 /**
@@ -37,7 +36,7 @@ class DatetimeMetricType extends MetricType {
    * @param value The date we want to set to.
    */
   static async _private_setUndispatched(instance: DatetimeMetricType, value?: Date): Promise<void> {
-    if (!instance.shouldRecord(Context.instance.uploadEnabled)) {
+    if (!instance.shouldRecord(Context.uploadEnabled)) {
       return;
     }
 
@@ -69,7 +68,7 @@ class DatetimeMetricType extends MetricType {
     }
 
     const metric = DatetimeMetric.fromDate(value, instance.timeUnit);
-    await Context.instance.metricsDatabase.record(instance, metric);
+    await Context.metricsDatabase.record(instance, metric);
   }
 
   /**
@@ -78,7 +77,7 @@ class DatetimeMetricType extends MetricType {
    * @param value The Date value to set. If not provided, will record the current time.
    */
   set(value?: Date): void {
-    Dispatcher.instance.launch(() => DatetimeMetricType._private_setUndispatched(this, value));
+    Context.dispatcher.launch(() => DatetimeMetricType._private_setUndispatched(this, value));
   }
 
   /**
@@ -96,8 +95,8 @@ class DatetimeMetricType extends MetricType {
    */
   private async testGetValueAsDatetimeMetric(ping: string): Promise<DatetimeMetric | undefined> {
     let value: DatetimeInternalRepresentation | undefined;
-    await Dispatcher.instance.testLaunch(async () => {
-      value = await Context.instance.metricsDatabase.getMetric<DatetimeInternalRepresentation>(ping, this);
+    await Context.dispatcher.testLaunch(async () => {
+      value = await Context.metricsDatabase.getMetric<DatetimeInternalRepresentation>(ping, this);
     });
     if (value) {
       return new DatetimeMetric(value);

--- a/glean/src/core/metrics/types/event.ts
+++ b/glean/src/core/metrics/types/event.ts
@@ -7,7 +7,6 @@ import { MetricType } from "../index.js";
 import type { ExtraMap} from "../events_database.js";
 import { RecordedEvent } from "../events_database.js";
 import { isUndefined } from "../../utils.js";
-import Dispatcher from "../../dispatcher.js";
 import { Context } from "../../context.js";
 
 const MAX_LENGTH_EXTRA_KEY_VALUE = 100;
@@ -48,8 +47,8 @@ class EventMetricType extends MetricType {
    *        The maximum length for values is 100 bytes.
    */
   record(extra?: ExtraMap): void {
-    Dispatcher.instance.launch(async () => {
-      if (!this.shouldRecord(Context.instance.uploadEnabled)) {
+    Context.dispatcher.launch(async () => {
+      if (!this.shouldRecord(Context.uploadEnabled)) {
         return;
       }
   
@@ -76,7 +75,7 @@ class EventMetricType extends MetricType {
         timestamp,
         truncatedExtra,
       );
-      await Context.instance.eventsDatabase.record(this, event);
+      await Context.eventsDatabase.record(this, event);
     });
   }
 
@@ -96,8 +95,8 @@ class EventMetricType extends MetricType {
    */
   async testGetValue(ping: string = this.sendInPings[0]): Promise<RecordedEvent[] | undefined> {
     let events: RecordedEvent[] | undefined;
-    await Dispatcher.instance.testLaunch(async () => {
-      events = await Context.instance.eventsDatabase.getEvents(ping, this);
+    await Context.dispatcher.testLaunch(async () => {
+      events = await Context.eventsDatabase.getEvents(ping, this);
     });
     return events;
   }

--- a/glean/src/core/metrics/types/event.ts
+++ b/glean/src/core/metrics/types/event.ts
@@ -9,6 +9,7 @@ import type { ExtraMap} from "../events_database.js";
 import { RecordedEvent } from "../events_database.js";
 import { isUndefined } from "../../utils.js";
 import Dispatcher from "../../dispatcher.js";
+import { Context } from "../../context.js";
 
 const MAX_LENGTH_EXTRA_KEY_VALUE = 100;
 
@@ -49,7 +50,7 @@ class EventMetricType extends MetricType {
    */
   record(extra?: ExtraMap): void {
     Dispatcher.instance.launch(async () => {
-      if (!this.shouldRecord(Glean.isUploadEnabled())) {
+      if (!this.shouldRecord(Context.instance.uploadEnabled)) {
         return;
       }
   

--- a/glean/src/core/metrics/types/event.ts
+++ b/glean/src/core/metrics/types/event.ts
@@ -4,7 +4,6 @@
 
 import type { CommonMetricData } from "../index.js";
 import { MetricType } from "../index.js";
-import Glean from "../../glean.js";
 import type { ExtraMap} from "../events_database.js";
 import { RecordedEvent } from "../events_database.js";
 import { isUndefined } from "../../utils.js";
@@ -77,7 +76,7 @@ class EventMetricType extends MetricType {
         timestamp,
         truncatedExtra,
       );
-      await Glean.eventsDatabase.record(this, event);
+      await Context.instance.eventsDatabase.record(this, event);
     });
   }
 
@@ -98,7 +97,7 @@ class EventMetricType extends MetricType {
   async testGetValue(ping: string = this.sendInPings[0]): Promise<RecordedEvent[] | undefined> {
     let events: RecordedEvent[] | undefined;
     await Dispatcher.instance.testLaunch(async () => {
-      events = await Glean.eventsDatabase.getEvents(ping, this);
+      events = await Context.instance.eventsDatabase.getEvents(ping, this);
     });
     return events;
   }

--- a/glean/src/core/metrics/types/event.ts
+++ b/glean/src/core/metrics/types/event.ts
@@ -8,6 +8,7 @@ import Glean from "../../glean.js";
 import type { ExtraMap} from "../events_database.js";
 import { RecordedEvent } from "../events_database.js";
 import { isUndefined } from "../../utils.js";
+import Dispatcher from "../../dispatcher.js";
 
 const MAX_LENGTH_EXTRA_KEY_VALUE = 100;
 
@@ -47,7 +48,7 @@ class EventMetricType extends MetricType {
    *        The maximum length for values is 100 bytes.
    */
   record(extra?: ExtraMap): void {
-    Glean.dispatcher.launch(async () => {
+    Dispatcher.instance.launch(async () => {
       if (!this.shouldRecord(Glean.isUploadEnabled())) {
         return;
       }
@@ -95,7 +96,7 @@ class EventMetricType extends MetricType {
    */
   async testGetValue(ping: string = this.sendInPings[0]): Promise<RecordedEvent[] | undefined> {
     let events: RecordedEvent[] | undefined;
-    await Glean.dispatcher.testLaunch(async () => {
+    await Dispatcher.instance.testLaunch(async () => {
       events = await Glean.eventsDatabase.getEvents(ping, this);
     });
     return events;

--- a/glean/src/core/metrics/types/string.ts
+++ b/glean/src/core/metrics/types/string.ts
@@ -5,7 +5,6 @@
 import type { CommonMetricData } from "../index.js";
 import { MetricType } from "../index.js";
 import { MAX_LENGTH_VALUE, StringMetric } from "./string_metric.js";
-import Dispatcher from "../../dispatcher.js";
 import { Context } from "../../context.js";
 
 /**
@@ -32,7 +31,7 @@ class StringMetricType extends MetricType {
    * @param value The string we want to set to.
    */
   static async _private_setUndispatched(instance: StringMetricType, value: string): Promise<void> {
-    if (!instance.shouldRecord(Context.instance.uploadEnabled)) {
+    if (!instance.shouldRecord(Context.uploadEnabled)) {
       return;
     }
 
@@ -42,7 +41,7 @@ class StringMetricType extends MetricType {
     }
 
     const metric = new StringMetric(value.substr(0, MAX_LENGTH_VALUE));
-    await Context.instance.metricsDatabase.record(instance, metric);
+    await Context.metricsDatabase.record(instance, metric);
   }
 
   /**
@@ -56,7 +55,7 @@ class StringMetricType extends MetricType {
    * @param value the value to set.
    */
   set(value: string): void {
-    Dispatcher.instance.launch(() => StringMetricType._private_setUndispatched(this, value));
+    Context.dispatcher.launch(() => StringMetricType._private_setUndispatched(this, value));
   }
 
   /**
@@ -75,8 +74,8 @@ class StringMetricType extends MetricType {
    */
   async testGetValue(ping: string = this.sendInPings[0]): Promise<string | undefined> {
     let metric: string | undefined;
-    await Dispatcher.instance.testLaunch(async () => {
-      metric = await Context.instance.metricsDatabase.getMetric<string>(ping, this);
+    await Context.dispatcher.testLaunch(async () => {
+      metric = await Context.metricsDatabase.getMetric<string>(ping, this);
     });
     return metric;
   }

--- a/glean/src/core/metrics/types/string.ts
+++ b/glean/src/core/metrics/types/string.ts
@@ -6,6 +6,7 @@ import type { CommonMetricData } from "../index.js";
 import { MetricType } from "../index.js";
 import Glean from "../../glean.js";
 import { MAX_LENGTH_VALUE, StringMetric } from "./string_metric.js";
+import Dispatcher from "../../dispatcher.js";
 
 /**
  * A string metric.
@@ -55,7 +56,7 @@ class StringMetricType extends MetricType {
    * @param value the value to set.
    */
   set(value: string): void {
-    Glean.dispatcher.launch(() => StringMetricType._private_setUndispatched(this, value));
+    Dispatcher.instance.launch(() => StringMetricType._private_setUndispatched(this, value));
   }
 
   /**
@@ -74,7 +75,7 @@ class StringMetricType extends MetricType {
    */
   async testGetValue(ping: string = this.sendInPings[0]): Promise<string | undefined> {
     let metric: string | undefined;
-    await Glean.dispatcher.testLaunch(async () => {
+    await Dispatcher.instance.testLaunch(async () => {
       metric = await Glean.metricsDatabase.getMetric<string>(ping, this);
     });
     return metric;

--- a/glean/src/core/metrics/types/string.ts
+++ b/glean/src/core/metrics/types/string.ts
@@ -4,9 +4,9 @@
 
 import type { CommonMetricData } from "../index.js";
 import { MetricType } from "../index.js";
-import Glean from "../../glean.js";
 import { MAX_LENGTH_VALUE, StringMetric } from "./string_metric.js";
 import Dispatcher from "../../dispatcher.js";
+import { Context } from "../../context.js";
 
 /**
  * A string metric.
@@ -32,7 +32,7 @@ class StringMetricType extends MetricType {
    * @param value The string we want to set to.
    */
   static async _private_setUndispatched(instance: StringMetricType, value: string): Promise<void> {
-    if (!instance.shouldRecord(Glean.isUploadEnabled())) {
+    if (!instance.shouldRecord(Context.instance.uploadEnabled)) {
       return;
     }
 
@@ -42,7 +42,7 @@ class StringMetricType extends MetricType {
     }
 
     const metric = new StringMetric(value.substr(0, MAX_LENGTH_VALUE));
-    await Glean.metricsDatabase.record(instance, metric);
+    await Context.instance.metricsDatabase.record(instance, metric);
   }
 
   /**
@@ -76,7 +76,7 @@ class StringMetricType extends MetricType {
   async testGetValue(ping: string = this.sendInPings[0]): Promise<string | undefined> {
     let metric: string | undefined;
     await Dispatcher.instance.testLaunch(async () => {
-      metric = await Glean.metricsDatabase.getMetric<string>(ping, this);
+      metric = await Context.instance.metricsDatabase.getMetric<string>(ping, this);
     });
     return metric;
   }

--- a/glean/src/core/metrics/types/uuid.ts
+++ b/glean/src/core/metrics/types/uuid.ts
@@ -6,7 +6,6 @@ import type { CommonMetricData } from "../index.js";
 import { MetricType } from "../index.js";
 import { generateUUIDv4 } from "../../utils.js";
 import { UUIDMetric } from "./uuid_metric.js";
-import Dispatcher from "../../dispatcher.js";
 import { Context } from "../../context.js";
 
 /**
@@ -32,7 +31,7 @@ class UUIDMetricType extends MetricType {
    * @param value The UUID we want to set to.
    */
   static async _private_setUndispatched(instance: UUIDMetricType, value: string): Promise<void> {
-    if (!instance.shouldRecord(Context.instance.uploadEnabled)) {
+    if (!instance.shouldRecord(Context.uploadEnabled)) {
       return;
     }
 
@@ -49,7 +48,7 @@ class UUIDMetricType extends MetricType {
       return;
     }
 
-    await Context.instance.metricsDatabase.record(instance, metric);
+    await Context.metricsDatabase.record(instance, metric);
   }
 
   /**
@@ -60,7 +59,7 @@ class UUIDMetricType extends MetricType {
    * @throws In case `value` is not a valid UUID.
    */
   set(value: string): void {
-    Dispatcher.instance.launch(() => UUIDMetricType._private_setUndispatched(this, value));
+    Context.dispatcher.launch(() => UUIDMetricType._private_setUndispatched(this, value));
   }
 
   /**
@@ -69,7 +68,7 @@ class UUIDMetricType extends MetricType {
    * @returns The generated value or `undefined` in case this metric shouldn't be recorded.
    */
   generateAndSet(): string | undefined {
-    if (!this.shouldRecord(Context.instance.uploadEnabled)) {
+    if (!this.shouldRecord(Context.uploadEnabled)) {
       return;
     }
 
@@ -95,8 +94,8 @@ class UUIDMetricType extends MetricType {
    */
   async testGetValue(ping: string = this.sendInPings[0]): Promise<string | undefined> {
     let metric: string | undefined;
-    await Dispatcher.instance.testLaunch(async () => {
-      metric = await Context.instance.metricsDatabase.getMetric<string>(ping, this);
+    await Context.dispatcher.testLaunch(async () => {
+      metric = await Context.metricsDatabase.getMetric<string>(ping, this);
     });
     return metric;
   }

--- a/glean/src/core/metrics/types/uuid.ts
+++ b/glean/src/core/metrics/types/uuid.ts
@@ -7,7 +7,7 @@ import { MetricType } from "../index.js";
 import { generateUUIDv4 } from "../../utils.js";
 import { UUIDMetric } from "./uuid_metric.js";
 import Dispatcher from "../../dispatcher.js";
-import Glean from "../../glean.js";
+import { Context } from "../../context.js";
 
 /**
  *  An UUID metric.
@@ -32,7 +32,7 @@ class UUIDMetricType extends MetricType {
    * @param value The UUID we want to set to.
    */
   static async _private_setUndispatched(instance: UUIDMetricType, value: string): Promise<void> {
-    if (!instance.shouldRecord(Glean.isUploadEnabled())) {
+    if (!instance.shouldRecord(Context.instance.uploadEnabled)) {
       return;
     }
 
@@ -49,7 +49,7 @@ class UUIDMetricType extends MetricType {
       return;
     }
 
-    await Glean.metricsDatabase.record(instance, metric);
+    await Context.instance.metricsDatabase.record(instance, metric);
   }
 
   /**
@@ -69,7 +69,7 @@ class UUIDMetricType extends MetricType {
    * @returns The generated value or `undefined` in case this metric shouldn't be recorded.
    */
   generateAndSet(): string | undefined {
-    if (!this.shouldRecord(Glean.isUploadEnabled())) {
+    if (!this.shouldRecord(Context.instance.uploadEnabled)) {
       return;
     }
 
@@ -96,7 +96,7 @@ class UUIDMetricType extends MetricType {
   async testGetValue(ping: string = this.sendInPings[0]): Promise<string | undefined> {
     let metric: string | undefined;
     await Dispatcher.instance.testLaunch(async () => {
-      metric = await Glean.metricsDatabase.getMetric<string>(ping, this);
+      metric = await Context.instance.metricsDatabase.getMetric<string>(ping, this);
     });
     return metric;
   }

--- a/glean/src/core/metrics/types/uuid.ts
+++ b/glean/src/core/metrics/types/uuid.ts
@@ -5,8 +5,9 @@
 import type { CommonMetricData } from "../index.js";
 import { MetricType } from "../index.js";
 import { generateUUIDv4 } from "../../utils.js";
-import Glean from "../../glean.js";
 import { UUIDMetric } from "./uuid_metric.js";
+import Dispatcher from "../../dispatcher.js";
+import Glean from "../../glean.js";
 
 /**
  *  An UUID metric.
@@ -59,7 +60,7 @@ class UUIDMetricType extends MetricType {
    * @throws In case `value` is not a valid UUID.
    */
   set(value: string): void {
-    Glean.dispatcher.launch(() => UUIDMetricType._private_setUndispatched(this, value));
+    Dispatcher.instance.launch(() => UUIDMetricType._private_setUndispatched(this, value));
   }
 
   /**
@@ -94,7 +95,7 @@ class UUIDMetricType extends MetricType {
    */
   async testGetValue(ping: string = this.sendInPings[0]): Promise<string | undefined> {
     let metric: string | undefined;
-    await Glean.dispatcher.testLaunch(async () => {
+    await Dispatcher.instance.testLaunch(async () => {
       metric = await Glean.metricsDatabase.getMetric<string>(ping, this);
     });
     return metric;

--- a/glean/src/core/pings/index.ts
+++ b/glean/src/core/pings/index.ts
@@ -7,6 +7,7 @@ import { generateUUIDv4 } from "../utils.js";
 import collectAndStorePing from "../pings/maker.js";
 import Glean from "../glean.js";
 import type CommonPingData from "./common_ping_data.js";
+import Dispatcher from "../dispatcher.js";
 
 /**
  * Stores information about a ping.
@@ -44,7 +45,7 @@ class PingType implements CommonPingData {
    *               `ping_info.reason` part of the payload.
    */
   submit(reason?: string): void {
-    Glean.dispatcher.launch(async () => {
+    Dispatcher.instance.launch(async () => {
       if (!Glean.initialized) {
         console.info("Glean must be initialized before submitting pings.");
         return;

--- a/glean/src/core/pings/index.ts
+++ b/glean/src/core/pings/index.ts
@@ -8,6 +8,7 @@ import collectAndStorePing from "../pings/maker.js";
 import Glean from "../glean.js";
 import type CommonPingData from "./common_ping_data.js";
 import Dispatcher from "../dispatcher.js";
+import { Context } from "../context.js";
 
 /**
  * Stores information about a ping.
@@ -51,7 +52,7 @@ class PingType implements CommonPingData {
         return;
       }
 
-      if (!Glean.isUploadEnabled() && !this.isDeletionRequest()) {
+      if (!Context.instance.uploadEnabled && !this.isDeletionRequest()) {
         console.info("Glean disabled: not submitting pings. Glean may still submit the deletion-request ping.");
         return;
       }
@@ -64,7 +65,7 @@ class PingType implements CommonPingData {
   
       const identifier = generateUUIDv4();
       await collectAndStorePing(
-        Glean.metricsDatabase,
+        Context.instance.metricsDatabase,
         Glean.eventsDatabase,
         Glean.pingsDatabase,
         Glean.applicationId,

--- a/glean/src/core/pings/index.ts
+++ b/glean/src/core/pings/index.ts
@@ -5,7 +5,6 @@
 import { DELETION_REQUEST_PING_NAME } from "../constants.js";
 import { generateUUIDv4 } from "../utils.js";
 import collectAndStorePing from "../pings/maker.js";
-import Glean from "../glean.js";
 import type CommonPingData from "./common_ping_data.js";
 import Dispatcher from "../dispatcher.js";
 import { Context } from "../context.js";
@@ -47,7 +46,7 @@ class PingType implements CommonPingData {
    */
   submit(reason?: string): void {
     Dispatcher.instance.launch(async () => {
-      if (!Glean.initialized) {
+      if (!Context.instance.initialized) {
         console.info("Glean must be initialized before submitting pings.");
         return;
       }
@@ -68,11 +67,11 @@ class PingType implements CommonPingData {
         Context.instance.metricsDatabase,
         Context.instance.eventsDatabase,
         Context.instance.pingsDatabase,
-        Glean.applicationId,
+        Context.instance.applicationId,
         identifier,
         this,
         correctedReason,
-        Glean.debugOptions
+        Context.instance.debugOptions
       );
       return;
     });

--- a/glean/src/core/pings/index.ts
+++ b/glean/src/core/pings/index.ts
@@ -6,7 +6,6 @@ import { DELETION_REQUEST_PING_NAME } from "../constants.js";
 import { generateUUIDv4 } from "../utils.js";
 import collectAndStorePing from "../pings/maker.js";
 import type CommonPingData from "./common_ping_data.js";
-import Dispatcher from "../dispatcher.js";
 import { Context } from "../context.js";
 
 /**
@@ -45,13 +44,13 @@ class PingType implements CommonPingData {
    *               `ping_info.reason` part of the payload.
    */
   submit(reason?: string): void {
-    Dispatcher.instance.launch(async () => {
-      if (!Context.instance.initialized) {
+    Context.dispatcher.launch(async () => {
+      if (!Context.initialized) {
         console.info("Glean must be initialized before submitting pings.");
         return;
       }
 
-      if (!Context.instance.uploadEnabled && !this.isDeletionRequest()) {
+      if (!Context.uploadEnabled && !this.isDeletionRequest()) {
         console.info("Glean disabled: not submitting pings. Glean may still submit the deletion-request ping.");
         return;
       }
@@ -63,16 +62,7 @@ class PingType implements CommonPingData {
       }
   
       const identifier = generateUUIDv4();
-      await collectAndStorePing(
-        Context.instance.metricsDatabase,
-        Context.instance.eventsDatabase,
-        Context.instance.pingsDatabase,
-        Context.instance.applicationId,
-        identifier,
-        this,
-        correctedReason,
-        Context.instance.debugOptions
-      );
+      await collectAndStorePing(identifier, this, correctedReason);
       return;
     });
   }

--- a/glean/src/core/pings/index.ts
+++ b/glean/src/core/pings/index.ts
@@ -66,8 +66,8 @@ class PingType implements CommonPingData {
       const identifier = generateUUIDv4();
       await collectAndStorePing(
         Context.instance.metricsDatabase,
-        Glean.eventsDatabase,
-        Glean.pingsDatabase,
+        Context.instance.eventsDatabase,
+        Context.instance.pingsDatabase,
         Glean.applicationId,
         identifier,
         this,

--- a/glean/tests/core/glean.spec.ts
+++ b/glean/tests/core/glean.spec.ts
@@ -17,6 +17,7 @@ import TestPlatform from "../../src/platform/qt";
 import Plugin from "../../src/plugins";
 import { Lifetime } from "../../src/core/metrics/lifetime";
 import Dispatcher from "../../src/core/dispatcher";
+import { Context } from "../../src/core/context";
 
 class MockPlugin extends Plugin<typeof CoreEvents["afterPingCollection"]> {
   constructor() {
@@ -42,7 +43,7 @@ describe("Glean", function() {
   });
 
   it("client_id and first_run_date are regenerated if cleared", async function() {
-    await Glean["metricsDatabase"].clearAll();
+    await Context.instance.metricsDatabase.clearAll();
     assert.strictEqual(
       await Glean["coreMetrics"]["clientId"].testGetValue(CLIENT_INFO_STORAGE), undefined);
     assert.strictEqual(
@@ -231,7 +232,7 @@ describe("Glean", function() {
 
     // This time it should not be called, which means upload should not be switched to `false`.
     await Glean.testInitialize(testAppId, false);
-    assert.ok(Glean.isUploadEnabled());
+    assert.ok(Context.instance.uploadEnabled);
   });
 
   it("flipping upload enabled respects order of events", async function() {

--- a/glean/tests/core/glean.spec.ts
+++ b/glean/tests/core/glean.spec.ts
@@ -16,6 +16,7 @@ import { isObject } from "../../src/core/utils";
 import TestPlatform from "../../src/platform/qt";
 import Plugin from "../../src/plugins";
 import { Lifetime } from "../../src/core/metrics/lifetime";
+import Dispatcher from "../../src/core/dispatcher";
 
 class MockPlugin extends Plugin<typeof CoreEvents["afterPingCollection"]> {
   constructor() {
@@ -147,7 +148,7 @@ describe("Glean", function() {
     const spy = sandbox.spy(Glean["coreMetrics"], "initialize");
     Glean.setUploadEnabled(true);
     // Wait for `setUploadEnabled` to be executed.
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     assert.strictEqual(spy.callCount, 0);
   });
 
@@ -156,7 +157,7 @@ describe("Glean", function() {
     Glean.setUploadEnabled(false);
     Glean.setUploadEnabled(false);
     // Wait for `setUploadEnabled` to be executed both times.
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     assert.strictEqual(spy.callCount, 1);
   });
 
@@ -226,7 +227,7 @@ describe("Glean", function() {
     await Glean.testUninitialize();
     await Glean.testInitialize(testAppId, true);
     // initialize is dispatched, we must await on the queue being completed to assert things.
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
 
     // This time it should not be called, which means upload should not be switched to `false`.
     await Glean.testInitialize(testAppId, false);
@@ -249,7 +250,7 @@ describe("Glean", function() {
     Glean.setUploadEnabled(false);
     ping.submit();
 
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     // TODO: Make this nicer once we resolve Bug 1691033 is resolved.
     await Glean["pingUploader"]["currentJob"];
 
@@ -263,14 +264,14 @@ describe("Glean", function() {
     const postSpy = sandbox.spy(Glean.platform.uploader, "post");
 
     Glean.setUploadEnabled(false);
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
 
     assert.strictEqual(postSpy.callCount, 1);
     assert.ok(postSpy.getCall(0).args[0].indexOf(DELETION_REQUEST_PING_NAME) !== -1);
 
     postSpy.resetHistory();
     Glean.setUploadEnabled(true);
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     assert.strictEqual(postSpy.callCount, 0);
   });
 
@@ -278,7 +279,7 @@ describe("Glean", function() {
     const postSpy = sandbox.spy(TestPlatform.uploader, "post");
 
     Glean.setUploadEnabled(true);
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
 
     // Can't use testResetGlean here because it clears all stores
     // and when there is no client_id at all stored, a deletion ping is also not sent.
@@ -297,7 +298,7 @@ describe("Glean", function() {
     const postSpy = sandbox.spy(Glean.platform.uploader, "post");
 
     Glean.setUploadEnabled(false);
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
 
     // A deletion request is sent
     assert.strictEqual(postSpy.callCount, 1);
@@ -307,7 +308,7 @@ describe("Glean", function() {
     // and when there is no client_id at all stored, a deletion ping is also not set.
     await Glean.testUninitialize();
     await Glean.testInitialize(testAppId, false);
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     // TODO: Make this nicer once we resolve Bug 1691033 is resolved.
     await Glean["pingUploader"]["currentJob"];
 
@@ -326,7 +327,7 @@ describe("Glean", function() {
 
     // Setting on initialize.
     await Glean.testInitialize(testAppId, true, { debug: { logPings: true } });
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     assert.ok(Glean.logPings);
 
     await Glean.testUninitialize();
@@ -334,7 +335,7 @@ describe("Glean", function() {
     // Setting before initialize.
     Glean.setLogPings(true);
     await Glean.testInitialize(testAppId, true);
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     assert.ok(Glean.logPings);
 
     // Setting after initialize.
@@ -349,7 +350,7 @@ describe("Glean", function() {
 
     // Setting on initialize.
     await Glean.testInitialize(testAppId, true, { debug: { debugViewTag: testTag } });
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     assert.strictEqual(Glean.debugViewTag, testTag);
 
     await Glean.testUninitialize();
@@ -357,7 +358,7 @@ describe("Glean", function() {
     // Setting before initialize.
     Glean.setDebugViewTag(testTag);
     await Glean.testInitialize(testAppId, true);
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     assert.strictEqual(Glean.debugViewTag, testTag);
 
     // Setting after initialize.
@@ -367,7 +368,7 @@ describe("Glean", function() {
   });
 
   it("attempting to set an invalid debug view tag is ignored and no task is dispatched", function () {
-    const dispatchSpy = sandbox.spy(Glean.dispatcher, "launch");
+    const dispatchSpy = sandbox.spy(Dispatcher.instance, "launch");
 
     const invaligTag = "inv@l!d_t*g";
     Glean.setDebugViewTag(invaligTag);
@@ -383,19 +384,19 @@ describe("Glean", function() {
     Glean.setDebugViewTag("test");
     Glean.unsetDebugViewTag();
 
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     assert.strictEqual(Glean.debugViewTag, undefined);
   });
 
   it("setting source tags on initialize works", async function () {
     await Glean.testUninitialize();
     await Glean.testInitialize(testAppId, true, { debug: { sourceTags: ["1", "2", "3", "4", "5"] } });
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     assert.strictEqual(Glean.sourceTags, "1,2,3,4,5");
   });
 
   it("attempting to set invalid source tags is ignored and no task is dispatched", function () {
-    const dispatchSpy = sandbox.spy(Glean.dispatcher, "launch");
+    const dispatchSpy = sandbox.spy(Dispatcher.instance, "launch");
 
     const invaligTags = ["inv@l!d_t*g"];
     Glean.setSourceTags(invaligTags);
@@ -411,7 +412,7 @@ describe("Glean", function() {
     Glean.setSourceTags(["test"]);
     Glean.unsetSourceTags();
 
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     assert.strictEqual(Glean.sourceTags, undefined);
   });
 
@@ -440,7 +441,7 @@ describe("Glean", function() {
     const testDisplayVersion = "1.2.3-stella";
 
     await Glean.testInitialize(testAppId, true, { appBuild: testBuild, appDisplayVersion: testDisplayVersion });
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
 
     assert.strictEqual(await Glean.coreMetrics.appBuild.testGetValue(), testBuild);
     assert.strictEqual(await Glean.coreMetrics.appDisplayVersion.testGetValue(), testDisplayVersion);
@@ -495,7 +496,7 @@ describe("Glean", function() {
       }),
     );
 
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     const storedPings = await Glean.pingsDatabase.getAllPings();
     const counterValues = [];
     for (const ident in storedPings) {

--- a/glean/tests/core/glean.spec.ts
+++ b/glean/tests/core/glean.spec.ts
@@ -498,7 +498,7 @@ describe("Glean", function() {
     );
 
     await Dispatcher.instance.testBlockOnQueue();
-    const storedPings = await Glean.pingsDatabase.getAllPings();
+    const storedPings = await Context.instance.pingsDatabase.getAllPings();
     const counterValues = [];
     for (const ident in storedPings) {
       const metrics = storedPings[ident].payload.metrics;

--- a/glean/tests/core/glean.spec.ts
+++ b/glean/tests/core/glean.spec.ts
@@ -16,7 +16,6 @@ import { isObject } from "../../src/core/utils";
 import TestPlatform from "../../src/platform/qt";
 import Plugin from "../../src/plugins";
 import { Lifetime } from "../../src/core/metrics/lifetime";
-import Dispatcher from "../../src/core/dispatcher";
 import { Context } from "../../src/core/context";
 
 class MockPlugin extends Plugin<typeof CoreEvents["afterPingCollection"]> {
@@ -43,7 +42,7 @@ describe("Glean", function() {
   });
 
   it("client_id and first_run_date are regenerated if cleared", async function() {
-    await Context.instance.metricsDatabase.clearAll();
+    await Context.metricsDatabase.clearAll();
     assert.strictEqual(
       await Glean["coreMetrics"]["clientId"].testGetValue(CLIENT_INFO_STORAGE), undefined);
     assert.strictEqual(
@@ -149,7 +148,7 @@ describe("Glean", function() {
     const spy = sandbox.spy(Glean["coreMetrics"], "initialize");
     Glean.setUploadEnabled(true);
     // Wait for `setUploadEnabled` to be executed.
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     assert.strictEqual(spy.callCount, 0);
   });
 
@@ -158,7 +157,7 @@ describe("Glean", function() {
     Glean.setUploadEnabled(false);
     Glean.setUploadEnabled(false);
     // Wait for `setUploadEnabled` to be executed both times.
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     assert.strictEqual(spy.callCount, 1);
   });
 
@@ -228,11 +227,11 @@ describe("Glean", function() {
     await Glean.testUninitialize();
     await Glean.testInitialize(testAppId, true);
     // initialize is dispatched, we must await on the queue being completed to assert things.
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
 
     // This time it should not be called, which means upload should not be switched to `false`.
     await Glean.testInitialize(testAppId, false);
-    assert.ok(Context.instance.uploadEnabled);
+    assert.ok(Context.uploadEnabled);
   });
 
   it("flipping upload enabled respects order of events", async function() {
@@ -251,7 +250,7 @@ describe("Glean", function() {
     Glean.setUploadEnabled(false);
     ping.submit();
 
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     // TODO: Make this nicer once we resolve Bug 1691033 is resolved.
     await Glean["pingUploader"]["currentJob"];
 
@@ -265,14 +264,14 @@ describe("Glean", function() {
     const postSpy = sandbox.spy(Glean.platform.uploader, "post");
 
     Glean.setUploadEnabled(false);
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
 
     assert.strictEqual(postSpy.callCount, 1);
     assert.ok(postSpy.getCall(0).args[0].indexOf(DELETION_REQUEST_PING_NAME) !== -1);
 
     postSpy.resetHistory();
     Glean.setUploadEnabled(true);
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     assert.strictEqual(postSpy.callCount, 0);
   });
 
@@ -280,7 +279,7 @@ describe("Glean", function() {
     const postSpy = sandbox.spy(TestPlatform.uploader, "post");
 
     Glean.setUploadEnabled(true);
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
 
     // Can't use testResetGlean here because it clears all stores
     // and when there is no client_id at all stored, a deletion ping is also not sent.
@@ -299,7 +298,7 @@ describe("Glean", function() {
     const postSpy = sandbox.spy(Glean.platform.uploader, "post");
 
     Glean.setUploadEnabled(false);
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
 
     // A deletion request is sent
     assert.strictEqual(postSpy.callCount, 1);
@@ -309,7 +308,7 @@ describe("Glean", function() {
     // and when there is no client_id at all stored, a deletion ping is also not set.
     await Glean.testUninitialize();
     await Glean.testInitialize(testAppId, false);
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     // TODO: Make this nicer once we resolve Bug 1691033 is resolved.
     await Glean["pingUploader"]["currentJob"];
 
@@ -328,7 +327,7 @@ describe("Glean", function() {
 
     // Setting on initialize.
     await Glean.testInitialize(testAppId, true, { debug: { logPings: true } });
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     assert.ok(Glean.logPings);
 
     await Glean.testUninitialize();
@@ -336,7 +335,7 @@ describe("Glean", function() {
     // Setting before initialize.
     Glean.setLogPings(true);
     await Glean.testInitialize(testAppId, true);
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     assert.ok(Glean.logPings);
 
     // Setting after initialize.
@@ -351,7 +350,7 @@ describe("Glean", function() {
 
     // Setting on initialize.
     await Glean.testInitialize(testAppId, true, { debug: { debugViewTag: testTag } });
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     assert.strictEqual(Glean.debugViewTag, testTag);
 
     await Glean.testUninitialize();
@@ -359,7 +358,7 @@ describe("Glean", function() {
     // Setting before initialize.
     Glean.setDebugViewTag(testTag);
     await Glean.testInitialize(testAppId, true);
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     assert.strictEqual(Glean.debugViewTag, testTag);
 
     // Setting after initialize.
@@ -369,7 +368,7 @@ describe("Glean", function() {
   });
 
   it("attempting to set an invalid debug view tag is ignored and no task is dispatched", function () {
-    const dispatchSpy = sandbox.spy(Dispatcher.instance, "launch");
+    const dispatchSpy = sandbox.spy(Context.dispatcher, "launch");
 
     const invaligTag = "inv@l!d_t*g";
     Glean.setDebugViewTag(invaligTag);
@@ -385,19 +384,19 @@ describe("Glean", function() {
     Glean.setDebugViewTag("test");
     Glean.unsetDebugViewTag();
 
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     assert.strictEqual(Glean.debugViewTag, undefined);
   });
 
   it("setting source tags on initialize works", async function () {
     await Glean.testUninitialize();
     await Glean.testInitialize(testAppId, true, { debug: { sourceTags: ["1", "2", "3", "4", "5"] } });
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     assert.strictEqual(Glean.sourceTags, "1,2,3,4,5");
   });
 
   it("attempting to set invalid source tags is ignored and no task is dispatched", function () {
-    const dispatchSpy = sandbox.spy(Dispatcher.instance, "launch");
+    const dispatchSpy = sandbox.spy(Context.dispatcher, "launch");
 
     const invaligTags = ["inv@l!d_t*g"];
     Glean.setSourceTags(invaligTags);
@@ -413,7 +412,7 @@ describe("Glean", function() {
     Glean.setSourceTags(["test"]);
     Glean.unsetSourceTags();
 
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     assert.strictEqual(Glean.sourceTags, undefined);
   });
 
@@ -442,7 +441,7 @@ describe("Glean", function() {
     const testDisplayVersion = "1.2.3-stella";
 
     await Glean.testInitialize(testAppId, true, { appBuild: testBuild, appDisplayVersion: testDisplayVersion });
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
 
     assert.strictEqual(await Glean.coreMetrics.appBuild.testGetValue(), testBuild);
     assert.strictEqual(await Glean.coreMetrics.appDisplayVersion.testGetValue(), testDisplayVersion);
@@ -497,8 +496,8 @@ describe("Glean", function() {
       }),
     );
 
-    await Dispatcher.instance.testBlockOnQueue();
-    const storedPings = await Context.instance.pingsDatabase.getAllPings();
+    await Context.dispatcher.testBlockOnQueue();
+    const storedPings = await Context.pingsDatabase.getAllPings();
     const counterValues = [];
     for (const ident in storedPings) {
       const metrics = storedPings[ident].payload.metrics;

--- a/glean/tests/core/metrics/boolean.spec.ts
+++ b/glean/tests/core/metrics/boolean.spec.ts
@@ -55,7 +55,7 @@ describe("BooleanMetric", function() {
     metric.set(true);
     assert.strictEqual(await metric.testGetValue("aPing"), true);
 
-    const snapshot = await Context.instance.metricsDatabase.getPingMetrics("aPing", true);
+    const snapshot = await Context.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "boolean": {
         "aCategory.aBooleanMetric": true

--- a/glean/tests/core/metrics/boolean.spec.ts
+++ b/glean/tests/core/metrics/boolean.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import assert from "assert";
+import { Context } from "../../../src/core/context";
 
 import Glean from "../../../src/core/glean";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
@@ -54,7 +55,7 @@ describe("BooleanMetric", function() {
     metric.set(true);
     assert.strictEqual(await metric.testGetValue("aPing"), true);
 
-    const snapshot = await Glean.metricsDatabase.getPingMetrics("aPing", true);
+    const snapshot = await Context.instance.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "boolean": {
         "aCategory.aBooleanMetric": true

--- a/glean/tests/core/metrics/counter.spec.ts
+++ b/glean/tests/core/metrics/counter.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import assert from "assert";
+import { Context } from "../../../src/core/context";
 
 import Glean from "../../../src/core/glean";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
@@ -54,7 +55,7 @@ describe("CounterMetric", function() {
     metric.add(10);
     assert.strictEqual(await metric.testGetValue("aPing"), 10);
   
-    const snapshot = await Glean.metricsDatabase.getPingMetrics("aPing", true);
+    const snapshot = await Context.instance.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "counter": {
         "aCategory.aCounterMetric": 10

--- a/glean/tests/core/metrics/counter.spec.ts
+++ b/glean/tests/core/metrics/counter.spec.ts
@@ -55,7 +55,7 @@ describe("CounterMetric", function() {
     metric.add(10);
     assert.strictEqual(await metric.testGetValue("aPing"), 10);
   
-    const snapshot = await Context.instance.metricsDatabase.getPingMetrics("aPing", true);
+    const snapshot = await Context.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "counter": {
         "aCategory.aCounterMetric": 10

--- a/glean/tests/core/metrics/database.spec.ts
+++ b/glean/tests/core/metrics/database.spec.ts
@@ -494,8 +494,8 @@ describe("MetricsDatabase", function() {
         lifetime: Lifetime.Ping,
         disabled: false
       });
-      await Context.instance.metricsDatabase.record(metric, new StringMetric("value"));
-      await Context.instance.metricsDatabase.clear(Lifetime.Ping, "aPing");
+      await Context.metricsDatabase.record(metric, new StringMetric("value"));
+      await Context.metricsDatabase.clear(Lifetime.Ping, "aPing");
 
       assert.strictEqual(await metric.testGetValue("aPing"), undefined);
       assert.strictEqual(await metric.testGetValue("twoPing"), "value");

--- a/glean/tests/core/metrics/database.spec.ts
+++ b/glean/tests/core/metrics/database.spec.ts
@@ -10,6 +10,7 @@ import { StringMetric } from "../../../src/core/metrics/types/string_metric";
 import type { JSONValue } from "../../../src/core/utils";
 import Glean from "../../../src/core/glean";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
+import { Context } from "../../../src/core/context";
 
 describe("MetricsDatabase", function() {
   const testAppId = `gleanjs.test.${this.title}`;
@@ -493,8 +494,8 @@ describe("MetricsDatabase", function() {
         lifetime: Lifetime.Ping,
         disabled: false
       });
-      await Glean.metricsDatabase.record(metric, new StringMetric("value"));
-      await Glean.metricsDatabase.clear(Lifetime.Ping, "aPing");
+      await Context.instance.metricsDatabase.record(metric, new StringMetric("value"));
+      await Context.instance.metricsDatabase.clear(Lifetime.Ping, "aPing");
 
       assert.strictEqual(await metric.testGetValue("aPing"), undefined);
       assert.strictEqual(await metric.testGetValue("twoPing"), "value");

--- a/glean/tests/core/metrics/datetime.spec.ts
+++ b/glean/tests/core/metrics/datetime.spec.ts
@@ -97,7 +97,7 @@ describe("DatetimeMetric", function() {
     metric.set(new Date(1995, 4, 25, 8, 15, 45, 385));
     assert.strictEqual(await metric.testGetValueAsString("aPing"), "1995-05-25T08:15+05:00");
 
-    const snapshot = await Context.instance.metricsDatabase.getPingMetrics("aPing", true);
+    const snapshot = await Context.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "datetime": {
         "aCategory.aDatetimeMetric": "1995-05-25T08:15+05:00"
@@ -207,7 +207,7 @@ describe("DatetimeMetric", function() {
       timezone: 60,
       date: "2021-01-07T14:41:26.312Z"
     });
-    await Context.instance.metricsDatabase.record(metric, concreteMetric);
+    await Context.metricsDatabase.record(metric, concreteMetric);
 
     // 1. The monkeypatched timezone it -300 (+05:00)
     // 2. The timezone manually set on the metric above is 60 (-01:00)

--- a/glean/tests/core/metrics/datetime.spec.ts
+++ b/glean/tests/core/metrics/datetime.spec.ts
@@ -10,6 +10,7 @@ import DatetimeMetricType from "../../../src/core/metrics/types/datetime";
 import { DatetimeMetric } from "../../../src/core/metrics/types/datetime_metric";
 import TimeUnit from "../../../src/core/metrics/time_unit";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
+import { Context } from "../../../src/core/context";
 
 const sandbox = sinon.createSandbox();
 
@@ -96,7 +97,7 @@ describe("DatetimeMetric", function() {
     metric.set(new Date(1995, 4, 25, 8, 15, 45, 385));
     assert.strictEqual(await metric.testGetValueAsString("aPing"), "1995-05-25T08:15+05:00");
 
-    const snapshot = await Glean.metricsDatabase.getPingMetrics("aPing", true);
+    const snapshot = await Context.instance.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "datetime": {
         "aCategory.aDatetimeMetric": "1995-05-25T08:15+05:00"
@@ -206,7 +207,7 @@ describe("DatetimeMetric", function() {
       timezone: 60,
       date: "2021-01-07T14:41:26.312Z"
     });
-    await Glean.metricsDatabase.record(metric, concreteMetric);
+    await Context.instance.metricsDatabase.record(metric, concreteMetric);
 
     // 1. The monkeypatched timezone it -300 (+05:00)
     // 2. The timezone manually set on the metric above is 60 (-01:00)

--- a/glean/tests/core/metrics/labeled.spec.ts
+++ b/glean/tests/core/metrics/labeled.spec.ts
@@ -5,7 +5,6 @@
 import assert from "assert";
 import sinon from "sinon";
 import { Context } from "../../../src/core/context";
-import Dispatcher from "../../../src/core/dispatcher";
 
 import Glean from "../../../src/core/glean";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
@@ -58,9 +57,9 @@ describe("LabeledMetric", function() {
     // TODO: bug 1691033 will allow us to change the code below this point,
     // once a custom uploader for testing will be available.
     ping.submit();
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
     
-    const storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
+    const storedPings = await Context.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 1);
 
     // TODO: bug 1682282 will validate the payload schema.
@@ -111,9 +110,9 @@ describe("LabeledMetric", function() {
     // TODO: bug 1691033 will allow us to change the code below this point,
     // once a custom uploader for testing will be available.
     ping.submit();
-    await Dispatcher.instance.testBlockOnQueue();
+    await Context.dispatcher.testBlockOnQueue();
 
-    const storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
+    const storedPings = await Context.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 1);
 
     // TODO: bug 1682282 will validate the payload schema.

--- a/glean/tests/core/metrics/labeled.spec.ts
+++ b/glean/tests/core/metrics/labeled.spec.ts
@@ -4,6 +4,7 @@
 
 import assert from "assert";
 import sinon from "sinon";
+import Dispatcher from "../../../src/core/dispatcher";
 
 import Glean from "../../../src/core/glean";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
@@ -56,7 +57,7 @@ describe("LabeledMetric", function() {
     // TODO: bug 1691033 will allow us to change the code below this point,
     // once a custom uploader for testing will be available.
     ping.submit();
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     
     const storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 1);
@@ -109,7 +110,7 @@ describe("LabeledMetric", function() {
     // TODO: bug 1691033 will allow us to change the code below this point,
     // once a custom uploader for testing will be available.
     ping.submit();
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
 
     const storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 1);

--- a/glean/tests/core/metrics/labeled.spec.ts
+++ b/glean/tests/core/metrics/labeled.spec.ts
@@ -4,6 +4,7 @@
 
 import assert from "assert";
 import sinon from "sinon";
+import { Context } from "../../../src/core/context";
 import Dispatcher from "../../../src/core/dispatcher";
 
 import Glean from "../../../src/core/glean";
@@ -59,7 +60,7 @@ describe("LabeledMetric", function() {
     ping.submit();
     await Dispatcher.instance.testBlockOnQueue();
     
-    const storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    const storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 1);
 
     // TODO: bug 1682282 will validate the payload schema.
@@ -112,7 +113,7 @@ describe("LabeledMetric", function() {
     ping.submit();
     await Dispatcher.instance.testBlockOnQueue();
 
-    const storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    const storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 1);
 
     // TODO: bug 1682282 will validate the payload schema.

--- a/glean/tests/core/metrics/string.spec.ts
+++ b/glean/tests/core/metrics/string.spec.ts
@@ -8,6 +8,7 @@ import Glean from "../../../src/core/glean";
 import StringMetricType from "../../../src/core/metrics/types/string";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
 import { MAX_LENGTH_VALUE } from "../../../src/core/metrics/types/string_metric";
+import { Context } from "../../../src/core/context";
  
 describe("StringMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
@@ -55,7 +56,7 @@ describe("StringMetric", function() {
     metric.set("test_string_value");
     assert.strictEqual(await metric.testGetValue("aPing"), "test_string_value");
 
-    const snapshot = await Glean.metricsDatabase.getPingMetrics("aPing", true);
+    const snapshot = await Context.instance.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "string": {
         "aCategory.aStringMetric": "test_string_value"

--- a/glean/tests/core/metrics/string.spec.ts
+++ b/glean/tests/core/metrics/string.spec.ts
@@ -56,7 +56,7 @@ describe("StringMetric", function() {
     metric.set("test_string_value");
     assert.strictEqual(await metric.testGetValue("aPing"), "test_string_value");
 
-    const snapshot = await Context.instance.metricsDatabase.getPingMetrics("aPing", true);
+    const snapshot = await Context.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "string": {
         "aCategory.aStringMetric": "test_string_value"

--- a/glean/tests/core/metrics/uuid.spec.ts
+++ b/glean/tests/core/metrics/uuid.spec.ts
@@ -8,6 +8,7 @@ import { v4 as UUIDv4 } from "uuid";
 import Glean from "../../../src/core/glean";
 import UUIDMetricType from "../../../src/core/metrics/types/uuid";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
+import { Context } from "../../../src/core/context";
  
 describe("UUIDMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
@@ -71,7 +72,7 @@ describe("UUIDMetric", function() {
     metric.set(expected);
     assert.strictEqual(await metric.testGetValue("aPing"), expected);
 
-    const snapshot = await Glean.metricsDatabase.getPingMetrics("aPing", true);
+    const snapshot = await Context.instance.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "uuid": {
         "aCategory.aUUIDMetric": expected

--- a/glean/tests/core/metrics/uuid.spec.ts
+++ b/glean/tests/core/metrics/uuid.spec.ts
@@ -72,7 +72,7 @@ describe("UUIDMetric", function() {
     metric.set(expected);
     assert.strictEqual(await metric.testGetValue("aPing"), expected);
 
-    const snapshot = await Context.instance.metricsDatabase.getPingMetrics("aPing", true);
+    const snapshot = await Context.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "uuid": {
         "aCategory.aUUIDMetric": expected

--- a/glean/tests/core/pings/index.spec.ts
+++ b/glean/tests/core/pings/index.spec.ts
@@ -9,6 +9,7 @@ import PingType from "../../../src/core/pings";
 import CounterMetricType from "../../../src/core/metrics/types/counter";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
 import Glean from "../../../src/core/glean";
+import Dispatcher from "../../../src/core/dispatcher";
 
 const sandbox = sinon.createSandbox();
 
@@ -20,7 +21,7 @@ const sandbox = sinon.createSandbox();
 async function submitSync(ping: PingType): Promise<void> {
   ping.submit();
   // TODO: Drop this whole approach once Bug 1691033 is resolved.
-  await Glean.dispatcher.testBlockOnQueue();
+  await Dispatcher.instance.testBlockOnQueue();
 }
 
 describe("PingType", function() {

--- a/glean/tests/core/pings/index.spec.ts
+++ b/glean/tests/core/pings/index.spec.ts
@@ -10,6 +10,7 @@ import CounterMetricType from "../../../src/core/metrics/types/counter";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
 import Glean from "../../../src/core/glean";
 import Dispatcher from "../../../src/core/dispatcher";
+import { Context } from "../../../src/core/context";
 
 const sandbox = sinon.createSandbox();
 
@@ -54,7 +55,7 @@ describe("PingType", function() {
     counter.add();
 
     await submitSync(ping);
-    const storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    const storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 1);
   });
 
@@ -74,11 +75,11 @@ describe("PingType", function() {
     });
 
     await submitSync(ping1);
-    let storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    let storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 0);
 
     await submitSync(ping2);
-    storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 1);
   });
 
@@ -91,7 +92,7 @@ describe("PingType", function() {
       sendIfEmpty: false,
     });
     await submitSync(ping);
-    const storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    const storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 0);
   });
 
@@ -104,7 +105,7 @@ describe("PingType", function() {
       sendIfEmpty: false,
     });
     await submitSync(ping);
-    const storedPings = await Glean.pingsDatabase["store"]._getWholeStore();
+    const storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 0);
   });
 });

--- a/glean/tests/core/pings/index.spec.ts
+++ b/glean/tests/core/pings/index.spec.ts
@@ -9,7 +9,6 @@ import PingType from "../../../src/core/pings";
 import CounterMetricType from "../../../src/core/metrics/types/counter";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
 import Glean from "../../../src/core/glean";
-import Dispatcher from "../../../src/core/dispatcher";
 import { Context } from "../../../src/core/context";
 
 const sandbox = sinon.createSandbox();
@@ -22,7 +21,7 @@ const sandbox = sinon.createSandbox();
 async function submitSync(ping: PingType): Promise<void> {
   ping.submit();
   // TODO: Drop this whole approach once Bug 1691033 is resolved.
-  await Dispatcher.instance.testBlockOnQueue();
+  await Context.dispatcher.testBlockOnQueue();
 }
 
 describe("PingType", function() {
@@ -55,7 +54,7 @@ describe("PingType", function() {
     counter.add();
 
     await submitSync(ping);
-    const storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
+    const storedPings = await Context.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 1);
   });
 
@@ -75,11 +74,11 @@ describe("PingType", function() {
     });
 
     await submitSync(ping1);
-    let storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
+    let storedPings = await Context.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 0);
 
     await submitSync(ping2);
-    storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
+    storedPings = await Context.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 1);
   });
 
@@ -92,7 +91,7 @@ describe("PingType", function() {
       sendIfEmpty: false,
     });
     await submitSync(ping);
-    const storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
+    const storedPings = await Context.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 0);
   });
 
@@ -105,7 +104,7 @@ describe("PingType", function() {
       sendIfEmpty: false,
     });
     await submitSync(ping);
-    const storedPings = await Context.instance.pingsDatabase["store"]._getWholeStore();
+    const storedPings = await Context.pingsDatabase["store"]._getWholeStore();
     assert.strictEqual(Object.keys(storedPings).length, 0);
   });
 });

--- a/glean/tests/core/pings/maker.spec.ts
+++ b/glean/tests/core/pings/maker.spec.ts
@@ -99,7 +99,7 @@ describe("PingMaker", function() {
       includeClientId: true,
       sendIfEmpty: false,
     });
-    assert.strictEqual(await PingMaker.collectPing(Context.instance.metricsDatabase, Glean.eventsDatabase, ping), undefined);
+    assert.strictEqual(await PingMaker.collectPing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, ping), undefined);
   });
 
   it("sequence numbers must be sequential", async function() {
@@ -152,13 +152,13 @@ describe("PingMaker", function() {
       sendIfEmpty: true,
     });
 
-    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
-    const recordedPing = (await Glean.pingsDatabase.getAllPings())["ident"];
+    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
+    const recordedPing = (await Context.instance.pingsDatabase.getAllPings())["ident"];
     assert.deepStrictEqual(recordedPing.payload, { "you": "got mocked!" });
 
     await Glean.testResetGlean(testAppId, true);
-    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
-    const recordedPingNoPlugin = (await Glean.pingsDatabase.getAllPings())["ident"];
+    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
+    const recordedPingNoPlugin = (await Context.instance.pingsDatabase.getAllPings())["ident"];
     assert.notDeepStrictEqual(recordedPingNoPlugin.payload, { "you": "got mocked!" });
   });
 
@@ -180,11 +180,11 @@ describe("PingMaker", function() {
     });
 
     const consoleSpy = sandbox.spy(console, "info");
-    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
+    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
 
     const loggedPayload = JSON.parse(consoleSpy.lastCall.args[0]) as JSONObject;
 
-    const recordedPing = (await Glean.pingsDatabase.getAllPings())["ident"];
+    const recordedPing = (await Context.instance.pingsDatabase.getAllPings())["ident"];
     assert.deepStrictEqual(recordedPing.payload, { "you": "got mocked!" });
     assert.notDeepStrictEqual(loggedPayload, { "you": "got mocked!" });
     assert.ok("client_info" in loggedPayload);
@@ -215,9 +215,9 @@ describe("PingMaker", function() {
       sendIfEmpty: true,
     });
 
-    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
+    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
 
-    const recordedPings = await Glean.pingsDatabase.getAllPings();
+    const recordedPings = await Context.instance.pingsDatabase.getAllPings();
     assert.ok(!("ident" in recordedPings));
   });
 });

--- a/glean/tests/core/pings/maker.spec.ts
+++ b/glean/tests/core/pings/maker.spec.ts
@@ -11,6 +11,7 @@ import Glean from "../../../src/core/glean";
 import CoreEvents from "../../../src/core/events";
 import Plugin from "../../../src/plugins";
 import type { JSONObject } from "../../../src/core/utils";
+import Dispatcher from "../../../src/core/dispatcher";
 
 const sandbox = sinon.createSandbox();
 
@@ -126,7 +127,7 @@ describe("PingMaker", function() {
   it("getPingHeaders returns headers when custom headers are set", async function () {
     Glean.setDebugViewTag("test");
     Glean.setSourceTags(["tag1", "tag2", "tag3"]);
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
 
     assert.deepStrictEqual({
       "X-Debug-ID": "test",
@@ -135,7 +136,7 @@ describe("PingMaker", function() {
 
     Glean.unsetDebugViewTag();
     Glean.unsetSourceTags();
-    await Glean.dispatcher.testBlockOnQueue();
+    await Dispatcher.instance.testBlockOnQueue();
     assert.strictEqual(PingMaker.getPingHeaders(Glean.debugOptions), undefined);
   });
 

--- a/glean/tests/core/pings/maker.spec.ts
+++ b/glean/tests/core/pings/maker.spec.ts
@@ -12,6 +12,7 @@ import CoreEvents from "../../../src/core/events";
 import Plugin from "../../../src/plugins";
 import type { JSONObject } from "../../../src/core/utils";
 import Dispatcher from "../../../src/core/dispatcher";
+import { Context } from "../../../src/core/context";
 
 const sandbox = sinon.createSandbox();
 
@@ -42,7 +43,7 @@ describe("PingMaker", function() {
       includeClientId: true,
       sendIfEmpty: false,
     });
-    const pingInfo = await PingMaker.buildPingInfoSection(Glean.metricsDatabase, ping);
+    const pingInfo = await PingMaker.buildPingInfoSection(Context.instance.metricsDatabase, ping);
 
     const startTime = new Date(pingInfo.start_time);
     const endTime = new Date(pingInfo.end_time);
@@ -56,7 +57,7 @@ describe("PingMaker", function() {
       includeClientId: true,
       sendIfEmpty: false,
     });
-    const pingInfo = await PingMaker.buildPingInfoSection(Glean.metricsDatabase, ping);
+    const pingInfo = await PingMaker.buildPingInfoSection(Context.instance.metricsDatabase, ping);
 
     assert.ok("seq" in pingInfo);
     assert.ok("start_time" in pingInfo);
@@ -70,7 +71,7 @@ describe("PingMaker", function() {
       includeClientId: true,
       sendIfEmpty: false,
     });
-    const clientInfo1 = await PingMaker.buildClientInfoSection(Glean.metricsDatabase, ping);
+    const clientInfo1 = await PingMaker.buildClientInfoSection(Context.instance.metricsDatabase, ping);
     assert.ok("telemetry_sdk_build" in clientInfo1);
 
     // Initialize will also initialize core metrics that are part of the client info.
@@ -80,7 +81,7 @@ describe("PingMaker", function() {
       serverEndpoint: "http://localhost:8080"
     });
 
-    const clientInfo2 = await PingMaker.buildClientInfoSection(Glean.metricsDatabase, ping);
+    const clientInfo2 = await PingMaker.buildClientInfoSection(Context.instance.metricsDatabase, ping);
     assert.ok("telemetry_sdk_build" in clientInfo2);
     assert.ok("client_id" in clientInfo2);
     assert.ok("first_run_date" in clientInfo2);
@@ -98,7 +99,7 @@ describe("PingMaker", function() {
       includeClientId: true,
       sendIfEmpty: false,
     });
-    assert.strictEqual(await PingMaker.collectPing(Glean.metricsDatabase, Glean.eventsDatabase, ping), undefined);
+    assert.strictEqual(await PingMaker.collectPing(Context.instance.metricsDatabase, Glean.eventsDatabase, ping), undefined);
   });
 
   it("sequence numbers must be sequential", async function() {
@@ -114,14 +115,14 @@ describe("PingMaker", function() {
     });
 
     for(let i = 0; i <= 10; i++) {
-      assert.strictEqual(await PingMaker.getSequenceNumber(Glean.metricsDatabase, ping1), i);
-      assert.strictEqual(await PingMaker.getSequenceNumber(Glean.metricsDatabase, ping2), i);
+      assert.strictEqual(await PingMaker.getSequenceNumber(Context.instance.metricsDatabase, ping1), i);
+      assert.strictEqual(await PingMaker.getSequenceNumber(Context.instance.metricsDatabase, ping2), i);
     }
 
-    await PingMaker.getSequenceNumber(Glean.metricsDatabase, ping1);
-    assert.strictEqual(await PingMaker.getSequenceNumber(Glean.metricsDatabase, ping1), 12);
-    assert.strictEqual(await PingMaker.getSequenceNumber(Glean.metricsDatabase, ping2), 11);
-    assert.strictEqual(await PingMaker.getSequenceNumber(Glean.metricsDatabase, ping1), 13);
+    await PingMaker.getSequenceNumber(Context.instance.metricsDatabase, ping1);
+    assert.strictEqual(await PingMaker.getSequenceNumber(Context.instance.metricsDatabase, ping1), 12);
+    assert.strictEqual(await PingMaker.getSequenceNumber(Context.instance.metricsDatabase, ping2), 11);
+    assert.strictEqual(await PingMaker.getSequenceNumber(Context.instance.metricsDatabase, ping1), 13);
   });
 
   it("getPingHeaders returns headers when custom headers are set", async function () {
@@ -151,12 +152,12 @@ describe("PingMaker", function() {
       sendIfEmpty: true,
     });
 
-    await PingMaker.collectAndStorePing(Glean.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
+    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
     const recordedPing = (await Glean.pingsDatabase.getAllPings())["ident"];
     assert.deepStrictEqual(recordedPing.payload, { "you": "got mocked!" });
 
     await Glean.testResetGlean(testAppId, true);
-    await PingMaker.collectAndStorePing(Glean.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
+    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
     const recordedPingNoPlugin = (await Glean.pingsDatabase.getAllPings())["ident"];
     assert.notDeepStrictEqual(recordedPingNoPlugin.payload, { "you": "got mocked!" });
   });
@@ -179,7 +180,7 @@ describe("PingMaker", function() {
     });
 
     const consoleSpy = sandbox.spy(console, "info");
-    await PingMaker.collectAndStorePing(Glean.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
+    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
 
     const loggedPayload = JSON.parse(consoleSpy.lastCall.args[0]) as JSONObject;
 
@@ -214,7 +215,7 @@ describe("PingMaker", function() {
       sendIfEmpty: true,
     });
 
-    await PingMaker.collectAndStorePing(Glean.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
+    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
 
     const recordedPings = await Glean.pingsDatabase.getAllPings();
     assert.ok(!("ident" in recordedPings));

--- a/glean/tests/core/pings/maker.spec.ts
+++ b/glean/tests/core/pings/maker.spec.ts
@@ -133,12 +133,12 @@ describe("PingMaker", function() {
     assert.deepStrictEqual({
       "X-Debug-ID": "test",
       "X-Source-Tags": "tag1,tag2,tag3"
-    }, PingMaker.getPingHeaders(Glean.debugOptions));
+    }, PingMaker.getPingHeaders(Context.instance.debugOptions));
 
     Glean.unsetDebugViewTag();
     Glean.unsetSourceTags();
     await Dispatcher.instance.testBlockOnQueue();
-    assert.strictEqual(PingMaker.getPingHeaders(Glean.debugOptions), undefined);
+    assert.strictEqual(PingMaker.getPingHeaders(Context.instance.debugOptions), undefined);
   });
 
   it("collect and store triggers the AfterPingCollection and deals with possible result correctly", async function () {
@@ -152,12 +152,12 @@ describe("PingMaker", function() {
       sendIfEmpty: true,
     });
 
-    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
+    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Context.instance.applicationId, "ident", ping, undefined, Context.instance.debugOptions);
     const recordedPing = (await Context.instance.pingsDatabase.getAllPings())["ident"];
     assert.deepStrictEqual(recordedPing.payload, { "you": "got mocked!" });
 
     await Glean.testResetGlean(testAppId, true);
-    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
+    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Context.instance.applicationId, "ident", ping, undefined, Context.instance.debugOptions);
     const recordedPingNoPlugin = (await Context.instance.pingsDatabase.getAllPings())["ident"];
     assert.notDeepStrictEqual(recordedPingNoPlugin.payload, { "you": "got mocked!" });
   });
@@ -180,7 +180,7 @@ describe("PingMaker", function() {
     });
 
     const consoleSpy = sandbox.spy(console, "info");
-    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
+    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Context.instance.applicationId, "ident", ping, undefined, Context.instance.debugOptions);
 
     const loggedPayload = JSON.parse(consoleSpy.lastCall.args[0]) as JSONObject;
 
@@ -215,7 +215,7 @@ describe("PingMaker", function() {
       sendIfEmpty: true,
     });
 
-    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Glean.applicationId, "ident", ping, undefined, Glean.debugOptions);
+    await PingMaker.collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Context.instance.applicationId, "ident", ping, undefined, Context.instance.debugOptions);
 
     const recordedPings = await Context.instance.pingsDatabase.getAllPings();
     assert.ok(!("ident" in recordedPings));

--- a/glean/tests/core/upload/index.spec.ts
+++ b/glean/tests/core/upload/index.spec.ts
@@ -7,6 +7,7 @@ import sinon from "sinon";
 import { v4 as UUIDv4 } from "uuid";
 
 import { Configuration } from "../../../src/core/config";
+import { Context } from "../../../src/core/context";
 import Glean from "../../../src/core/glean";
 import PingType from "../../../src/core/pings";
 import collectAndStorePing from "../../../src/core/pings/maker";
@@ -31,7 +32,7 @@ async function fillUpPingsDatabase(numPings: number): Promise<string[]> {
 
   const identifiers = Array.from({ length: numPings }, () => UUIDv4());
   for (const identifier of identifiers) {
-    await collectAndStorePing(Glean.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, identifier, ping);
+    await collectAndStorePing(Context.instance.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, identifier, ping);
   }
 
   return identifiers;

--- a/glean/tests/core/upload/index.spec.ts
+++ b/glean/tests/core/upload/index.spec.ts
@@ -32,7 +32,7 @@ async function fillUpPingsDatabase(numPings: number): Promise<string[]> {
 
   const identifiers = Array.from({ length: numPings }, () => UUIDv4());
   for (const identifier of identifiers) {
-    await collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Glean.applicationId, identifier, ping);
+    await collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Context.instance.applicationId, identifier, ping);
   }
 
   return identifiers;

--- a/glean/tests/core/upload/index.spec.ts
+++ b/glean/tests/core/upload/index.spec.ts
@@ -32,7 +32,7 @@ async function fillUpPingsDatabase(numPings: number): Promise<string[]> {
 
   const identifiers = Array.from({ length: numPings }, () => UUIDv4());
   for (const identifier of identifiers) {
-    await collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Context.instance.applicationId, identifier, ping);
+    await collectAndStorePing(identifier, ping);
   }
 
   return identifiers;
@@ -79,9 +79,9 @@ describe("PingUploader", function() {
     await fillUpPingsDatabase(10);
 
     // Create a new uploader and attach it to the existing storage.
-    const uploader = new PingUploader(new Configuration(), Glean.platform, Context.instance.pingsDatabase);
+    const uploader = new PingUploader(new Configuration(), Glean.platform, Context.pingsDatabase);
     uploader.setInitialized();
-    Context.instance.pingsDatabase.attachObserver(uploader);
+    Context.pingsDatabase.attachObserver(uploader);
 
     // Mock the 'triggerUpload' function so that 'scanPendingPings' does not
     // mistakenly trigger ping submission. Note that since we're swapping
@@ -93,12 +93,12 @@ describe("PingUploader", function() {
       // Intentionally empty.
     };
     
-    await Context.instance.pingsDatabase.scanPendingPings();
+    await Context.pingsDatabase.scanPendingPings();
     assert.strictEqual(uploader["queue"].length, 10);
 
     uploader.triggerUpload = uploadTriggerFunc;
     await uploader.triggerUpload();
-    assert.deepStrictEqual(await Context.instance.pingsDatabase.getAllPings(), {});
+    assert.deepStrictEqual(await Context.pingsDatabase.getAllPings(), {});
     assert.strictEqual(uploader["queue"].length, 0);
   });
 
@@ -113,10 +113,10 @@ describe("PingUploader", function() {
     disableGleanUploader();
     await fillUpPingsDatabase(10);
 
-    const uploader = new PingUploader(new Configuration(), Glean.platform, Context.instance.pingsDatabase);
+    const uploader = new PingUploader(new Configuration(), Glean.platform, Context.pingsDatabase);
     uploader.setInitialized();
-    Context.instance.pingsDatabase.attachObserver(uploader);
-    await Context.instance.pingsDatabase.scanPendingPings();
+    Context.pingsDatabase.attachObserver(uploader);
+    await Context.pingsDatabase.scanPendingPings();
 
     // Trigger uploading, but don't wait for it to finish,
     // so that it is ongoing when we cancel.
@@ -134,7 +134,7 @@ describe("PingUploader", function() {
     await fillUpPingsDatabase(10);
 
     await waitForGleanUploader();
-    assert.deepStrictEqual(await Context.instance.pingsDatabase.getAllPings(), {});
+    assert.deepStrictEqual(await Context.pingsDatabase.getAllPings(), {});
     assert.strictEqual(Glean["pingUploader"]["queue"].length, 0);
   });
 
@@ -147,7 +147,7 @@ describe("PingUploader", function() {
     await fillUpPingsDatabase(10);
 
     await waitForGleanUploader();
-    assert.deepStrictEqual(await Context.instance.pingsDatabase.getAllPings(), {});
+    assert.deepStrictEqual(await Context.pingsDatabase.getAllPings(), {});
     assert.strictEqual(Glean["pingUploader"]["queue"].length, 0);
   });
 
@@ -161,13 +161,13 @@ describe("PingUploader", function() {
 
     await waitForGleanUploader();
     // Ping should still be there.
-    const allPings = await Context.instance.pingsDatabase.getAllPings();
+    const allPings = await Context.pingsDatabase.getAllPings();
     assert.deepStrictEqual(Object.keys(allPings).length, 1);
     assert.strictEqual(Glean["pingUploader"]["queue"].length, 1);
   });
 
   it("duplicates are not enqueued", function() {
-    const uploader = new PingUploader(new Configuration(), Glean.platform, Context.instance.pingsDatabase);
+    const uploader = new PingUploader(new Configuration(), Glean.platform, Context.pingsDatabase);
     for (let i = 0; i < 10; i++) {
       uploader["enqueuePing"]({
         identifier: "id",

--- a/glean/tests/plugins/encryption.spec.ts
+++ b/glean/tests/plugins/encryption.spec.ts
@@ -19,6 +19,7 @@ import type Uploader from "../../src/core/upload/uploader";
 import { UploadResultStatus } from "../../src/core/upload/uploader";
 import CounterMetricType from "../../src/core/metrics/types/counter";
 import { Lifetime } from "../../src/core/metrics/lifetime";
+import { Context } from "../../src/core/context";
 
 const sandbox = sinon.createSandbox();
 
@@ -62,7 +63,7 @@ describe("PingEncryptionPlugin", function() {
       sinon.match.string
     );
 
-    await collectAndStorePing(Glean.metricsDatabase, Glean.eventsDatabase, Glean.pingsDatabase, Glean.applicationId, pingId, ping, undefined, Glean.debugOptions);
+    await collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Glean.applicationId, pingId, ping, undefined, Glean.debugOptions);
     assert.ok(postSpy.calledOnce);
 
     const payload = JSON.parse(postSpy.args[0][1]) as JSONObject;

--- a/glean/tests/plugins/encryption.spec.ts
+++ b/glean/tests/plugins/encryption.spec.ts
@@ -59,11 +59,11 @@ describe("PingEncryptionPlugin", function() {
     const pingId = "ident";
 
     const postSpy = sandbox.spy(TestPlatform.uploader, "post").withArgs(
-      sinon.match(makePath(Context.instance.applicationId, pingId, ping)),
+      sinon.match(makePath(Context.applicationId, pingId, ping)),
       sinon.match.string
     );
 
-    await collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Context.instance.applicationId, pingId, ping, undefined, Context.instance.debugOptions);
+    await collectAndStorePing(pingId, ping);
     assert.ok(postSpy.calledOnce);
 
     const payload = JSON.parse(postSpy.args[0][1]) as JSONObject;

--- a/glean/tests/plugins/encryption.spec.ts
+++ b/glean/tests/plugins/encryption.spec.ts
@@ -59,11 +59,11 @@ describe("PingEncryptionPlugin", function() {
     const pingId = "ident";
 
     const postSpy = sandbox.spy(TestPlatform.uploader, "post").withArgs(
-      sinon.match(makePath(Glean.applicationId, pingId, ping)),
+      sinon.match(makePath(Context.instance.applicationId, pingId, ping)),
       sinon.match.string
     );
 
-    await collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Glean.applicationId, pingId, ping, undefined, Glean.debugOptions);
+    await collectAndStorePing(Context.instance.metricsDatabase, Context.instance.eventsDatabase, Context.instance.pingsDatabase, Context.instance.applicationId, pingId, ping, undefined, Context.instance.debugOptions);
     assert.ok(postSpy.calledOnce);
 
     const payload = JSON.parse(postSpy.args[0][1]) as JSONObject;


### PR DESCRIPTION
As discussed with @brizental , this introduces a new shared state object called `Context` and uses that in the metric types, instead of referring to the Glean object (creating circular dependencies).

It additionally makes the `Dispatcher` a singleton.

Finally, it enabled the circular dependencies checker on CI.