### PR TITLE
Bug 1707896 - Make the Qt package a QML module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,8 +209,8 @@ jobs:
             # Attach Qt build to release
             npm --prefix ./glean install
             npm --prefix ./glean run build:qt
-            cp glean/dist/glean.js glean/dist/glean_js-${CIRCLE_TAG}-qt.js
-            ./ghr -u mozilla -replace ${CIRCLE_TAG} glean/dist/glean_js-${CIRCLE_TAG}-qt.js
+            tar -zcvf "glean/dist/glean_js-${CIRCLE_TAG}-qt.tar.gz" glean/dist/qt
+            ./ghr -u mozilla -replace ${CIRCLE_TAG} glean/dist/glean_js-${CIRCLE_TAG}-qt.tar.gz
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,8 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install -r requirements.txt
-            glean_parser translate metrics.yaml pings.yaml -f javascript -o generated --option platform=qt
+            glean_parser translate metrics.yaml pings.yaml -f javascript -o generated \
+            --option platform=qt --option version=0.14
 
             sudo apt-get install xvfb
             xvfb-run python main.py &> qml.log &

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.14.1...main)
 
 * [#389](https://github.com/mozilla/glean.js/pull/389): BUGFIX: Make sure to submit a `deletion-request` ping before clearing data when toggling upload.
+* [#375](https://github.com/mozilla/glean.js/pull/375): Release Glean.js for Qt as a QML module.
 
 # v0.14.1 (2021-05-21)
 

--- a/bin/prepare-qml-module.sh
+++ b/bin/prepare-qml-module.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -eo pipefail
+
+WORKSPACE_ROOT="$( cd "$(dirname "$0")/.." ; pwd -P )"
+
+# Get @mozilla/glean current version without the patch version.
+# Qt import paths may only have major and minor version.
+GLEAN_VERSION=$(node -p -e "require('${WORKSPACE_ROOT}/glean/package.json').version.split('.').reverse().slice(1).reverse().join('.')")
+
+# Create the qmldir file
+FILE=glean/dist/qt/org/mozilla/Glean/qmldir
+touch "${WORKSPACE_ROOT}/${FILE}"
+{
+    echo module org.mozilla.Glean
+    echo Glean $GLEAN_VERSION glean.js
+} >> "${WORKSPACE_ROOT}/${FILE}"
+
+# Add the glean.js file to the final module
+cp "${WORKSPACE_ROOT}/glean/qt.entry.js" "${WORKSPACE_ROOT}/glean/dist/qt/org/mozilla/Glean/glean.js"

--- a/bin/prepare-qml-module.sh
+++ b/bin/prepare-qml-module.sh
@@ -21,4 +21,4 @@ touch "${WORKSPACE_ROOT}/${FILE}"
 } >> "${WORKSPACE_ROOT}/${FILE}"
 
 # Add the glean.js file to the final module
-cp "${WORKSPACE_ROOT}/glean/qt.entry.js" "${WORKSPACE_ROOT}/glean/dist/qt/org/mozilla/Glean/glean.js"
+cp "${WORKSPACE_ROOT}/glean/src/index/qt.js" "${WORKSPACE_ROOT}/glean/dist/qt/org/mozilla/Glean/glean.js"

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -114,13 +114,16 @@ run $SED -i.bak -E \
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
 ### Qt sample app ###
+# Qt changes are necessary because QML requires that you add
+# version number along with the import statements.
 
-# This gets the version without the path version.
-GLEAN_VERSION_FOR_QML=$(node -p -e "require('${WORKSPACE_ROOT}/glean/package.json').version.split('.').reverse().slice(1).reverse().join('.')")
+# This gets the version string without the patch version.
+GLEAN_VERSION_FOR_QML=$(node -p -e "'${NEW_VERSION}'.split('.').reverse().slice(1).reverse().join('.')")
 
 FILE=samples/qt-qml-app/main.qml
 run $SED -i.bak -E \
     -e "s/import org.mozilla.Glean [0-9a-z.-]+/import org.mozilla.Glean \"${GLEAN_VERSION_FOR_QML}\";/" \
+    -e "s/import generated [0-9a-z.-]+/import generated \"${GLEAN_VERSION_FOR_QML}\";/" \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -113,6 +113,29 @@ run $SED -i.bak -E \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
+### Qt sample app ###
+
+# This gets the version without the path version.
+GLEAN_VERSION_FOR_QML=$(node -p -e "require('${WORKSPACE_ROOT}/glean/package.json').version.split('.').reverse().slice(1).reverse().join('.')")
+
+FILE=samples/qt-qml-app/main.qml
+run $SED -i.bak -E \
+    -e "s/import org.mozilla.Glean [0-9a-z.-]+/import org.mozilla.Glean \"${GLEAN_VERSION_FOR_QML}\";/" \
+    "${WORKSPACE_ROOT}/${FILE}"
+run rm "${WORKSPACE_ROOT}/${FILE}.bak"
+
+FILE=samples/qt-qml-app/README.md
+run $SED -i.bak -E \
+    -e "s/--option platform=qt --option version=[0-9a-z.-]+/--option platform=qt --option version=\"${GLEAN_VERSION_FOR_QML}\";/" \
+    "${WORKSPACE_ROOT}/${FILE}"
+run rm "${WORKSPACE_ROOT}/${FILE}.bak"
+
+FILE=.circleci/config.yml
+run $SED -i.bak -E \
+    -e "s/--option platform=qt --option version=[0-9a-z.-]+/--option platform=qt --option version=\"${GLEAN_VERSION_FOR_QML}\";/" \
+    "${WORKSPACE_ROOT}/${FILE}"
+run rm "${WORKSPACE_ROOT}/${FILE}.bak"
+
 echo "Everything prepared for v${NEW_VERSION}"
 echo
 echo "Changed files:"

--- a/glean/.eslintignore
+++ b/glean/.eslintignore
@@ -1,3 +1,4 @@
 dist
 venv
 node_modules
+qt.entry.js

--- a/glean/.eslintignore
+++ b/glean/.eslintignore
@@ -1,4 +1,4 @@
 dist
 venv
 node_modules
-qt.entry.js
+qt.js

--- a/glean/package.json
+++ b/glean/package.json
@@ -51,7 +51,7 @@
     "build:webext:lib": "tsc -p ./tsconfig/webext/index.json",
     "build:webext:types": "tsc -p ./tsconfig/webext/types.json",
     "build:webext": "rm -rf dist/webext && run-s build:webext:lib build:webext:types",
-    "build:qt": "webpack --config webpack.config.qt.js --mode production",
+    "build:qt": "rm -rf dist/qt && webpack --config webpack.config.qt.js --mode production && ../bin/prepare-qml-module.sh",
     "build:docs": "rm -rf dist/docs && typedoc src/ --out dist/docs --tsconfig tsconfig/docs.json --theme minimal",
     "publish:docs": "NODE_DEBUG=gh-pages gh-pages --dotfiles --message \"[skip ci] Updates\" --dist dist/docs",
     "prepublishOnly": "cp ../README.md ./README.md && run-s build:cli build:webext",

--- a/glean/qt.entry.js
+++ b/glean/qt.entry.js
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This file in the entry point file for Glean.js in QML.
+
+.pragma library
+
+.import "glean.lib.js" as Glean
+
+/**
+ * Initialize Glean. This method should only be called once, subsequent calls will be no-op.
+ *
+ * @param applicationId The application ID (will be sanitized during initialization).
+ * @param uploadEnabled Determines whether telemetry is enabled.
+ *        If disabled, all persisted metrics, events and queued pings (except
+ *        first_run_date) are cleared.
+ * @param config Glean configuration options.
+ */
+function initialize(applicationId, uploadEnabled, config) {
+  Glean.Glean.default.initialize(applicationId, uploadEnabled, config);
+}
+
+/**
+ * Sets whether upload is enabled or not.
+ *
+ * When uploading is disabled, metrics aren't recorded at all and no data is uploaded.
+ *
+ * When disabling, all pending metrics, events and queued pings are cleared.
+ *
+ * When enabling, the core Glean metrics are recreated.
+ *
+ * If the value of this flag is not actually changed, this is a no-op.
+ *
+ * If Glean has not been initialized yet, this is also a no-op.
+ *
+ * @param flag When true, enable metric collection.
+ */
+function setUploadEnabled(flag) {
+  Glean.Glean.default.setUploadEnabled(flag);
+}
+
+/**
+ * Sets the `logPings` flag.
+ *
+ * When this flag is `true` pings will be logged
+ * to the console right before they are collected.
+ *
+ * @param flag Whether or not to log pings.
+ */
+function setLogPings(flag) {
+  Glean.Glean.default.setLogPings(flag);
+}
+
+/**
+ * Sets the `debugViewTag` debug option.
+ *
+ * When this property is set, all subsequent outgoing pings will include the `X-Debug-ID` header
+ * which will redirect them to the ["Ping Debug Viewer"](https://debug-ping-preview.firebaseapp.com/).
+ *
+ * To unset the `debugViewTag` call `Glean.unsetDebugViewTag();
+ *
+ * @param value The value of the header.
+ *        This value must satify the regex `^[a-zA-Z0-9-]{1,20}$` otherwise it will be ignored.
+ */
+function setDebugViewTag(value) {
+  Glean.Glean.default.setDebugViewTag(value);
+}
+
+/**
+ * Sets the `sourceTags` debug option.
+ *
+ * Ping tags will show in the destination datasets, after ingestion.
+ *
+ * Note** Setting `sourceTags` will override all previously set tags.
+ *
+ * To unset the `sourceTags` call `Glean.unsetSourceTags();
+ *
+ * @param value A vector of at most 5 valid HTTP header values.
+ *        Individual tags must match the regex: "[a-zA-Z0-9-]{1,20}".
+ */
+function setSourceTags(value) {
+  Glean.Glean.default.setSourceTags(value);
+}
+
+const _private = Glean.Glean.default._private;

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -15,7 +15,7 @@ import { promisify } from "util";
 const VIRTUAL_ENVIRONMENT_DIR = ".venv";
 
 // The version of glean_parser to install from PyPI.
-const GLEAN_PARSER_VERSION = "3.2.0";
+const GLEAN_PARSER_VERSION = "3.5.0";
 
 // This script runs a given Python module as a "main" module, like
 // `python -m module`. However, it first checks that the installed

--- a/glean/src/index/qt.js
+++ b/glean/src/index/qt.js
@@ -2,7 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// This file in the entry point file for Glean.js in QML.
+// This file is the actual entry point file for Glean.js in QML, that users will interact with.
+//
+// I was not able to figure out a way to simply use the Webpack generated file to
+// be the entry point in Qt, because of the unusual syntax allowed in Qt Javascript.
+// Thus, we compile the Glean.js library normaly into the `glean.lib.js` file and then
+// we have this file which interacts opaquely with the Webpack generated one.
+//
+// **All functions and variables defined here are public.**
 
 .pragma library
 

--- a/glean/src/index/qt.ts
+++ b/glean/src/index/qt.ts
@@ -23,18 +23,10 @@ export default {
   /**
    * Initialize Glean. This method should only be called once, subsequent calls will be no-op.
    *
-   * # Note
-   *
-   * Before this method is called Glean will not be able to upload pings or record metrics,
-   * all such operations will be no-op.
-   *
-   * This is _not_ the way glean-core deals with this. It will record tasks performed before init
-   * and flush them on init. We have a bug to figure out how to do that for Glean.js, Bug 1687491.
-   *
    * @param applicationId The application ID (will be sanitized during initialization).
    * @param uploadEnabled Determines whether telemetry is enabled.
-   *                      If disabled, all persisted metrics, events and queued pings (except
-   *                      first_run_date) are cleared.
+   *        If disabled, all persisted metrics, events and queued pings (except
+   *        first_run_date) are cleared.
    * @param config Glean configuration options.
    */
   initialize(

--- a/glean/src/index/webext.ts
+++ b/glean/src/index/webext.ts
@@ -11,14 +11,6 @@ export default {
   /**
    * Initialize Glean. This method should only be called once, subsequent calls will be no-op.
    *
-   * # Note
-   *
-   * Before this method is called Glean will not be able to upload pings or record metrics,
-   * all such operations will be no-op.
-   *
-   * This is _not_ the way glean-core deals with this. It will record tasks performed before init
-   * and flush them on init. We have a bug to figure out how to do that for Glean.js, Bug 1687491.
-   *
    * @param applicationId The application ID (will be sanitized during initialization).
    * @param uploadEnabled Determines whether telemetry is enabled.
    *                      If disabled, all persisted metrics, events and queued pings (except

--- a/glean/webpack.config.qt.js
+++ b/glean/webpack.config.qt.js
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
-
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
+
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -33,7 +32,6 @@ class TsResolvePlugin {
 
 export default {
   entry: "./src/index/qt.ts",
-  devtool : "cheap-source-map",
   module: {
     rules: [
       {
@@ -57,8 +55,8 @@ export default {
     ]
   },
   output: {
-    path: path.resolve(__dirname, "dist"),
-    filename: "glean.js",
+    path: path.resolve(__dirname, "dist/qt/org/mozilla/Glean"),
+    filename: "glean.lib.js",
     libraryTarget: "var",
     library: "Glean",
   }

--- a/samples/qt-qml-app/README.md
+++ b/samples/qt-qml-app/README.md
@@ -28,7 +28,8 @@ python3 -m venv .venv
 3. Generate metrics and pings files.
 
 ```bash
-.venv/bin/python3 -m glean_parser translate metrics.yaml pings.yaml -f javascript -o generated --option platform=qt
+.venv/bin/python3 -m glean_parser translate metrics.yaml pings.yaml -f javascript -o generated \
+--option platform=qt --option version=0.14
 ```
 
 4. Run the application.

--- a/samples/qt-qml-app/main.py
+++ b/samples/qt-qml-app/main.py
@@ -14,7 +14,9 @@ app = QApplication([])
 view = QQuickView()
 url = QUrl("main.qml")
 
+# Path to the Glean.js module
 view.engine().addImportPath("../../glean/dist/qt")
+# Path to the generated files module
 view.engine().addImportPath(".")
 view.setSource(url)
 view.show()

--- a/samples/qt-qml-app/main.py
+++ b/samples/qt-qml-app/main.py
@@ -14,6 +14,8 @@ app = QApplication([])
 view = QQuickView()
 url = QUrl("main.qml")
 
+view.engine().addImportPath("../../glean/dist/qt")
+view.engine().addImportPath(".")
 view.setSource(url)
 view.show()
 app.exec_()

--- a/samples/qt-qml-app/main.qml
+++ b/samples/qt-qml-app/main.qml
@@ -6,10 +6,8 @@ import QtQuick 2.0
 import QtQuick.Controls 2.0
 import QtGraphicalEffects 1.15
 
-import "../../glean/dist/glean.js" as Glean;
-// These must be imported after Glean because they rely on Glean being in the environment.
-import "./generated/pings.js" as Pings;
-import "./generated/sample.js" as Metrics;
+import org.mozilla.Glean 0.14
+import "./generated"
 
 Rectangle {
   id: screen
@@ -29,7 +27,7 @@ Rectangle {
     font.bold: true
     onClicked: () => {
       console.log("Adding to the `button_clicked` metric.");
-      Metrics.buttonClicked.add();
+      Sample.buttonClicked.add();
     }
   }
 
@@ -66,8 +64,8 @@ Rectangle {
 
   Component.onCompleted: {
     // Initialize Glean.
-    Glean.Glean.default.initialize("qt-qml-app", true, { debug: { logPings: true }});
-    Metrics.appStarted.set();
+    Glean.initialize("qt-qml-app", true, { debug: { logPings: true }});
+    Sample.appStarted.set();
     // !IMPORTANT!
     // If this message is changed the check in bin/qt-js-check **must** be updated.
     console.log("Initialized Glean succesfully.");

--- a/samples/qt-qml-app/main.qml
+++ b/samples/qt-qml-app/main.qml
@@ -7,7 +7,7 @@ import QtQuick.Controls 2.0
 import QtGraphicalEffects 1.15
 
 import org.mozilla.Glean 0.14
-import "./generated"
+import generated 0.14
 
 Rectangle {
   id: screen

--- a/samples/qt-qml-app/requirements.txt
+++ b/samples/qt-qml-app/requirements.txt
@@ -1,3 +1,3 @@
 PySide2==5.15.2
 shiboken2==5.15.2
-glean_parser==3.2.0
+glean_parser==3.5.0


### PR DESCRIPTION
Opening as a draft as this depends on https://github.com/mozilla/glean_parser/pull/342

I have tested manually of course, but we will be sure once CI turns out green after updating glean_parser 👀 

Just remembered that I still need to:

- [x] Change the way we release the Qt package in order to release it as a QML module (i.e. with the long path + qmldir file).