### PR TITLE
Bug 1712080 - Gzip ping paylod before upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * [#411](https://github.com/mozilla/glean.js/pull/411): Tag all messages logged by Glean with the component they are coming from.
 * [#399](https://github.com/mozilla/glean.js/pull/399): Check if there are ping data before attempting to delete it.
   * This change lowers the amount of log messages related to attempting to delete inexistent data.
+* [#415](https://github.com/mozilla/glean.js/pull/415): Gzip ping paylod before upload
+  * This changes the signature of `Uploader.post` to accept `string | Uint8Array` for the `body` parameter, instead of only `string`.
+  * The gizpping functionality is disabled in Qt/QML environments. Follow [Bug 1716322](https://bugzilla.mozilla.org/show_bug.cgi?id=1716322) for updates on the status of this feature on that platform.
 
 # v0.15.0 (2021-06-03)
 

--- a/glean/package-lock.json
+++ b/glean/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.15.0",
       "license": "MPL-2.0",
       "dependencies": {
+        "fflate": "^0.7.0",
         "jose": "^3.7.0",
         "uuid": "^8.3.2"
       },
@@ -2782,6 +2783,11 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.0.tgz",
+      "integrity": "sha512-rL8N1NGlP36Hj8S+h6cyQs1RLKNp40e+BjAelaT738RrhSr9Ud99imQ2be9OYrCsIlnVcTM/Ru6c01YN5cK+dQ=="
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -9659,6 +9665,11 @@
       "requires": {
         "reusify": "^1.0.4"
       }
+    },
+    "fflate": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.0.tgz",
+      "integrity": "sha512-rL8N1NGlP36Hj8S+h6cyQs1RLKNp40e+BjAelaT738RrhSr9Ud99imQ2be9OYrCsIlnVcTM/Ru6c01YN5cK+dQ=="
     },
     "file-entry-cache": {
       "version": "6.0.1",

--- a/glean/package.json
+++ b/glean/package.json
@@ -3,6 +3,7 @@
   "version": "0.15.0",
   "description": "An implementation of the Glean SDK, a modern cross-platform telemetry client, for Javascript environments.",
   "type": "module",
+  "sideEffects": "false",
   "exports": {
     "./package.json": "./package.json",
     "./webext": "./dist/webext/index/webext.js",

--- a/glean/package.json
+++ b/glean/package.json
@@ -51,7 +51,7 @@
     "build:webext:lib": "tsc -p ./tsconfig/webext/index.json",
     "build:webext:types": "tsc -p ./tsconfig/webext/types.json",
     "build:webext": "rm -rf dist/webext && run-s build:webext:lib build:webext:types",
-    "build:qt": "rm -rf dist/qt && webpack --config webpack.config.qt.js --mode production && ../bin/prepare-qml-module.sh",
+    "build:qt": "rm -rf dist/qt && webpack --config webpack.config.qt.js && ../bin/prepare-qml-module.sh",
     "build:docs": "rm -rf dist/docs && typedoc src/ --out dist/docs --tsconfig tsconfig/docs.json --theme minimal",
     "publish:docs": "NODE_DEBUG=gh-pages gh-pages --dotfiles --message \"[skip ci] Updates\" --dist dist/docs",
     "prepublishOnly": "cp ../README.md ./README.md && run-s build:cli build:webext",
@@ -106,6 +106,7 @@
     "webpack-cli": "^4.5.0"
   },
   "dependencies": {
+    "fflate": "^0.7.0",
     "jose": "^3.7.0",
     "uuid": "^8.3.2"
   },

--- a/glean/src/core/upload/uploader.ts
+++ b/glean/src/core/upload/uploader.ts
@@ -47,7 +47,7 @@ export interface Uploader {
    * @param headers Optional header to include in the request
    * @returns The status code of the response.
    */
-  post(url: string, body: string, headers?: Record<string, string>): Promise<UploadResult>;
+  post(url: string, body: string | Uint8Array, headers?: Record<string, string>): Promise<UploadResult>;
 }
 
 export default Uploader;

--- a/glean/src/core/upload/uploader.ts
+++ b/glean/src/core/upload/uploader.ts
@@ -43,7 +43,9 @@ export interface Uploader {
    * Makes a POST request to a given url, with the given headers and body.
    *
    * @param url The URL to make the POST request
-   * @param body The stringified body of this post request
+   * @param body The body of this post request. The body may be a stringified JSON or, most likely,
+   *        a Uint8Array containing the gzipped version of said stringified JSON. We need to accept
+   *        both in case the compression fails.
    * @param headers Optional header to include in the request
    * @returns The status code of the response.
    */

--- a/glean/src/platform/qt/fflate.stub.js
+++ b/glean/src/platform/qt/fflate.stub.js
@@ -10,5 +10,8 @@
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 export function gzipSync() {
+  // We throw here because when the gzipping action throws the ping upload manager will
+  // catch and send the uncompressed ping, which is what we want on QML for the time being.
+  // We are trying to figure out how to actually add the gzipping step to QML on Bug 1716322.
   throw new Error("Attempted to use `gzipSync` from QML, but that is not supported.");
 }

--- a/glean/src/platform/qt/fflate.stub.js
+++ b/glean/src/platform/qt/fflate.stub.js
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * This file is a drop in replacement for `fflate` in QML.
+ * This library raises errors in QML. https://github.com/101arrowz/fflate/issues/71
+ * could be the the culprit, but it is unclear at this point.
+ */
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function gzipSync() {
+  throw new Error("Attempted to use `gzipSync` from QML, but that is not supported.");
+}

--- a/glean/src/platform/test/index.ts
+++ b/glean/src/platform/test/index.ts
@@ -12,7 +12,7 @@ import type Platform from "../index.js";
 
 class MockUploader implements Uploader {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  post(_url: string, _body: string, _headers?: Record<string, string>): Promise<UploadResult> {
+  post(_url: string, _body: string | Uint8Array, _headers?: Record<string, string>): Promise<UploadResult> {
     const result: UploadResult = {
       result: UploadResultStatus.Success,
       status: 200

--- a/glean/src/platform/webext/uploader.ts
+++ b/glean/src/platform/webext/uploader.ts
@@ -10,7 +10,7 @@ import { DEFAULT_UPLOAD_TIMEOUT_MS, UploadResultStatus } from "../../core/upload
 const LOG_TAG = "platform.webext.Uploader";
 
 class BrowserUploader implements Uploader {
-  async post(url: string, body: string, headers: Record<string, string> = {}): Promise<UploadResult> {
+  async post(url: string, body: string | Uint8Array, headers: Record<string, string> = {}): Promise<UploadResult> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), DEFAULT_UPLOAD_TIMEOUT_MS);
 

--- a/glean/tests/unit/plugins/encryption.spec.ts
+++ b/glean/tests/unit/plugins/encryption.spec.ts
@@ -20,6 +20,7 @@ import { UploadResultStatus } from "../../../src/core/upload/uploader";
 import CounterMetricType from "../../../src/core/metrics/types/counter";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
 import { Context } from "../../../src/core/context";
+import { unzipPingPayload } from "../../utils";
 
 const sandbox = sinon.createSandbox();
 
@@ -60,13 +61,13 @@ describe("PingEncryptionPlugin", function() {
 
     const postSpy = sandbox.spy(TestPlatform.uploader, "post").withArgs(
       sinon.match(makePath(Context.applicationId, pingId, ping)),
-      sinon.match.string
+      sinon.match.any
     );
 
     await collectAndStorePing(pingId, ping);
     assert.ok(postSpy.calledOnce);
 
-    const payload = JSON.parse(postSpy.args[0][1]) as JSONObject;
+    const payload = unzipPingPayload(postSpy.args[0][1]);
     assert.ok("payload" in payload);
     assert.ok(typeof payload.payload === "string");
   });
@@ -127,7 +128,7 @@ describe("PingEncryptionPlugin", function() {
 
     const { url, body } = await uploadPromise;
 
-    const parsedBody = JSON.parse(body) as JSONObject;
+    const parsedBody = unzipPingPayload(body);
     const { plaintext, protectedHeader } = await compactDecrypt(
       parsedBody?.payload as string,
       privateKey
@@ -152,3 +153,4 @@ describe("PingEncryptionPlugin", function() {
     assert.ok("typ" in protectedHeader);
   });
 });
+

--- a/glean/tests/utils.ts
+++ b/glean/tests/utils.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gunzipSync } from "fflate";
+
+import type { JSONObject } from "../src/core/utils";
+import { isString } from "../src/core/utils";
+
+/**
+ * Decoded, unzips and parses the ping payload into a JSON object.
+ *
+ * @param payload The payload to process.
+ * @returns The processed payload.
+ */
+export function unzipPingPayload(payload: Uint8Array | string): JSONObject {
+  let parsedBody: JSONObject;
+  if (!isString(payload)) {
+    const decoder = new TextDecoder("utf8");
+    parsedBody = JSON.parse(decoder.decode(gunzipSync(payload))) as JSONObject;
+  } else {
+    parsedBody = JSON.parse(payload) as JSONObject;
+  }
+  return parsedBody;
+}

--- a/glean/webpack.config.qt.js
+++ b/glean/webpack.config.qt.js
@@ -32,6 +32,12 @@ class TsResolvePlugin {
 
 export default {
   entry: "./src/index/qt.ts",
+  mode: "production",
+  optimization: {
+    usedExports: true,
+    providedExports: true,
+    sideEffects: true,
+  },
   module: {
     rules: [
       {
@@ -52,7 +58,10 @@ export default {
     extensions: [ ".tsx", ".ts", ".js" ],
     plugins: [
       new TsResolvePlugin()
-    ]
+    ],
+    alias: {
+      "fflate": path.resolve(__dirname, "src/platform/qt/fflate.stub.js")
+    }
   },
   output: {
     path: path.resolve(__dirname, "dist/qt/org/mozilla/Glean"),


### PR DESCRIPTION
Should I file a bug to document that pings are gzipped? I looked and that is not mentioned on the Glean book. That could be important for folks using custom uploaders for testing, but that could also be behaviour we want to disencourage... Even if we don't disencourage it, we might want to expose the [WaitableHttpClient](https://github.com/mozilla/glean.js/blob/main/glean/tests/integration/schema/schema.spec.ts#L46-L81) in the future. Then people still don't need to worry about gzipping.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/folder`, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint && npm run lint:circular-deps` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
