### PR TITLE
Bug 1705720 - Ensure the dispatcher is always available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.10.0...main)
 
+* [#254](https://github.com/mozilla/glean.js/pull/254): BUGFIX: Allow the usage of the Glean specific metrics API before Glean is initialized.
+
 # v0.10.0 (2021-04-20)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.9.2...v0.10.0)

--- a/glean/src/core/context.ts
+++ b/glean/src/core/context.ts
@@ -58,6 +58,9 @@ export class Context {
       await Context.instance._dispatcher.testUninitialize();
     }
 
+    // Due to the test requirement of keeping storage in place,
+    // we can't simply wipe out the full `Context` instance.
+    // The closest thing we can do is making the dispatcher `null`.
     Context.instance._dispatcher = null;
     Context.initialized = false;
   }

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -14,7 +14,6 @@ import EventsDatabase from "./metrics/events_database.js";
 import UUIDMetricType from "./metrics/types/uuid.js";
 import DatetimeMetricType from "./metrics/types/datetime.js";
 import { DatetimeMetric } from "./metrics/types/datetime_metric.js";
-import Dispatcher from "./dispatcher.js";
 import CorePings from "./internal_pings.js";
 import { registerPluginToEvent, testResetEvents } from "./events/utils.js";
 
@@ -51,10 +50,8 @@ class Glean {
       Use Glean.instance instead to access the Glean singleton.`);
     }
 
-    Context.dispatcher = new Dispatcher();
     this._coreMetrics = new CoreMetrics();
     this._corePings = new CorePings();
-    Context.initialized = false;
   }
 
   private static get instance(): Glean {
@@ -501,15 +498,10 @@ class Glean {
    */
   static async testUninitialize(): Promise<void> {
     // Get back to an uninitialized state.
-    Context.initialized = false;
+    await Context.testUninitialize();
 
     // Deregister all plugins
     testResetEvents();
-
-    // Clear the dispatcher queue and return the dispatcher back to an uninitialized state.
-    if (Context.dispatcher) {
-      await Context.dispatcher.testUninitialize();
-    }
 
     // Stop ongoing jobs and clear pending pings queue.
     if (Glean.pingUploader) {

--- a/glean/tests/core/context.spec.ts
+++ b/glean/tests/core/context.spec.ts
@@ -68,4 +68,20 @@ describe("Context", function() {
     assert.notStrictEqual(Context.pingsDatabase, undefined);
     assert.ok(Context.pingsDatabase instanceof PingsDatabase);
   });
+
+  it("the dispatcher is always available", async function () {
+    const originalDispatcher = Context.dispatcher;
+    assert.notStrictEqual(originalDispatcher, null);
+
+    await Context.testUninitialize();
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    assert.strictEqual(Context.instance._dispatcher, null);
+
+    // Trying to access the dispatcher will instantiate a new one.
+    const newDispatcher = Context.instance;
+    assert.notStrictEqual(newDispatcher, null);
+    assert.notStrictEqual(newDispatcher, originalDispatcher);
+  });
 });


### PR DESCRIPTION
This guarantees the dispatcher is always available even before the Glean initialization. We need this because our APIs can be used before initialization, to perform fast recording of metrics.