### PR TITLE
RFC: Bug 1702208: Reuse WaitableHttpClient in schema tests for other test …

### DIFF
--- a/glean/src/platform/test/waitable_uploader.ts
+++ b/glean/src/platform/test/waitable_uploader.ts
@@ -1,0 +1,54 @@
+import Uploader, { UploadResult, UploadResultStatus } from "../../core/upload/uploader";
+import { JSONObject } from "../../core/utils";
+import { unzipPingPayload } from "../../../tests/utils";
+
+/**
+ * A Glean mock HTTP which allows one to wait for a specific ping submission.
+ */
+class WaitableUploader implements Uploader {
+  private waitingForName?: string;
+  private waitingForPath? : string;
+  private waitResolver?: (pingBody: JSONObject) => void;
+
+  /**
+   * Returns a promise that resolves once a ping is submitted or times out after a 2s wait.
+   *
+   * @param name The name of the ping to wait for.
+   * @param path
+   * @returns A promise that resolves once a ping is submitted or times out after a 2s wait.
+   */
+  waitForPingSubmission(name: string, path?: string): Promise<JSONObject> {
+    this.waitingForName = name;
+    this.waitingForPath = path;
+    return new Promise<JSONObject>((resolve, reject) => {
+      this.waitResolver = (pingBody: JSONObject) => {
+        this.waitingForName = undefined;
+        this.waitingForPath = undefined;
+        // Uncomment for debugging the ping payload.
+        // console.log(JSON.stringify(pingBody, null, 2));
+        resolve(pingBody);
+      };
+
+      setTimeout(() => reject(), 2000);
+    });
+  }
+
+  post(url: string, body: string): Promise<UploadResult> {
+    if (this.waitingForPath) {
+      if (url.includes(this.waitingForPath)) {
+        this.waitResolver?.(unzipPingPayload(body));
+      } else {
+        return Promise.reject(new Error('The submitted ping is not from the url we are waiting for.'));
+      }
+    } else if (this.waitingForName && url.includes(this.waitingForName)) {
+      this.waitResolver?.(unzipPingPayload(body));
+    }
+
+    return Promise.resolve({
+      result: UploadResultStatus.Success,
+      status: 200
+    });
+  }
+}
+
+export default WaitableUploader

--- a/glean/tests/unit/plugins/encryption.spec.ts
+++ b/glean/tests/unit/plugins/encryption.spec.ts
@@ -12,6 +12,7 @@ import Glean from "../../../src/core/glean";
 import PingType from "../../../src/core/pings/ping_type";
 import type { JSONObject } from "../../../src/core/utils";
 import TestPlatform from "../../../src/platform/test";
+import WaitableUploader from "../../../src/platform/test/waitable_uploader";
 import PingEncryptionPlugin from "../../../src/plugins/encryption";
 import collectAndStorePing, { makePath } from "../../../src/core/pings/maker";
 import type { UploadResult} from "../../../src/core/upload/uploader";
@@ -36,6 +37,20 @@ describe("PingEncryptionPlugin", function() {
   });
 
   it("collect and store triggers the AfterPingCollection and deals with possible result correctly", async function () {
+    const pingId = "ident";
+    const ping = new PingType({
+      name: "test",
+      includeClientId: false,
+      sendIfEmpty: true,
+    });
+
+    const path = makePath(Context.applicationId, pingId, ping);
+    const mockUploader = new WaitableUploader();
+    const postSpy = sandbox.spy(mockUploader, "post");
+    // const wrongPingID = "wrong";
+    // const wrongPath = makePath(Context.applicationId, wrongPingID, ping);
+    const pingBody  = mockUploader.waitForPingSubmission("test", path);
+
     await Glean.testResetGlean(
       testAppId,
       true,
@@ -48,24 +63,13 @@ describe("PingEncryptionPlugin", function() {
             "x": "Q20tsJdrryWJeuPXTM27wIPb_YbsdYPpkK2N9O6aXwM",
             "y": "1onW1swaCcN1jkmkIwhXpCm55aMP8GRJln5E8WQKLJk"
           })
-        ]
+        ],
+        httpClient: mockUploader,
       }
     );
 
-    const ping = new PingType({
-      name: "test",
-      includeClientId: true,
-      sendIfEmpty: true,
-    });
-    const pingId = "ident";
-
-    const postSpy = sandbox.spy(TestPlatform.uploader, "post").withArgs(
-      sinon.match(makePath(Context.applicationId, pingId, ping)),
-      sinon.match.any
-    );
-
     await collectAndStorePing(pingId, ping);
-    assert.ok(postSpy.calledOnce);
+    await pingBody;
 
     const payload = unzipPingPayload(postSpy.args[0][1]);
     assert.ok("payload" in payload);


### PR DESCRIPTION
…files
Coming back a bit late, and here's the draft PR.
I didn't add much new stuff to `WaitableUploader`, of which the code is largely borrowed from the `waitableHttpClient`.
After looking into the places where `testBeforeNextSubmit`, I am not sure where's the pitfall of this - `testBeforeNextSubmit` allows the ping to assert the state or value of other variables in the test scope, and it looks fine to me.

Also, it seems like this [test case](https://github.com/mozilla/glean.js/blob/88a349c651e3c2a76dba00ebff458270fc7400f0/glean/tests/unit/core/pings/ping_type.spec.ts#L244), which is expected to fail, actually succeeded if I comment out [this line](https://github.com/mozilla/glean.js/blob/88a349c651e3c2a76dba00ebff458270fc7400f0/glean/tests/unit/core/pings/ping_type.spec.ts#L266).

It would be great if people can provide some feedback and what they would like to see.
Thank you!

* Changelog not modified, as this bug only concerns tests.

This PR does not include test(s) 
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/folder`, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint && npm run lint:circular-deps` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
