### PR TITLE
Bug 1699394 - Improve the error reporting of the Glean cli tool

### DIFF
--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -10,9 +10,6 @@ import * as path from "path";
 import { argv, platform } from "process";
 import { promisify } from "util";
 
-// Define an async/await version of "exec".
-const execAsync = promisify(exec.exec);
-
 // The name of the directory which will contain the Python virtual environment
 // used to run the glean-parser.
 const VIRTUAL_ENVIRONMENT_DIR = ".venv";
@@ -140,10 +137,12 @@ async function createPythonVenv(venvPath: string): Promise<boolean> {
   const venvCmd = `${getSystemPythonBinName()} -m venv ${VIRTUAL_ENVIRONMENT_DIR}`;
 
   for (const cmd of [venvCmd, pipCmd]) {
-    try {
-      await execAsync(cmd);
-    } catch (e) {
-      console.error(e);
+    const {err, stdout, stderr} = await new Promise<{err: exec.ExecException | null, stdout: string, stderr: string}>(resolve => {
+      exec.exec(cmd, (err, stdout, stderr) => resolve({err, stdout, stderr}));
+    });
+
+    if (err) {
+      console.error(`${stdout}\n${stderr}`);
       return false;
     }
   }
@@ -178,10 +177,13 @@ async function runGlean(projectRoot: string, parserArgs: string[]) {
   const venvRoot = path.join(projectRoot, VIRTUAL_ENVIRONMENT_DIR);
   const pythonBin = path.join(getPythonVenvBinariesPath(venvRoot), getSystemPythonBinName());
   const cmd = `${pythonBin} -c "${PYTHON_SCRIPT}" online glean_parser ${GLEAN_PARSER_VERSION} ${parserArgs.join(" ")}`;
-  try {
-    await execAsync(cmd);
-  } catch (e) {
-    console.error(e);
+
+  const {err, stdout, stderr} = await new Promise<{err: exec.ExecException | null, stdout: string, stderr: string}>(resolve => {
+    exec.exec(cmd, (err, stdout, stderr) => resolve({err, stdout, stderr}));
+  });
+
+  if (err) {
+    console.error(`${stdout}\n${stderr}`);
   }
 }
 


### PR DESCRIPTION
Instead of printing the whole exception, this exclusively prints stdout and stderr.

In case of error, here's what gets printed:

```
npx glean glinter src/*.yaml
Checking for a Glean virtual environment at /mnt/c/Mozilla/glean.js/samples/web-extension/javascript/.venv
Using Glean virtual environment at /mnt/c/Mozilla/glean.js/samples/web-extension/javascript/.venv
ERROR running glean_parser v2.5.0

==============================================================================
/mnt/c/Mozilla/glean.js/samples/web-extension/javascript/src/metrics.yaml:
    ```
    sample: webext_started!
    ```

    'webext_started!' is not valid under any of the given schemas
        'webext_started!' does not match '^[a-z_][a-z0-9_]*$'
```
