### PR TITLE
Bug 1716724 - Events treshold for custom pings

### DIFF
--- a/glean/src/core/context.ts
+++ b/glean/src/core/context.ts
@@ -72,6 +72,7 @@ export class Context {
     // The closest thing we can do is making the dispatcher `null`.
     Context.instance._dispatcher = null;
     Context.initialized = false;
+    Context._instance._startTime = new Date();
   }
 
   static get dispatcher(): Dispatcher {

--- a/glean/src/core/context.ts
+++ b/glean/src/core/context.ts
@@ -40,8 +40,12 @@ export class Context {
 
   private _debugOptions!: DebugOptions;
 
+  // The moment the current Glean.js session started.
+  private _startTime: Date;
+
   private constructor() {
     this._initialized = false;
+    this._startTime = new Date();
   }
 
   static get instance(): Context {
@@ -148,5 +152,9 @@ export class Context {
 
   static set debugOptions(options: DebugOptions) {
     Context.instance._debugOptions = options;
+  }
+
+  static get startTime(): Date {
+    return Context._instance._startTime;
   }
 }

--- a/glean/src/core/metrics/events_database.ts
+++ b/glean/src/core/metrics/events_database.ts
@@ -85,15 +85,16 @@ class EventsDatabase {
   /**
    * Records a given event.
    *
-   * @param metric The metric to record to.
+   * @param isDisabled Whether or not the metric is disabled.
+   * @param sendInPings The list of pings to record the event to.
    * @param value The value we want to record to the given metric.
    */
-  async record(metric: EventMetricType, value: RecordedEvent): Promise<void> {
-    if (metric.disabled) {
+  async record(isDisabled: boolean, sendInPings: string[], value: RecordedEvent): Promise<void> {
+    if (isDisabled) {
       return;
     }
 
-    for (const ping of metric.sendInPings) {
+    for (const ping of sendInPings) {
       const transformFn = (v?: JSONValue): JSONArray => {
         const existing: JSONArray = (v as JSONArray) ?? [];
         existing.push(RecordedEvent.toJSONObject(value));

--- a/glean/src/core/metrics/events_database.ts
+++ b/glean/src/core/metrics/events_database.ts
@@ -252,7 +252,7 @@ class EventsDatabase {
    *          `undefined` in case the ping doesn't contain any recorded metrics.
    */
   private getCustomPingEvents(pingData: RecordedEvent[], referenceTime: Date): JSONArray | undefined {
-    // Sort the events by their timestamp.
+    // Sort events by `gleanExecutionCounter`.
     const sortedData = pingData.sort((a, b) => {
       if (a.extra && b.extra) {
         // TODO bug 1693487: remove the stringification once the new events API
@@ -267,10 +267,10 @@ class EventsDatabase {
 
         // Intentionally fall-through in case the two execution counter values are equal.
         // It will perform a timestamp based comparision in that case.
+        // The timestamp check below takes care of any missing `gleanExecutionCounter`(s).
+        // While theoretically possible, it should never happen to have events without a
+        // corresponding `gleanExecutionCounter`.
       }
-
-      // While theoretically possible, it should never happen to have events without a
-      // corresponding gleanExecutionCounter.
       return a.timestamp - b.timestamp;
     });
 

--- a/glean/src/core/metrics/events_database.ts
+++ b/glean/src/core/metrics/events_database.ts
@@ -151,13 +151,13 @@ class EventsDatabase {
           await Context.metricsDatabase.getMetric(PING_INFO_STORAGE, executionCounter) ?? 0;
 
         if (rawEventObject["extra"]) {
-          // TODO: Fixme, remove the stringification once the new events API
+          // TODO bug 1693487: remove the stringification once the new events API
           // is implemented.
           (rawEventObject["extra"] as JSONObject)["gleanExecutionCounter"] = currentExecutionCount.toString();
         } else {
           rawEventObject["extra"] =
           {
-            // TODO: Fixme, remove the stringification once the new events API
+            // TODO bug 1693487: remove the stringification once the new events API
             // is implemented.
             "gleanExecutionCounter": currentExecutionCount.toString()
           };
@@ -255,7 +255,7 @@ class EventsDatabase {
     // Sort the events by their timestamp.
     const sortedData = pingData.sort((a, b) => {
       if (a.extra && b.extra) {
-        // TODO: Fixme, remove the stringification once the new events API
+        // TODO bug 1693487: remove the stringification once the new events API
         // is implemented.
         if(Number(a.extra["gleanExecutionCounter"]) > Number(b.extra["gleanExecutionCounter"])) {
           return 1;

--- a/glean/src/core/metrics/events_database.ts
+++ b/glean/src/core/metrics/events_database.ts
@@ -67,6 +67,8 @@ export class RecordedEvent {
 
     // The following line applies destructuring to return an object without
     // the `gleanStartupDate` and `gleanExecutionCounter` properties.
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {gleanStartupDate, gleanExecutionCounter, ...filteredExtras } = this.extra;
 
     return new RecordedEvent(
@@ -307,17 +309,23 @@ class EventsDatabase {
     }
 
     // Make all the events relative to the first 'glean.restarted' date. Note
-    // that we use the bang operator because we're sure the data is not undefined,
-    // given that we created it a few lines above.
+    // that we use the bang operator and disable the typescript linting rule
+    // because we're sure the data is not undefined, given that we created it
+    // a few lines above.
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     let previousRestartDate = sortedData.shift()!.extra!["gleanStartupDate"];
     let currentOffsetInMs = 0;
 
     sortedData.forEach((event, index) => {
-      if (event.category === "glean" && event.name === "restarted") {
+      if (event.category === "glean"
+          && event.name === "restarted"
+          && event.extra
+          && "gleanStartupDate" in event.extra) {
         // Compute the time difference in milliseconds between this event's startup
         // date and the previous one. Then use it as an offset for the next timestamps.
-        const dateOffsetInMs = Date.parse(event.extra!["gleanStartupDate"]) - Date.parse(previousRestartDate);
-        previousRestartDate = event.extra!["gleanStartupDate"];
+        const dateOffsetInMs = Date.parse(event.extra["gleanStartupDate"]) - Date.parse(previousRestartDate);
+        previousRestartDate = event.extra["gleanStartupDate"];
 
         // Update the current offset and move to the next event.
         currentOffsetInMs += dateOffsetInMs;

--- a/glean/src/core/metrics/events_database.ts
+++ b/glean/src/core/metrics/events_database.ts
@@ -135,9 +135,38 @@ class EventsDatabase {
     }
 
     for (const ping of sendInPings) {
+      // Add an execution counter to all the recorded events.
+      const executionCounter = new CounterMetricType({
+        category: "",
+        name: `${ping}#execution_counter`,
+        sendInPings: [PING_INFO_STORAGE],
+        lifetime: Lifetime.Ping,
+        disabled: false
+      });
+
+      // Note that, at this point, we should always have a valid value stored
+      // for the execution counter. But let's err on the side of caution and
+      // use 1 if that's not the case.
+      const currentExecutionCount =
+        await Context.metricsDatabase.getMetric(PING_INFO_STORAGE, executionCounter) ?? 1;
+
+      const rawEventObject = RecordedEvent.toJSONObject(value);
+      if (rawEventObject["extra"]) {
+        // TODO: Fixme, remove the stringification once the new events API
+        // is implemented.
+        (rawEventObject["extra"] as JSONObject)["gleanExecutionCounter"] = currentExecutionCount.toString();
+      } else {
+        rawEventObject["extra"] =
+        {
+          // TODO: Fixme, remove the stringification once the new events API
+          // is implemented.
+          "gleanExecutionCounter": currentExecutionCount.toString()
+        }
+      }
+
       const transformFn = (v?: JSONValue): JSONArray => {
         const existing: JSONArray = (v as JSONArray) ?? [];
-        existing.push(RecordedEvent.toJSONObject(value));
+        existing.push(rawEventObject);
         return existing;
       };
       await this.eventsStore.update([ping], transformFn);

--- a/glean/src/core/metrics/types/event.ts
+++ b/glean/src/core/metrics/types/event.ts
@@ -60,7 +60,7 @@ class EventMetricType extends MetricType {
         timestamp,
         truncatedExtra,
       );
-      await Context.eventsDatabase.record(this, event);
+      await Context.eventsDatabase.record(this.disabled, this.sendInPings, event);
     });
   }
 

--- a/glean/src/core/pings/maker.ts
+++ b/glean/src/core/pings/maker.ts
@@ -20,9 +20,6 @@ import log, { LoggingLevel } from "../log.js";
 
 const LOG_TAG = "core.Pings.Maker";
 
-// The moment the current Glean.js session started.
-const GLEAN_START_TIME = new Date();
-
 /**
  * Gets, and then increments, the sequence number for a given ping.
  *
@@ -85,7 +82,7 @@ export async function getStartEndTimes(metricsDatabase: MetricsDatabase, ping: C
   if (startTimeData) {
     startTime = new DatetimeMetric(startTimeData);
   } else {
-    startTime = DatetimeMetric.fromDate(GLEAN_START_TIME, TimeUnit.Minute);
+    startTime = DatetimeMetric.fromDate(Context.startTime, TimeUnit.Minute);
   }
 
   // Update the start time with the current time.

--- a/glean/src/core/pings/maker.ts
+++ b/glean/src/core/pings/maker.ts
@@ -21,6 +21,38 @@ import log, { LoggingLevel } from "../log.js";
 const LOG_TAG = "core.Pings.Maker";
 
 /**
+ * Gets the start time metric and its currently stored data.
+ *
+ * @param metricsDatabase The metrics database.
+ * @param ping The ping for which we want to get the times.
+ * @returns An object containing the start time metric and its value.
+ */
+async function getStartTimeMetricAndData(metricsDatabase: MetricsDatabase, ping: CommonPingData): Promise<{startTimeMetric: DatetimeMetricType, startTime: DatetimeMetric}> {
+  const startTimeMetric = new DatetimeMetricType({
+    category: "",
+    name: `${ping.name}#start`,
+    sendInPings: [PING_INFO_STORAGE],
+    lifetime: Lifetime.User,
+    disabled: false
+  }, TimeUnit.Minute);
+
+  // "startTime" is the time the ping was generated the last time.
+  // If not available, we use the date the Glean object was initialized.
+  const startTimeData = await metricsDatabase.getMetric(PING_INFO_STORAGE, startTimeMetric);
+  let startTime: DatetimeMetric;
+  if (startTimeData) {
+    startTime = new DatetimeMetric(startTimeData);
+  } else {
+    startTime = DatetimeMetric.fromDate(Context.startTime, TimeUnit.Minute);
+  }
+
+  return {
+    startTimeMetric,
+    startTime,
+  };
+}
+
+/**
  * Gets, and then increments, the sequence number for a given ping.
  *
  * @param metricsDatabase The metrics database.
@@ -67,27 +99,11 @@ export async function getSequenceNumber(metricsDatabase: MetricsDatabase, ping: 
  * @returns An object containing start and times in their payload format.
  */
 export async function getStartEndTimes(metricsDatabase: MetricsDatabase, ping: CommonPingData): Promise<{ startTime: string, endTime: string }> {
-  const start = new DatetimeMetricType({
-    category: "",
-    name: `${ping.name}#start`,
-    sendInPings: [PING_INFO_STORAGE],
-    lifetime: Lifetime.User,
-    disabled: false
-  }, TimeUnit.Minute);
-
-  // "startTime" is the time the ping was generated the last time.
-  // If not available, we use the date the Glean object was initialized.
-  const startTimeData = await metricsDatabase.getMetric(PING_INFO_STORAGE, start);
-  let startTime: DatetimeMetric;
-  if (startTimeData) {
-    startTime = new DatetimeMetric(startTimeData);
-  } else {
-    startTime = DatetimeMetric.fromDate(Context.startTime, TimeUnit.Minute);
-  }
+  const { startTimeMetric, startTime } = await getStartTimeMetricAndData(metricsDatabase, ping);
 
   // Update the start time with the current time.
   const endTimeData = new Date();
-  await DatetimeMetricType._private_setUndispatched(start, endTimeData);
+  await DatetimeMetricType._private_setUndispatched(startTimeMetric, endTimeData);
   const endTime = DatetimeMetric.fromDate(endTimeData, TimeUnit.Minute);
 
   return {
@@ -191,8 +207,9 @@ export function getPingHeaders(debugOptions?: DebugOptions): Record<string, stri
  *          If there is no data stored for the ping, `undefined` is returned.
  */
 export async function collectPing(metricsDatabase: MetricsDatabase, eventsDatabase: EventsDatabase, ping: CommonPingData, reason?: string): Promise<PingPayload | undefined> {
+  const { startTime } = await getStartTimeMetricAndData(metricsDatabase, ping);
   const metricsData = await metricsDatabase.getPingMetrics(ping.name, true);
-  const eventsData = await eventsDatabase.getPingEvents(ping.name, true);
+  const eventsData = await eventsDatabase.getPingEvents(ping.name, true, startTime.date);
   if (!metricsData && !eventsData) {
     if (!ping.sendIfEmpty) {
       log(LOG_TAG, `Storage for ${ping.name} empty. Bailing out.`, LoggingLevel.Info);

--- a/glean/src/metrics.yaml
+++ b/glean/src/metrics.yaml
@@ -244,6 +244,7 @@ glean.internal.metrics:
 
   start_time:
     type: datetime
+    time_unit: minute
     lifetime: user
     send_in_pings:
       - glean_internal_info
@@ -262,6 +263,7 @@ glean.internal.metrics:
 
   end_time:
     type: datetime
+    time_unit: minute
     lifetime: ping
     send_in_pings:
       - glean_internal_info
@@ -357,3 +359,34 @@ glean.error:
       - all-pings
     no_lint:
       - COMMON_PREFIX
+
+glean:
+  restarted:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - all-pings
+    description: |
+      TODO
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1716724
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+    extra_keys:
+      glean_startup_date:
+        description: |
+          This is a special key holding the Glean startup date and time,
+          with the same precision as `ping_info.start_time` (minutes), to
+          be used to approximate the time between the ping `start_time`
+          and this restart event when assembling the ping.
+        type: string
+      glean_execution_counter:
+        description: |
+          This is a special key holding the number of times Glean was
+          initialized up to the moment this event gets injected.
+        type: quantity

--- a/glean/tests/unit/core/metrics/events_database.spec.ts
+++ b/glean/tests/unit/core/metrics/events_database.spec.ts
@@ -95,7 +95,7 @@ describe("EventsDatabase", function() {
     let snapshot = await db.getPingEvents("store1", false);
     assert.strictEqual(snapshot, undefined);
 
-    await db.record(metric, new RecordedEvent(
+    await db.record(metric.disabled, metric.sendInPings, new RecordedEvent(
       "telemetry",
       "test_event_clear",
       1000,
@@ -131,19 +131,19 @@ describe("EventsDatabase", function() {
       disabled: false
     });
 
-    await db.record(metric, new RecordedEvent(
+    await db.record(metric.disabled, metric.sendInPings, new RecordedEvent(
       metric.category,
       metric.name,
       1000,
     ));
 
-    await db.record(metric, new RecordedEvent(
+    await db.record(metric.disabled, metric.sendInPings, new RecordedEvent(
       metric.category,
       metric.name,
       100,
     ));
 
-    await db.record(metric, new RecordedEvent(
+    await db.record(metric.disabled, metric.sendInPings, new RecordedEvent(
       metric.category,
       metric.name,
       10000,


### PR DESCRIPTION
This work in progress PR is a first attempt at implementing [this proposal](https://docs.google.com/document/d/1R-tIZYz4Izx8rDB_YUiJXU9Xtk8VcJoF8Pmhggps_GU/edit?ts=60992051#).

TODO

- [x] Compute the timestamps relative to the reference data.
- [x] Add unit tests.
- [ ] Add integration tests.
- [ ] Update documentation.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/folder`, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint && npm run lint:circular-deps` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
