### PR TITLE
Bug 1707601 - Add the doc for instructions on how to getting started (#)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ folder in this repository and Glean.js' user documentation lives in [The Glean B
 > does not have a related bug filed with the [`[docdays]`](https://bugzilla.mozilla.org/buglist.cgi?query_format=advanced&f2=component&o1=substring&o2=equals&f1=status_whiteboard&v1=%5Bdocdays%5D&classification=Client%20Software&classification=Developer%20Infrastructure&classification=Components&classification=Server%20Software&classification=Other&list_id=15653426&resolution=---&v2=Glean.js) tag,
 > please file a bug.
 
+Here's the [guide](https://github.com/mozilla/glean.js/tree/main/docs/getting_started.md) to get you started!
+
 ## Bug reports / Feature Requests
 
 If you are using Glean.js and found a bug or a missing feature, please file a bug.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,73 @@
+# Getting started
+This guide is for developers who want to develop on Glean.js.
+## Prerequisites
+Glean.js uses [Node.js](https://nodejs.org/).
+Follow the [official guide](https://nodejs.dev/) to install it.
+### Version requirements
+* `node` >= 12.0.0
+* `npm`  >=  7.0.0
+
+## Building Glean.js
+1.  a terminal, navigate to the directory you want the Glean.js repository to live. Then:
+```bash
+git clone https://github.com/mozilla/glean.js
+```
+2. navigate to the `glean` folder:
+```bash
+cd glean.js/glean
+```
+3. Install all the node modules used by Glean.js:
+```bash
+npm install
+```
+
+## Running tests
+Once you have [built](#building-gleanjs) Glean.js, run
+```bash
+npm run test
+```
+in the `glean` folder.
+
+This runs all the tests in the `glean` folder. 
+Alternatively, you may want to run component-specific tests. 
+To do so, substitute `test` in the command above with one of the followings:
+* `test:core` - executes tests inside `tests/core` folder.
+* `test:plugins` - executes tests inside `tests/plugins` folder.
+* `test:platform` - executes tests inside `tests/platform` folder.
+
+You might want to run one specific test within a certain folder.
+To run the test with the title `DatetimeMetric` in the `core` folder: 
+```bash
+npm run test:core -- --grep "DateTimeMetric"
+```
+You should see the output similar to the following:
+```shell
+
+> @mozilla/glean@0.10.2 test:core
+> npm run test:base -- "tests/core/**/*.spec.ts" --recursive "--grep" "DatetimeMetric"
+
+
+> @mozilla/glean@0.10.2 test:base
+> node --experimental-modules --experimental-specifier-resolution=node --loader=ts-node/esm node_modules/mocha/lib/cli/cli.js "tests/core/**/*.spec.ts" "--recursive" "--grep" "DatetimeMetric"
+
+(node:52217) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+
+
+  DatetimeMetric
+    ✓ datetime internal representation validation works as expected
+    ✓ attempting to get the value of a metric that hasn't been recorded doesn't error
+    ✓ attempting to set when glean upload is disabled is a no-op
+Attempted to delete an entry from an invalid index. Ignoring.
+Attempted to delete an entry from an invalid index. Ignoring.
+Storage for deletion-request empty. Ping will still be sent.
+Attempted to delete an entry from an invalid index. Ignoring.
+Ping 053b739c-0b86-4032-ac45-29533d57ddc7 succesfully sent 200.
+    ✓ ping payload is correct
+    ✓ set properly sets the value in all pings
+    ✓ truncation works
+    ✓ get from different timezone than recording timezone keeps the original time intact
+
+
+  7 passing (27ms)
+```


### PR DESCRIPTION
This PR fixes bug 1707601 on BugZilla, and hopefully this would help JavaScript newbies (like me!)
However, there may be more things to be added to the `getting_started` doc.
Any suggestion is appreciated! 