### PR TITLE
Bug 1712285 - Tag all log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.15.0...main)
 
+* [#411](https://github.com/mozilla/glean.js/pull/411): Tag all messages logged by Glean with the component they are coming from.
 * [#399](https://github.com/mozilla/glean.js/pull/399): Check if there are ping data before attempting to delete it.
   * This change lowers the amount of log messages related to attempting to delete inexistent data.
 

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -10,6 +10,10 @@ import * as path from "path";
 import { argv, platform } from "process";
 import { promisify } from "util";
 
+import log, { LoggingLevel } from "./core/log.js";
+
+const LOG_TAG = "CLI";
+
 // The name of the directory which will contain the Python virtual environment
 // used to run the glean-parser.
 const VIRTUAL_ENVIRONMENT_DIR = ".venv";
@@ -100,7 +104,7 @@ function getPythonVenvBinariesPath(venvRoot: string): string {
  *          is accessible, `false` otherwise.
  */
 async function checkPythonVenvExists(venvPath: string): Promise<boolean> {
-  console.log(`Checking for a Glean virtual environment at ${venvPath}`);
+  log(LOG_TAG, `Checking for a Glean virtual environment at ${venvPath}`);
 
   const venvPython =
     path.join(getPythonVenvBinariesPath(venvPath), getSystemPythonBinName());
@@ -124,7 +128,7 @@ async function checkPythonVenvExists(venvPath: string): Promise<boolean> {
  * @returns `true` if the environment was correctly created, `false` otherwise.
  */
 async function createPythonVenv(venvPath: string): Promise<boolean> {
-  console.log(`Creating a Glean virtual environment at ${venvPath}`);
+  log(LOG_TAG, `Creating a Glean virtual environment at ${venvPath}`);
 
   const pipFilename = (platform === "win32") ? "pip3.exe" : "pip3";
   const venvPip =
@@ -140,10 +144,10 @@ async function createPythonVenv(venvPath: string): Promise<boolean> {
     });
 
     stopSpinner(spinner);
-    console.log(`${stdout}`);
+    log(LOG_TAG, `${stdout}`);
 
     if (err) {
-      console.error(`${stderr}`);
+      log(LOG_TAG, `${stderr}`);
       return false;
     }
   }
@@ -162,9 +166,9 @@ async function setup(projectRoot: string) {
 
   const venvExists = await checkPythonVenvExists(venvRoot);
   if (venvExists) {
-    console.log(`Using Glean virtual environment at ${venvRoot}`);
+    log(LOG_TAG, `Using Glean virtual environment at ${venvRoot}`);
   } else if (!await createPythonVenv(venvRoot)){
-    console.error(`Failed to create a Glean virtual environment at ${venvRoot}`);
+    log(LOG_TAG, `Failed to create a Glean virtual environment at ${venvRoot}`);
     process.exit(1);
   }
 }
@@ -186,10 +190,10 @@ async function runGlean(projectRoot: string, parserArgs: string[]) {
   });
 
   stopSpinner(spinner);
-  console.log(`${stdout}`);
+  log(LOG_TAG, `${stdout}`);
 
   if (err) {
-    console.error(`${stderr}`);
+    log(LOG_TAG, `${stderr}`);
     process.exit(1);
   }
 }
@@ -232,7 +236,7 @@ async function run(args: string[]) {
   try {
     await setup(projectRoot);
   } catch (err) {
-    console.error("Failed to setup the Glean build environment", err);
+    log(LOG_TAG, ["Failed to setup the Glean build environment.\n", err], LoggingLevel.Error);
     process.exit(1);
   }
 
@@ -241,6 +245,6 @@ async function run(args: string[]) {
 
 // For discoverability, try to leave this function as the last one on this file.
 run(argv).catch(e => {
-  console.error("There was an error running Glean", e);
+  log(LOG_TAG, ["There was an error running Glean.\n", e], LoggingLevel.Error);
   process.exit(1);
 });

--- a/glean/src/core/config.ts
+++ b/glean/src/core/config.ts
@@ -7,6 +7,9 @@ import type Plugin from "../plugins/index.js";
 import { validateHeader, validateURL } from "./utils.js";
 import type Uploader from "./upload/uploader.js";
 import type { DebugOptions } from "./debug_options.js";
+import log, { LoggingLevel } from "./log.js";
+
+const LOG_TAG = "core.Config";
 
 /**
  * Describes how to configure Glean.
@@ -69,9 +72,13 @@ export class Configuration implements ConfigurationInterface {
   static validateDebugViewTag(tag: string): boolean {
     const validation = validateHeader(tag);
     if (!validation) {
-      console.error(
-        `"${tag}" is not a valid \`debugViewTag\` value.`,
-        "Please make sure the value passed satisfies the regex `^[a-zA-Z0-9-]{1,20}$`."
+      log(
+        LOG_TAG,
+        [
+          `"${tag}" is not a valid \`debugViewTag\` value.`,
+          "Please make sure the value passed satisfies the regex `^[a-zA-Z0-9-]{1,20}$`."
+        ],
+        LoggingLevel.Error
       );
     }
     return validation;
@@ -79,13 +86,21 @@ export class Configuration implements ConfigurationInterface {
 
   static validateSourceTags(tags: string[]): boolean {
     if (tags.length < 1 || tags.length > GLEAN_MAX_SOURCE_TAGS) {
-      console.error(`A list of tags cannot contain more than ${GLEAN_MAX_SOURCE_TAGS} elements.`);
+      log(
+        LOG_TAG,
+        `A list of tags cannot contain more than ${GLEAN_MAX_SOURCE_TAGS} elements.`,
+        LoggingLevel.Error
+      );
       return false;
     }
 
     for (const tag of tags) {
       if (tag.startsWith("glean")) {
-        console.error("Tags starting with `glean` are reserved and must not be used.");
+        log(
+          LOG_TAG,
+          "Tags starting with `glean` are reserved and must not be used.",
+          LoggingLevel.Error
+        );
         return false;
       }
 

--- a/glean/src/core/dispatcher.ts
+++ b/glean/src/core/dispatcher.ts
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import log, { LoggingLevel } from "./log.js";
+
+const LOG_TAG = "core.Dispatcher";
+
 // The possible states a dispatcher instance can be in.
 export const enum DispatcherState {
   // The dispatcher has not been initialized yet.
@@ -84,7 +88,7 @@ class Dispatcher {
     try {
       await task();
     } catch(e) {
-      console.error("Error executing task:", e);
+      log(LOG_TAG, ["Error executing task:", e], LoggingLevel.Error);
     }
   }
 
@@ -144,9 +148,13 @@ class Dispatcher {
           }
         })
         .catch(error => {
-          console.error(
-            "IMPOSSIBLE: Something went wrong while the dispatcher was executing the tasks queue.",
-            error
+          log(
+            LOG_TAG,
+            [
+              "IMPOSSIBLE: Something went wrong while the dispatcher was executing the tasks queue.",
+              error
+            ],
+            LoggingLevel.Error
           );
         });
     }
@@ -169,7 +177,11 @@ class Dispatcher {
   private launchInternal(command: Command, priorityTask = false): boolean {
     if (!priorityTask && this.state === DispatcherState.Uninitialized) {
       if (this.queue.length >= this.maxPreInitQueueSize) {
-        console.warn("Unable to enqueue task, pre init queue is full.");
+        log(
+          LOG_TAG,
+          "Unable to enqueue task, pre init queue is full.",
+          LoggingLevel.Warn
+        );
         return false;
       }
     }
@@ -213,7 +225,11 @@ class Dispatcher {
    */
   flushInit(task?: Task): void {
     if (this.state !== DispatcherState.Uninitialized) {
-      console.warn("Attempted to initialize the Dispatcher, but it is already initialized. Ignoring.");
+      log(
+        LOG_TAG,
+        "Attempted to initialize the Dispatcher, but it is already initialized. Ignoring.",
+        LoggingLevel.Warn
+      );
       return;
     }
 

--- a/glean/src/core/error/index.ts
+++ b/glean/src/core/error/index.ts
@@ -6,6 +6,18 @@ import type { MetricType } from "../metrics/index.js";
 import type { ErrorType } from "./error_type.js";
 import CounterMetricType from "../metrics/types/counter.js";
 import { combineIdentifierAndLabel, stripLabel } from "../metrics/types/labeled.js";
+import log from "../log.js";
+
+/**
+ * Create a log tag for a specific metric type.
+ *
+ * @param metric The metric type to create a tag for.
+ * @returns The tag.
+ */
+function createLogTag(metric: MetricType): string {
+  const capitalizedType = metric.type.charAt(0).toUpperCase() + metric.type.slice(1);
+  return `core.Metrics.${capitalizedType}`;
+}
 
 /**
  * For a given metric, get the metric in which to record errors.
@@ -54,7 +66,7 @@ export default class ErrorManager {
     numErrors = 1
   ): Promise<void> {
     const errorMetric = getErrorMetricForMetric(metric, error);
-    console.warn(`${metric.baseIdentifier()}: ${message}`);
+    log(createLogTag(metric), `${metric.baseIdentifier()}: ${message}`);
     if (numErrors > 0) {
       await CounterMetricType._private_addUndispatched(errorMetric, numErrors);
     } else {

--- a/glean/src/core/events/index.ts
+++ b/glean/src/core/events/index.ts
@@ -3,9 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type Plugin from "../../plugins/index.js";
+import log, { LoggingLevel } from "../log.js";
 
 import type { PingPayload } from "../pings/ping_payload.js";
 import type { JSONObject } from "../utils.js";
+
+const LOG_TAG = "core.Events";
 
 export class CoreEvent<
    // An array of arguments that the event will provide as context to the plugin action.
@@ -29,10 +32,14 @@ export class CoreEvent<
    */
   registerPlugin(plugin: Plugin<CoreEvent<Context, Result>>): void {
     if (this.plugin) {
-      console.error(
-        `Attempted to register plugin '${plugin.name}', which listens to the event '${plugin.event}'.`,
-        `That event is already watched by plugin '${this.plugin.name}'`,
-        `Plugin '${plugin.name}' will be ignored.`
+      log(
+        LOG_TAG,
+        [
+          `Attempted to register plugin '${plugin.name}', which listens to the event '${plugin.event}'.`,
+          `That event is already watched by plugin '${this.plugin.name}'`,
+          `Plugin '${plugin.name}' will be ignored.`
+        ],
+        LoggingLevel.Error
       );
       return;
     }

--- a/glean/src/core/events/utils.ts
+++ b/glean/src/core/events/utils.ts
@@ -5,6 +5,9 @@
 import type { CoreEvent } from "./index.js";
 import CoreEvents from "./index.js";
 import type Plugin from "../../plugins/index.js";
+import log, { LoggingLevel } from "../log.js";
+
+const LOG_TAG = "core.Events.Utils";
 
 /**
  * Registers a plugin to the desired Glean event.
@@ -21,9 +24,13 @@ export function registerPluginToEvent<E extends CoreEvent>(plugin: Plugin<E>): v
     return;
   }
 
-  console.error(
-    `Attempted to register plugin '${plugin.name}', which listens to the event '${plugin.event}'.`,
-    "That is not a valid Glean event. Ignoring"
+  log(
+    LOG_TAG,
+    [
+      `Attempted to register plugin '${plugin.name}', which listens to the event '${plugin.event}'.`,
+      "That is not a valid Glean event. Ignoring"
+    ],
+    LoggingLevel.Error
   );
 }
 

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -21,6 +21,9 @@ import TestPlatform from "../platform/test/index.js";
 import { Lifetime } from "./metrics/lifetime.js";
 import { Context } from "./context.js";
 import PingType from "./pings/ping_type.js";
+import log, { LoggingLevel } from "./log.js";
+
+const LOG_TAG = "core.Glean";
 
 class Glean {
   // The Glean singleton.
@@ -179,17 +182,29 @@ class Glean {
     config?: ConfigurationInterface
   ): void {
     if (Context.initialized) {
-      console.warn("Attempted to initialize Glean, but it has already been initialized. Ignoring.");
+      log(
+        LOG_TAG,
+        "Attempted to initialize Glean, but it has already been initialized. Ignoring.",
+        LoggingLevel.Warn
+      );
       return;
     }
 
     if (applicationId.length === 0) {
-      console.error("Unable to initialize Glean, applicationId cannot be an empty string.");
+      log(
+        LOG_TAG,
+        "Unable to initialize Glean, applicationId cannot be an empty string.",
+        LoggingLevel.Error
+      );
       return;
     }
 
     if (!Glean.instance._platform) {
-      console.error("Unable to initialize Glean, environment has not been set.");
+      log(
+        LOG_TAG,
+        "Unable to initialize Glean, environment has not been set.",
+        LoggingLevel.Error
+      );
       return;
     }
 
@@ -316,10 +331,14 @@ class Glean {
   static setUploadEnabled(flag: boolean): void {
     Context.dispatcher.launch(async () => {
       if (!Context.initialized) {
-        console.error(
-          "Changing upload enabled before Glean is initialized is not supported.\n",
-          "Pass the correct state into `Glean.initialize\n`.",
-          "See documentation at https://mozilla.github.io/glean/book/user/general-api.html#initializing-the-glean-sdk`"
+        log(
+          LOG_TAG,
+          [
+            "Changing upload enabled before Glean is initialized is not supported.\n",
+            "Pass the correct state into `Glean.initialize\n`.",
+            "See documentation at https://mozilla.github.io/glean/book/user/general-api.html#initializing-the-glean-sdk`"
+          ],
+          LoggingLevel.Error
         );
         return;
       }
@@ -362,7 +381,7 @@ class Glean {
    */
   static setDebugViewTag(value: string): void {
     if (!Configuration.validateDebugViewTag(value)) {
-      console.error(`Invalid \`debugViewTag\` ${value}. Ignoring.`);
+      log(LOG_TAG, `Invalid \`debugViewTag\` ${value}. Ignoring.`, LoggingLevel.Error);
       return;
     }
 
@@ -388,7 +407,7 @@ class Glean {
    */
   static setSourceTags(value: string[]): void {
     if (!Configuration.validateSourceTags(value)) {
-      console.error(`Invalid \`sourceTags\` ${value.toString()}. Ignoring.`);
+      log(LOG_TAG, `Invalid \`sourceTags\` ${value.toString()}. Ignoring.`, LoggingLevel.Error);
       return;
     }
 
@@ -426,7 +445,8 @@ class Glean {
     // we log a debug message about the change.
     if (Glean.instance._platform && Glean.instance._platform.name !== platform.name) {
       // TODO: Only show this message outside of test mode, and rephrase it as an error (depends on Bug 1682771).
-      console.debug(
+      log(
+        LOG_TAG,
         `Changing Glean platform from "${Glean.platform.name}" to "${platform.name}".`,
       );
     }

--- a/glean/src/core/internal_metrics.ts
+++ b/glean/src/core/internal_metrics.ts
@@ -13,6 +13,9 @@ import type { ConfigurationInterface } from "./config.js";
 import type Platform from "../platform/index.js";
 import type MetricsDatabase from "./metrics/database.js";
 import { Lifetime } from "./metrics/lifetime.js";
+import log, { LoggingLevel } from "./log.js";
+
+const LOG_TAG = "core.InternalMetrics";
 
 /**
  * Glean internal metrics.
@@ -124,7 +127,7 @@ export class CoreMetrics {
           needNewClientId = true;
         }
       } catch {
-        console.warn("Unexpected value found for Glean clientId. Ignoring.");
+        log(LOG_TAG, "Unexpected value found for Glean clientId. Ignoring.", LoggingLevel.Warn);
         needNewClientId = true;
       }
     } else {

--- a/glean/src/core/log.ts
+++ b/glean/src/core/log.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { isString } from "./utils.js";
+
+// The available logging levels for a message.
+export enum LoggingLevel {
+  // Will result in calling the `console.debug` API.
+  Debug = "debug",
+  // Will result in calling the `console.info` API.
+  Info = "info",
+  // Will result in calling the `console.warn` API.
+  Warn = "warn",
+  // Will result in calling the `console.error` API.
+  Error = "error"
+}
+
+/**
+ * Logs a message to the console, tagging it as a message that is coming from Glean.
+ *
+ * # Important
+ *
+ * The message is always logged on the `debug` level.
+ *
+ * @param modulePath The path to the entity which logging this message.
+ *        This should be a dotted camel case string, so spaces. Note that whatever path is
+ *        given here will be prefixed with `Glean.`.
+ * @param message The message to log.
+ * @param level The level in which to log this message, default is LoggingLevel.Debug.
+ */
+export default function log(
+  modulePath: string,
+  message: string | string[],
+  level = LoggingLevel.Debug
+): void {
+  const prefix = `(Glean.${modulePath})`;
+  if (isString(message)) {
+    console[level](prefix, message);
+  } else {
+    console[level](prefix, ...message);
+  }
+}

--- a/glean/src/core/log.ts
+++ b/glean/src/core/log.ts
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { isString } from "./utils.js";
-
 // The available logging levels for a message.
 export enum LoggingLevel {
   // Will result in calling the `console.debug` API.
@@ -35,7 +33,7 @@ export default function log(
   level = LoggingLevel.Debug
 ): void {
   const prefix = `(Glean.${modulePath})`;
-  if (isString(message)) {
+  if (typeof message === "string") {
     console[level](prefix, message);
   } else {
     console[level](prefix, ...message);

--- a/glean/src/core/metrics/database.ts
+++ b/glean/src/core/metrics/database.ts
@@ -11,6 +11,9 @@ import type { JSONObject, JSONValue } from "../utils.js";
 import { createMetric, validateMetricInternalRepresentation } from "./utils.js";
 import { isObject, isUndefined } from "../utils.js";
 import { Lifetime } from "./lifetime.js";
+import log, { LoggingLevel } from "../log.js";
+
+const LOG_TAG = "core.Metrics.Database";
 
 /**
  * Verifies if a given value is a valid Metrics object.
@@ -199,7 +202,11 @@ class MetricsDatabase {
     const storageKey = await metric.identifier(this);
     const value = await store.get([ping, metric.type, storageKey]);
     if (!isUndefined(value) && !validateMetricInternalRepresentation<T>(metric.type, value)) {
-      console.error(`Unexpected value found for metric ${storageKey}: ${JSON.stringify(value)}. Clearing.`);
+      log(
+        LOG_TAG,
+        `Unexpected value found for metric ${storageKey}: ${JSON.stringify(value)}. Clearing.`,
+        LoggingLevel.Error
+      );
       await store.delete([ping, metric.type, storageKey]);
       return;
     } else {
@@ -229,7 +236,11 @@ class MetricsDatabase {
     }
 
     if (!isValidInternalMetricsRepresentation(data)) {
-      console.error(`Unexpected value found for ping ${ping} in ${lifetime} store: ${JSON.stringify(data)}. Clearing.`);
+      log(
+        LOG_TAG,
+        `Unexpected value found for ping ${ping} in ${lifetime} store: ${JSON.stringify(data)}. Clearing.`,
+        LoggingLevel.Error
+      );
       await store.delete([ping]);
       return {};
     }

--- a/glean/src/core/metrics/events_database.ts
+++ b/glean/src/core/metrics/events_database.ts
@@ -7,6 +7,9 @@ import type { JSONArray, JSONObject, JSONValue } from "../utils.js";
 import { isUndefined } from "../utils.js";
 import type EventMetricType from "./types/event.js";
 import type { StorageBuilder } from "../../platform/index.js";
+import log, { LoggingLevel } from "../log.js";
+
+const LOG_TAG = "core.Metric.EventsDatabase";
 
 // An helper type for the 'extra' map.
 export type ExtraMap = Record<string, string>;
@@ -148,7 +151,11 @@ class EventsDatabase {
 
     // We expect arrays!
     if (!Array.isArray(data)) {
-      console.error(`Unexpected value found for ping ${ping}: ${JSON.stringify(data)}. Clearing.`);
+      log(
+        LOG_TAG,
+        `Unexpected value found for ping ${ping}: ${JSON.stringify(data)}. Clearing.`,
+        LoggingLevel.Error
+      );
       await this.eventsStore.delete([ping]);
       return [];
     }

--- a/glean/src/core/metrics/metric.ts
+++ b/glean/src/core/metrics/metric.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import log, { LoggingLevel } from "../log.js";
 import type { JSONValue } from "../utils.js";
+
+const LOG_TAG = "core.Metrics.Metric";
 
 /**
  * The Metric class describes the shared behaviour amongst concrete metrics.
@@ -48,7 +51,11 @@ export abstract class Metric<
    */
   set(v: unknown): void {
     if (!this.validate(v)) {
-      console.error(`Unable to set metric to ${JSON.stringify(v)}. Value is in unexpected format. Ignoring.`);
+      log(
+        LOG_TAG,
+        `Unable to set metric to ${JSON.stringify(v)}. Value is in unexpected format. Ignoring.`,
+        LoggingLevel.Error
+      );
       return;
     }
 

--- a/glean/src/core/pings/database.ts
+++ b/glean/src/core/pings/database.ts
@@ -6,6 +6,9 @@ import type Store from "../storage/index.js";
 import type { JSONObject} from "../utils.js";
 import { isObject, isJSONValue, isString } from "../utils.js";
 import type { StorageBuilder } from "../../platform/index.js";
+import log, { LoggingLevel } from "../log.js";
+
+const LOG_TAG = "core.Pings.Database";
 
 export interface PingInternalRepresentation extends JSONObject {
   path: string,
@@ -128,7 +131,7 @@ class PingsDatabase {
       if (isValidPingInternalRepresentation(ping)) {
         finalPings[identifier] = ping;
       } else {
-        console.warn("Unexpected data found in pings database. Deleting.");
+        log(LOG_TAG, "Unexpected data found in pings database. Deleting.", LoggingLevel.Warn);
         await this.store.delete([identifier]);
       }
     }

--- a/glean/src/core/storage/utils.ts
+++ b/glean/src/core/storage/utils.ts
@@ -2,9 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import log, { LoggingLevel } from "../log.js";
 import type { StorageIndex } from "../storage/index.js";
 import type { JSONObject, JSONValue } from "../utils.js";
 import { isJSONValue, isObject } from "../utils.js";
+
+const LOG_TAG = "core.Storage.Utils";
 
 /**
  * Gets an entry in a given object on a given index.
@@ -80,7 +83,11 @@ export function updateNestedObject(
     target[finalKey] = value;
     return returnObject;
   } catch(e) {
-    console.error("Error while transforming stored value. Ignoring old value.", e);
+    log(
+      LOG_TAG,
+      ["Error while transforming stored value. Ignoring old value.", e],
+      LoggingLevel.Error
+    );
     target[finalKey] = transformFn(undefined);
     return returnObject;
   }

--- a/glean/src/core/utils.ts
+++ b/glean/src/core/utils.ts
@@ -180,7 +180,7 @@ export function getMonotonicNow(): number {
 }
 
 /**
- * Truncates a string to agiven max length.
+ * Truncates a string to a given max length.
  *
  * If the string required truncation, records an error through the error
  * reporting mechanism.

--- a/glean/src/platform/test/storage.ts
+++ b/glean/src/platform/test/storage.ts
@@ -2,10 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import log, { LoggingLevel } from "../../core/log.js";
 import type { StorageIndex } from "../../core/storage/index.js";
 import type Store from "../../core/storage/index.js";
 import { updateNestedObject, getValueFromNestedObject, deleteKeyFromNestedObject } from "../../core/storage/utils.js";
 import type { JSONObject, JSONValue } from "../../core/utils.js";
+
+const LOG_TAG = "plaftom.test.Storage";
 
 // Enable storing the data outside of `MockStore` instances to simulate the
 // behaviour of the other persistent storages.
@@ -54,7 +57,7 @@ class MockStore implements Store {
     try {
       globalStore = deleteKeyFromNestedObject(globalStore, [ this.rootKey, ...index ]);
     } catch (e) {
-      console.warn((e as Error).message, "Ignoring.");
+      log(LOG_TAG, [(e as Error).message, "Ignoring."], LoggingLevel.Warn);
     }
     return Promise.resolve();
   }

--- a/glean/src/platform/webext/storage.ts
+++ b/glean/src/platform/webext/storage.ts
@@ -2,11 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import log, { LoggingLevel } from "../../core/log.js";
 import type { StorageIndex } from "../../core/storage/index.js";
 import type Store from "../../core/storage/index.js";
 import { updateNestedObject, getValueFromNestedObject, deleteKeyFromNestedObject } from "../../core/storage/utils.js";
 import type { JSONArray, JSONObject, JSONPrimitive, JSONValue } from "../../core/utils.js";
 import { isJSONValue, isObject } from "../../core/utils.js";
+
+const LOG_TAG = "platform.webext.Storage";
 
 type WebExtStoreQuery = { [x: string]: WebExtStoreQuery | JSONPrimitive | JSONArray | null; };
 
@@ -112,9 +115,13 @@ class WebExtStore implements Store {
       }
     }
 
-    console.warn(
-      `Unexpected value found in storage for index ${JSON.stringify(index)}. Ignoring.
-      ${JSON.stringify(response, null, 2)}`
+    log(
+      LOG_TAG,
+      [
+        `Unexpected value found in storage for index ${JSON.stringify(index)}. Ignoring.
+        ${JSON.stringify(response, null, 2)}`
+      ],
+      LoggingLevel.Warn
     );
   }
 
@@ -146,7 +153,7 @@ class WebExtStore implements Store {
       );
       return this.store.set(query);
     } catch(e) {
-      console.warn("Ignoring key", e);
+      log(LOG_TAG, ["Ignoring key", e], LoggingLevel.Warn);
     }
   }
 }

--- a/glean/src/platform/webext/uploader.ts
+++ b/glean/src/platform/webext/uploader.ts
@@ -2,9 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import log, { LoggingLevel } from "../../core/log.js";
 import type Uploader from "../../core/upload/uploader.js";
 import type { UploadResult } from "../../core/upload/uploader.js";
 import { DEFAULT_UPLOAD_TIMEOUT_MS, UploadResultStatus } from "../../core/upload/uploader.js";
+
+const LOG_TAG = "platform.webext.Uploader";
 
 class BrowserUploader implements Uploader {
   async post(url: string, body: string, headers: Record<string, string> = {}): Promise<UploadResult> {
@@ -27,7 +30,7 @@ class BrowserUploader implements Uploader {
       // If we time out and call controller.abort,
       // the fetch API will throw a DOMException with name "AbortError".
       if (e instanceof DOMException) {
-        console.error("Timeout while attempting to upload ping.", e);
+        log(LOG_TAG, ["Timeout while attempting to upload ping.\n", e.message], LoggingLevel.Error);
       } else if (e instanceof TypeError) {
         // From MDN: "A fetch() promise will reject with a TypeError
         // when a network error is encountered or CORS is misconfigured on the server-side,
@@ -35,9 +38,9 @@ class BrowserUploader implements Uploader {
         // See: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#checking_that_the_fetch_was_successful
         //
         // We will treat this as we treat server / network errors in this case.
-        console.error("Network error while attempting to upload ping.", e);
+        log(LOG_TAG, ["Network error while attempting to upload ping.\n", e.message], LoggingLevel.Error);
       } else {
-        console.error("Unknown error while attempting to upload ping.", e);
+        log(LOG_TAG, ["Unknown error while attempting to upload ping.\n", e], LoggingLevel.Error);
       }
 
       clearTimeout(timeout);

--- a/glean/tests/unit/core/pings/maker.spec.ts
+++ b/glean/tests/unit/core/pings/maker.spec.ts
@@ -179,7 +179,9 @@ describe("PingMaker", function() {
     const consoleSpy = sandbox.spy(console, "info");
     await PingMaker.collectAndStorePing("ident", ping);
 
-    const loggedPayload = JSON.parse(consoleSpy.lastCall.args[0]) as JSONObject;
+    // Need to get the second argument of the console.info call,
+    // because the first one contains the log tag.
+    const loggedPayload = JSON.parse(consoleSpy.lastCall.args[1]) as JSONObject;
 
     const recordedPing = (await Context.pingsDatabase.getAllPings())["ident"];
     assert.deepStrictEqual(recordedPing.payload, { "you": "got mocked!" });


### PR DESCRIPTION
This allows to easily add functionality to turn debug logs off. Filed a bug for it: https://bugzilla.mozilla.org/show_bug.cgi?id=1715312

We should also audit the levels of these messages, some messages are internal error but are in the Error level. They should really be debug, or trace... Anyways, that can be done as part of the but I created above.