### PR TITLE
Remove the observer mechanism to wait for test tasks

### DIFF
--- a/glean/src/core/dispatcher.ts
+++ b/glean/src/core/dispatcher.ts
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { generateUUIDv4 } from "./utils.js";
-
 // The possible states a dispatcher instance can be in.
 export const enum DispatcherState {
   // The dispatcher has not been initialized yet.
@@ -41,7 +39,6 @@ type Command = {
   task: Task,
   command: Commands.Task,
 } | {
-  testId?: string,
   resolver: (value: void | PromiseLike<void>) => void,
   task: Task,
   command: Commands.TestTask,
@@ -324,13 +321,9 @@ class Dispatcher {
    *          or is guaranteed to not be executed ever i.e. if the queue gets cleared.
    */
   testLaunch(task: Task): Promise<void> {
-    const testId = generateUUIDv4();
-    console.info("Launching a test task.", testId);
-
     return new Promise((resolver, reject) => {
       this.resume();
       const wasLaunched = this.launchInternal({
-        testId,
         resolver,
         task,
         command: Commands.TestTask

--- a/glean/tests/core/dispatcher.spec.ts
+++ b/glean/tests/core/dispatcher.spec.ts
@@ -340,16 +340,6 @@ describe("Dispatcher", function() {
     assert.strictEqual(dispatcher["state"], DispatcherState.Idle);
   });
 
-  it("testLaunch will reject in case the dispatcher is uninitialized for too long", async function () {
-    dispatcher = new Dispatcher();
-    try {
-      await dispatcher.testLaunch(sampleTask);
-      assert.ok(false);
-    } catch {
-      assert.ok(true);
-    }
-  });
-
   it("testLaunch will not reject in case the dispatcher is uninitialized, but quickly initializes", async function () {
     dispatcher = new Dispatcher();
     const testLaunchedTask = dispatcher.testLaunch(sampleTask);
@@ -377,23 +367,5 @@ describe("Dispatcher", function() {
     await Promise.all([test1, test2, test3]);
 
     sinon.assert.callOrder(stub1, stub2, stub3);
-  });
-
-  it("testLaunch observers are unattached after promise is resolved or rejected", async function() {
-    dispatcher = new Dispatcher();
-
-    const willReject = dispatcher.testLaunch(sampleTask);
-    assert.strictEqual(dispatcher["observers"].length, 1);
-    try {
-      await willReject;
-    } catch {
-      assert.strictEqual(dispatcher["observers"].length, 0);
-    }
-
-    dispatcher.flushInit();
-    const willNotReject = dispatcher.testLaunch(sampleTask);
-    assert.strictEqual(dispatcher["observers"].length, 1);
-    await willNotReject;
-    assert.strictEqual(dispatcher["observers"].length, 0);
   });
 });


### PR DESCRIPTION
This PR removes the mechanism based on timeouts and observers to wait on test tasks in the dispatcher. It instead defines a new task type, TestTask, and passes a resolver function when its created.