### PR TITLE
Bug 1708366: Ensure only empty pings triggers logging of "empty ping" message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.11.0...main)
 
+* [#279](https://github.com/mozilla/glean.js/pull/279): BUGFIX: Ensure only empty pings triggers logging of "empty ping" messages.
+
 # v0.11.0 (2021-05-03)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.10.2...v0.11.0)

--- a/glean/src/core/pings/maker.ts
+++ b/glean/src/core/pings/maker.ts
@@ -195,10 +195,11 @@ export function getPingHeaders(debugOptions?: DebugOptions): Record<string, stri
 export async function collectPing(metricsDatabase: MetricsDatabase, eventsDatabase: EventsDatabase, ping: CommonPingData, reason?: string): Promise<PingPayload | undefined> {
   const metricsData = await metricsDatabase.getPingMetrics(ping.name, true);
   const eventsData = await eventsDatabase.getPingEvents(ping.name, true);
-  if (!metricsData && !eventsData && !ping.sendIfEmpty) {
-    console.info(`Storage for ${ping.name} empty. Bailing out.`);
-    return;
-  } else if (!metricsData) {
+  if (!metricsData && !eventsData) {
+    if (!ping.sendIfEmpty) {
+      console.info(`Storage for ${ping.name} empty. Bailing out.`);
+      return;
+    }
     console.info(`Storage for ${ping.name} empty. Ping will still be sent.`);
   }
 


### PR DESCRIPTION
I think the original logic is wrong, in that the message `Storage for ${ping.name} empty. Ping will still be sent.` will be logged if `eventsData` is defined.
https://github.com/mozilla/glean.js/blob/0557f318a4637b471850313a8006f46a32b6a1fa/glean/src/core/pings/maker.ts#L198-L203

