### PR TITLE
Bug 1681484: Add the consistency check between package.json and package-lock.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,19 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Check that package-lock.json is updated as needed
+          command: |
+            npm install --prefix ./glean --package-lock-only
+            if ! git diff --exit-code HEAD -- glean/package-lock.json; then
+              echo "=================================================="
+              echo "The committed package-lock.json is out-dated."
+              echo "Please regenerate package-lock.json using"
+              echo "    npm i --package-lock-only"
+              echo "Commit the modified file and push."
+              echo "=================================================="
+              exit 1
+            fi
+      - run:
           name: Install Javascript dependencies
           command: npm --prefix ./glean install
       - run:


### PR DESCRIPTION
The PR aims to tackle bug 1681484; 
Right now, `package-lock.json` is intentionally modified to see whether the newly added CI check fails as expected.
