### PR TITLE
Bug 1706102 - Collect Qt platform information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.11.0...main)
 
 * [#279](https://github.com/mozilla/glean.js/pull/279): BUGFIX: Ensure only empty pings triggers logging of "empty ping" messages.
+* [#288](https://github.com/mozilla/glean.js/pull/288): Support collecting `PlatformInfo` from `Qt` applications. Only OS name and locale are supported.
 
 # v0.11.0 (2021-05-03)
 

--- a/glean/src/core/platform_info.ts
+++ b/glean/src/core/platform_info.ts
@@ -15,6 +15,11 @@ export const enum KnownOperatingSystems {
   Solaris = "Solaris",
   // ChromeOS is not listed in the Glean SDK because it is not a possibility there.
   ChromeOS = "ChromeOS",
+  // The following additions might be reported by Qt.
+  TvOS = "tvOS", // https://developer.apple.com/tvos/
+  Qnx = "QNX", // BlackBerry QNX
+  Wasm = "Wasm",
+  // The Qt-specific additions end here.
   Unknown = "Unknown",
 }
 

--- a/glean/src/platform/qt/index.ts
+++ b/glean/src/platform/qt/index.ts
@@ -2,6 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Qt does not have its implementations yet,
-// we leave this here so that the sample will still work.
-export { default } from "../test";
+// Qt does not have its implementations yet, we use pieces of
+// the `TestPlatform` so that the sample will still work.
+import TestPlatform from "../test";
+
+import info from "./platform_info.js";
+import type Platform from "../index.js";
+
+const QtPlatform: Platform = {
+  Storage: TestPlatform.Storage,
+  uploader: TestPlatform.uploader,
+  info,
+  name: "Qt"
+};
+
+export default QtPlatform;

--- a/glean/src/platform/qt/platform_info.ts
+++ b/glean/src/platform/qt/platform_info.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type PlatformInfo from "../../core/platform_info.js";
+import { KnownOperatingSystems } from "../../core/platform_info.js";
+
+// The `Qt` symbol can be used in this file without TS compiler errors
+// because that symbol is described as a constant in `./types/Qt/index.d.ts`.
+
+const QtPlatformInfo: PlatformInfo = {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async os(): Promise<KnownOperatingSystems> {
+    // Possible values are listed in https://doc.qt.io/qt-5/qml-qtqml-qt.html#platform-prop
+    const osName = Qt.platform.os;
+    switch(osName) {
+    case "android":
+      return KnownOperatingSystems.Android;
+    case "ios":
+      return KnownOperatingSystems.iOS;
+    case "tvos":
+      return KnownOperatingSystems.TvOS;
+    case "linux":
+      return KnownOperatingSystems.Linux;
+    case "osx":
+      return KnownOperatingSystems.MacOS;
+    case "qnx":
+      return KnownOperatingSystems.Qnx;
+    case "windows":
+    case "winrt":
+      return KnownOperatingSystems.Windows;
+    case "wasm":
+      return KnownOperatingSystems.Wasm;
+    default:
+      return KnownOperatingSystems.Unknown;
+    }
+  },
+
+  async osVersion(): Promise<string> {
+    // This data point is not available in Qt QML.
+    return Promise.resolve("Unknown");
+  },
+
+  async arch(): Promise<string> {
+    // This data point is not available in Qt QML.
+    return Promise.resolve("Unknown");
+  },
+
+  async locale(): Promise<string> {
+    const locale = Qt.locale();
+    return Promise.resolve(locale ? locale.name : "und");
+  }
+};
+
+export default QtPlatformInfo;

--- a/glean/src/platform/qt/platform_info.ts
+++ b/glean/src/platform/qt/platform_info.ts
@@ -48,7 +48,7 @@ const QtPlatformInfo: PlatformInfo = {
 
   async locale(): Promise<string> {
     const locale = Qt.locale();
-    return Promise.resolve(locale ? locale.name : "und");
+    return Promise.resolve(locale ? locale.name.replace("_", "-") : "und");
   }
 };
 

--- a/glean/tests/core/glean.spec.ts
+++ b/glean/tests/core/glean.spec.ts
@@ -13,7 +13,7 @@ import CounterMetricType from "../../src/core/metrics/types/counter";
 import PingType from "../../src/core/pings/ping_type";
 import type { JSONObject } from "../../src/core/utils";
 import { isObject } from "../../src/core/utils";
-import TestPlatform from "../../src/platform/qt";
+import TestPlatform from "../../src/platform/test";
 import Plugin from "../../src/plugins";
 import { Lifetime } from "../../src/core/metrics/lifetime";
 import { Context } from "../../src/core/context";

--- a/glean/tests/plugins/encryption.spec.ts
+++ b/glean/tests/plugins/encryption.spec.ts
@@ -11,7 +11,7 @@ import compactDecrypt from "jose/jwe/compact/decrypt";
 import Glean from "../../src/core/glean";
 import PingType from "../../src/core/pings/ping_type";
 import type { JSONObject } from "../../src/core/utils";
-import TestPlatform from "../../src/platform/qt";
+import TestPlatform from "../../src/platform/test";
 import PingEncryptionPlugin from "../../src/plugins/encryption";
 import collectAndStorePing, { makePath } from "../../src/core/pings/maker";
 import type { UploadResult} from "../../src/core/upload/uploader";

--- a/glean/tsconfig/qt.json
+++ b/glean/tsconfig/qt.json
@@ -1,7 +1,11 @@
 {
   "extends": "./base.json",
   "compilerOptions": {
-    "target": "ES5"
+    "target": "ES5",
+    "typeRoots": [
+      "../node_modules/@types",
+      "../types"
+    ]
   },
   "include": ["../src/index/qt.ts" ]
 }

--- a/glean/types/Qt/index.d.ts
+++ b/glean/types/Qt/index.d.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This file was created from the template offered on the TS website:
+// https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-d-ts.html
+
+declare namespace Qt {
+  interface Locale {
+    name: string;
+  }
+
+  interface Platform {
+    os: string;
+  }
+
+  const platform: Platform;
+
+  function locale(): Locale | undefined;
+}


### PR DESCRIPTION
This uses the global `Qt` object to get the OS name and the locale. Unfortunately, os version and architecture are not available.

I manually tested that this works using the Glean.js Qt sample app. I get the following output:

```
D:\Mozilla\glean.js\samples\qt-qml-app>python main.py
qml: Initialized Glean succesfully.
qml: Adding to the `button_clicked` metric.
qml: Attempted to delete an entry from an invalid index. Ignoring.
qml: {
  "metrics": {
    "datetime": {
      "sample.app_started": "2021-05-06T16:17:26.529+02:00"
    },
    "counter": {
      "sample.button_clicked": 1
    }
  },
  "ping_info": {
    "seq": 0,
    "start_time": "2021-05-06T16:17+02:00",
    "end_time": "2021-05-06T16:17+02:00"
  },
  "client_info": {
    "telemetry_sdk_build": "0.11.0",
    "client_id": "06cbc5b3-2c1b-4cc5-bdaf-85ba62a4afca",
    "first_run_date": "2021-05-06+02:00",
    "os": "Windows",
    "os_version": "Unknown",
    "architecture": "Unknown",
    "locale": "it_IT",
    "app_build": "Unknown",
    "app_display_version": "Unknown"
  }
}
qml: Ping e23108de-1a60-4091-9b7f-b70215d3115d succesfully sent 200.
```
