### PR TITLE
Bug 1710377 - Only check string format when validating UUID

### DIFF
--- a/glean/src/core/metrics/types/uuid.ts
+++ b/glean/src/core/metrics/types/uuid.ts
@@ -6,9 +6,11 @@ import type { CommonMetricData } from "../index.js";
 import { MetricType } from "../index.js";
 import { generateUUIDv4, isString } from "../../utils.js";
 import { Context } from "../../context.js";
-import { validate as UUIDvalidate } from "uuid";
-import { KNOWN_CLIENT_ID } from "../../constants.js";
 import { Metric } from "../metric.js";
+
+// Loose UUID regex for checking if a string has a UUID shape.
+// Note: This does not contain version checks.
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export class UUIDMetric extends Metric<string, string> {
   constructor(v: unknown) {
@@ -20,11 +22,7 @@ export class UUIDMetric extends Metric<string, string> {
       return false;
     }
 
-    if (v === KNOWN_CLIENT_ID) {
-      return true;
-    }
-
-    return UUIDvalidate(v);
+    return UUID_REGEX.test(v);
   }
 
   payload(): string {

--- a/glean/tests/core/metrics/timespan.spec.ts
+++ b/glean/tests/core/metrics/timespan.spec.ts
@@ -76,7 +76,7 @@ describe("TimespanMetric", function() {
   });
 
   it("ping payload is correct", async function() {
-    const fakeDateNow = sandbox.stub(Date, "now");
+    const fakeDateNow = performance ? sandbox.stub(performance, "now") : sandbox.stub(Date, "now");
     fakeDateNow.onCall(0).callsFake(() => 0);
     fakeDateNow.onCall(1).callsFake(() => 100);
 
@@ -101,7 +101,7 @@ describe("TimespanMetric", function() {
   });
 
   it("recording APIs properly sets the value in all pings", async function() {
-    const fakeDateNow = sandbox.stub(Date, "now");
+    const fakeDateNow = performance ? sandbox.stub(performance, "now") : sandbox.stub(Date, "now");
     fakeDateNow.onCall(0).callsFake(() => 0);
     fakeDateNow.onCall(1).callsFake(() => 100);
 
@@ -153,7 +153,7 @@ describe("TimespanMetric", function() {
     ];
 
     for (const testCase of testCases) {
-      const fakeDateNow = sandbox.stub(Date, "now");
+      const fakeDateNow = performance ? sandbox.stub(performance, "now") : sandbox.stub(Date, "now");
       fakeDateNow.onCall(0).callsFake(() => 0);
       fakeDateNow.onCall(1).callsFake(() => 3600000); // One hour.
 
@@ -174,7 +174,7 @@ describe("TimespanMetric", function() {
   });
 
   it("second timer run is skipped", async function() {
-    const fakeDateNow = sandbox.stub(Date, "now");
+    const fakeDateNow = performance ? sandbox.stub(performance, "now") : sandbox.stub(Date, "now");
     // First check, duration: 100
     fakeDateNow.onCall(0).callsFake(() => 0);
     fakeDateNow.onCall(1).callsFake(() => 100);
@@ -226,7 +226,7 @@ describe("TimespanMetric", function() {
   });
 
   it("nothing is stored before stop", async function() {
-    const fakeDateNow = sandbox.stub(Date, "now");
+    const fakeDateNow = performance ? sandbox.stub(performance, "now") : sandbox.stub(Date, "now");
     fakeDateNow.onCall(0).callsFake(() => 0);
     fakeDateNow.onCall(1).callsFake(() => 100);
 
@@ -278,7 +278,7 @@ describe("TimespanMetric", function() {
   });
 
   it("time cannot go backwards", async function() {
-    const fakeDateNow = sandbox.stub(Date, "now");
+    const fakeDateNow = performance ? sandbox.stub(performance, "now") : sandbox.stub(Date, "now");
     fakeDateNow.onCall(0).callsFake(() => 100);
     fakeDateNow.onCall(1).callsFake(() => 0);
 


### PR DESCRIPTION
For legacy reasons we need to accept non-RFC'd UUID strings. 

See also: https://github.com/mozilla-extensions/bergamot-browser-extension/issues/106#issuecomment-831838830