### PR TITLE
Fix labeled booleans and string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.9.2...main)
 
+* [#227](https://github.com/mozilla/glean.js/pull/227): BUGFIX: Fix a bug that prevented using `labeled_string` and `labeled_boolean`.
+
 # v0.9.2 (2021-04-19)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.9.1...v0.9.2)

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -141,8 +141,10 @@ async function createPythonVenv(venvPath: string): Promise<boolean> {
       exec.exec(cmd, (err, stdout, stderr) => resolve({err, stdout, stderr}));
     });
 
+    console.log(`${stdout}`);
+
     if (err) {
-      console.error(`${stdout}\n${stderr}`);
+      console.error(`${stderr}`);
       return false;
     }
   }
@@ -182,8 +184,10 @@ async function runGlean(projectRoot: string, parserArgs: string[]) {
     exec.exec(cmd, (err, stdout, stderr) => resolve({err, stdout, stderr}));
   });
 
+  console.log(`${stdout}`);
+
   if (err) {
-    console.error(`${stdout}\n${stderr}`);
+    console.error(`${stderr}`);
   }
 }
 

--- a/glean/src/core/metrics/utils.ts
+++ b/glean/src/core/metrics/utils.ts
@@ -21,7 +21,9 @@ const METRIC_MAP: {
   "boolean": BooleanMetric,
   "counter": CounterMetric,
   "datetime": DatetimeMetric,
+  "labeled_boolean": LabeledMetric,
   "labeled_counter": LabeledMetric,
+  "labeled_string": LabeledMetric,
   "string": StringMetric,
   "uuid": UUIDMetric,
 });


### PR DESCRIPTION
Without this fix products using these types silently fail ping submission with the following error:

```
Error executing task: Error: Unable to create metric of unknown type labeled_boolean
    at createMetric (file:///mnt/d/Mozilla/rally/core-addon/node_modules/@mozilla/glean/dist/webext/core/metrics/utils.js:17:15)
    at createMetricsPayload (file:///mnt/d/Mozilla/rally/core-addon/node_modules/@mozilla/glean/dist/webext/core/metrics/database.js:30:28)
    at MetricsDatabase.getPingMetrics (file:///mnt/d/Mozilla/rally/core-addon/node_modules/@mozilla/glean/dist/webext/core/metrics/database.js:153:20)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async collectPing (file:///mnt/d/Mozilla/rally/core-addon/node_modules/@mozilla/glean/dist/webext/core/pings/maker.js:98:25)
    at async collectAndStorePing (file:///mnt/d/Mozilla/rally/core-addon/node_modules/@mozilla/glean/dist/webext/core/pings/maker.js:122:30)
    at async file:///mnt/d/Mozilla/rally/core-addon/node_modules/@mozilla/glean/dist/webext/core/pings/ping_type.js:32:13
    at async Dispatcher.executeTask (file:///mnt/d/Mozilla/rally/core-addon/node_modules/@mozilla/glean/dist/webext/core/dispatcher.js:46:13)
    at async Dispatcher.execute (file:///mnt/d/Mozilla/rally/core-addon/node_modules/@mozilla/glean/dist/webext/core/dispatcher.js:66:21)
```