### PR TITLE
Bug 1706103 - Add step to relase Qt build in Publish CI script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,23 @@ jobs:
       - run:
           name: Publish to npm
           command: export PATH=.:$PATH && (cd glean && npm publish --access public)
+      - run:
+          name: Get ghr release tool
+          command: |
+            GHR=ghr_v0.13.0_linux_amd64
+            GHR_SHA256=c428627270ae26e206cb526cb8c7bdfba475dd278f6691ddaf863355adadfa13
+            curl -sfSL --retry 5 -O "https://github.com/tcnksm/ghr/releases/download/v0.13.0/${GHR}.tar.gz"
+            echo "${GHR_SHA256} *${GHR}.tar.gz" | sha256sum -c -
+            tar -xf "${GHR}.tar.gz"
+            cp ./${GHR}/ghr ghr
+      - run:
+          name: Publish to Github
+          command: |
+            # Attach Qt build to release
+            npm --prefix ./glean install
+            npm --prefix ./glean run build:qt
+            cp glean/dist/glean.js glean/dist/glean_js-${CIRCLE_TAG}-qt.js
+            ./ghr -u mozilla -replace ${CIRCLE_TAG} glean/dist/glean_js-${CIRCLE_TAG}-qt.js
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.9.2...main)
 
+* [#228](https://github.com/mozilla/glean.js/pull/228): Provide a Qt build with every new release.
 * [#227](https://github.com/mozilla/glean.js/pull/227): BUGFIX: Fix a bug that prevented using `labeled_string` and `labeled_boolean`.
-* [#226](https://github.com/mozilla/glean.js/pull/226): Fix Qt build configuration to target ES5.
+* [#226](https://github.com/mozilla/glean.js/pull/226): BUGFIX: Fix Qt build configuration to target ES5.
 
 # v0.9.2 (2021-04-19)
 


### PR DESCRIPTION
I copied the way the Glean SDK does it and also how it names the final file.  I tested this locally and it worked, I added a Qt asset to the 0.9.2 with the loca test, see https://github.com/mozilla/glean.js/releases/tag/v0.9.2. 

(self reminder: For this to work I need to add a `GITHUB_TOKEN` env var to CircleCI).