### PR TITLE
Bug 1712922 - Implement ping body size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#431](https://github.com/mozilla/glean.js/pull/431): BUGFIX: Record the timestamp for events before dispatching to the internal task queue.
 * [#462](https://github.com/mozilla/glean.js/pull/462): Implement Storage module for Qt/QML platform.
 * [#466](https://github.com/mozilla/glean.js/pull/466): Expose `ErrorType` enum, for using with the `testGetNumRecordedErrors` API.
+* [#497](https://github.com/mozilla/glean.js/pull/497): Implement limit of 1MB for ping request payload. Limit is calculated after gzip compression.
 
 # v0.15.0 (2021-06-03)
 

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -249,7 +249,6 @@ class Glean {
       // This is fine, we are inside a dispatched task that is guaranteed to run before any
       // other task. No external API call will be executed before we leave this task.
       Context.initialized = true;
-      Glean.pingUploader.setInitialized(true);
 
       // The upload enabled flag may have changed since the last run, for
       // example by the changing of a config file.

--- a/glean/src/core/upload/index.ts
+++ b/glean/src/core/upload/index.ts
@@ -162,11 +162,9 @@ class PingUploader implements PingsDatabaseObserver {
       finalBody = gzipSync(encodedBody);
       bodySizeInBytes = finalBody.length;
       headers["Content-Encoding"] = "gzip";
-      headers["Content-Length"] = finalBody.length.toString();
     } catch {
       finalBody = stringifiedBody;
       bodySizeInBytes = encodedBody.length;
-      headers["Content-Length"] = stringifiedBody.length.toString();
     }
 
     if (bodySizeInBytes > this.policy.maxPingBodySize) {
@@ -175,6 +173,7 @@ class PingUploader implements PingsDatabaseObserver {
       );
     }
 
+    headers["Content-Length"] = bodySizeInBytes.toString();
     return {
       headers,
       payload: finalBody

--- a/glean/src/core/upload/index.ts
+++ b/glean/src/core/upload/index.ts
@@ -11,11 +11,21 @@ import log, { LoggingLevel } from "../log.js";
 import type { Observer as PingsDatabaseObserver, PingInternalRepresentation } from "../pings/database.js";
 import type PingsDatabase from "../pings/database.js";
 import type PlatformInfo from "../platform_info.js";
-import type { UploadResult} from "./uploader.js";
+import type { UploadResult } from "./uploader.js";
 import type Uploader from "./uploader.js";
 import { UploadResultStatus } from "./uploader.js";
 
 const LOG_TAG = "core.Upload";
+
+/**
+ * Policies for ping storage, uploading and requests.
+ */
+export class Policy {
+  constructor (
+    // The maximum size in bytes a ping body may have to be eligible for upload.
+    readonly maxPingBodySize: number = 1024 * 1024 // 1MB
+  ) {}
+}
 
 interface QueuedPing extends PingInternalRepresentation {
   identifier: string
@@ -31,6 +41,14 @@ const enum PingUploaderStatus {
   Uploading,
   // Currently processing a signal to stop uploading pings.
   Cancelling,
+}
+
+// Error to be thrown in case the final ping body is larger than MAX_PING_BODY_SIZE.
+class PingBodyOverflowError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "PingBodyOverflow";
+  }
 }
 
 /**
@@ -57,13 +75,17 @@ class PingUploader implements PingsDatabaseObserver {
 
   private readonly platformInfo: PlatformInfo;
   private readonly serverEndpoint: string;
-  private readonly pingsDatabase: PingsDatabase;
 
   // Whether or not Glean was initialized, as reported by the
   // singleton object.
   private initialized = false;
 
-  constructor(config: Configuration, platform: Platform, pingsDatabase: PingsDatabase) {
+  constructor(
+    config: Configuration,
+    platform: Platform,
+    private readonly pingsDatabase: PingsDatabase,
+    private readonly policy = new Policy
+  ) {
     this.queue = [];
     this.status = PingUploaderStatus.Idle;
     // Initialize the ping uploader with either the platform defaults or a custom
@@ -139,21 +161,34 @@ class PingUploader implements PingsDatabaseObserver {
     };
 
     const stringifiedBody = JSON.stringify(ping.payload);
+    // We prefer using `strToU8` instead of TextEncoder directly,
+    // because it will polyfill TextEncoder if it's not present in the environment.
+    // Environments that don't provide TextEncoder are IE and most importantly QML.
+    const encodedBody = strToU8(stringifiedBody);
+
+    let finalBody: string | Uint8Array;
+    let bodySizeInBytes: number;
     try {
-      const compressedBody = gzipSync(strToU8(stringifiedBody));
+      finalBody = gzipSync(encodedBody);
+      bodySizeInBytes = finalBody.length;
       headers["Content-Encoding"] = "gzip";
-      headers["Content-Length"] = compressedBody.length.toString();
-      return {
-        headers,
-        payload: compressedBody
-      };
+      headers["Content-Length"] = finalBody.length.toString();
     } catch {
+      finalBody = stringifiedBody;
+      bodySizeInBytes = encodedBody.length;
       headers["Content-Length"] = stringifiedBody.length.toString();
-      return {
-        headers,
-        payload: stringifiedBody
-      };
     }
+
+    if (bodySizeInBytes > this.policy.maxPingBodySize) {
+      throw new PingBodyOverflowError(
+        `Body for ping ${ping.identifier} exceeds ${this.policy.maxPingBodySize}bytes. Discarding.`
+      );
+    }
+
+    return {
+      headers,
+      payload: finalBody
+    };
   }
 
   /**
@@ -172,17 +207,24 @@ class PingUploader implements PingsDatabaseObserver {
       return { result: UploadResultStatus.RecoverableFailure };
     }
 
-    const finalPing = await this.preparePingForUpload(ping);
-    const result = await this.uploader.post(
-      // We are sure that the applicationId is not `undefined` at this point,
-      // this function is only called when submitting a ping
-      // and that function return early when Glean is not initialized.
-      `${this.serverEndpoint}${ping.path}`,
-      finalPing.payload,
-      finalPing.headers
-    );
-
-    return result;
+    try {
+      const finalPing = await this.preparePingForUpload(ping);
+      return await this.uploader.post(
+        // We are sure that the applicationId is not `undefined` at this point,
+        // this function is only called when submitting a ping
+        // and that function return early when Glean is not initialized.
+        `${this.serverEndpoint}${ping.path}`,
+        finalPing.payload,
+        finalPing.headers
+      );
+    } catch(e) {
+      log(LOG_TAG, ["Error trying to build ping request:", e], LoggingLevel.Warn);
+      // An unrecoverable failure will make sure the offending ping is removed from the queue and
+      // deleted from the database, which is what we want here.
+      return {
+        result: UploadResultStatus.UnrecoverableFailure
+      };
+    }
   }
 
   /**
@@ -232,7 +274,7 @@ class PingUploader implements PingsDatabaseObserver {
     if (result === UploadResultStatus.UnrecoverableFailure || (status && status >= 400 && status < 500)) {
       log(
         LOG_TAG,
-        `Unrecoverable upload failure while attempting to send ping ${identifier}. Error was ${status ?? "no status"}.`,
+        `Unrecoverable upload failure while attempting to send ping ${identifier}. Error was: ${status ?? "no status"}.`,
         LoggingLevel.Warn
       );
       await this.pingsDatabase.deletePing(identifier);

--- a/glean/src/core/upload/index.ts
+++ b/glean/src/core/upload/index.ts
@@ -23,6 +23,10 @@ const LOG_TAG = "core.Upload";
  */
 export class Policy {
   constructor (
+    // The maximum recoverable failures allowed per uploading window.
+    //
+    // Limiting this is necessary to avoid infinite loops on requesting upload tasks.
+    readonly maxRecoverableFailures: number = 3,
     // The maximum size in bytes a ping body may have to be eligible for upload.
     readonly maxPingBodySize: number = 1024 * 1024 // 1MB
   ) {}
@@ -289,7 +293,7 @@ class PingUploader implements PingsDatabaseObserver {
         this.enqueuePing(nextPing);
       }
 
-      if (retries >= 3) {
+      if (retries >= this.policy.maxRecoverableFailures) {
         log(
           LOG_TAG,
           "Reached maximum recoverable failures for the current uploading window. You are done.",

--- a/glean/tests/unit/core/upload/index.spec.ts
+++ b/glean/tests/unit/core/upload/index.spec.ts
@@ -195,9 +195,23 @@ describe("PingUploader", function() {
       status: 500,
       result: UploadResultStatus.Success
     }));
-    await fillUpPingsDatabase(1);
 
-    await waitForUploader();
+    // Create a new ping uploader with a fixed max recoverable failures limit.
+    const uploader = new PingUploader(
+      new Configuration(),
+      Glean.platform,
+      Context.pingsDatabase,
+      new Policy(
+        3, // maxRecoverableFailures
+      )
+    );
+
+    // Overwrite the Glean ping uploader with the test one.
+    Context.pingsDatabase.attachObserver(uploader);
+
+    await fillUpPingsDatabase(1);
+    await waitForUploader(uploader);
+
     assert.strictEqual(stub.callCount, 3);
   });
 

--- a/glean/tests/unit/core/upload/index.spec.ts
+++ b/glean/tests/unit/core/upload/index.spec.ts
@@ -83,7 +83,6 @@ describe("PingUploader", function() {
 
     // Create a new uploader and attach it to the existing storage.
     const uploader = new PingUploader(new Configuration(), Glean.platform, Context.pingsDatabase);
-    uploader.setInitialized();
     Context.pingsDatabase.attachObserver(uploader);
 
     // Mock the 'triggerUpload' function so that 'scanPendingPings' does not
@@ -117,7 +116,6 @@ describe("PingUploader", function() {
     await fillUpPingsDatabase(10);
 
     const uploader = new PingUploader(new Configuration(), Glean.platform, Context.pingsDatabase);
-    uploader.setInitialized();
     Context.pingsDatabase.attachObserver(uploader);
     await Context.pingsDatabase.scanPendingPings();
 

--- a/glean/tests/unit/core/upload/index.spec.ts
+++ b/glean/tests/unit/core/upload/index.spec.ts
@@ -41,7 +41,7 @@ async function fillUpPingsDatabase(numPings: number): Promise<string[]> {
  * Waits for a PingUploader to end its uploading job,
  * if it's actualy doing any.
  *
- * By default will sait for the uploader on the Glean singleton.
+ * By default will wait for the uploader on the Glean singleton.
  *
  * @param uploader The uploader to wait for.
  */

--- a/glean/tests/unit/core/upload/index.spec.ts
+++ b/glean/tests/unit/core/upload/index.spec.ts
@@ -11,7 +11,7 @@ import { Context } from "../../../../src/core/context";
 import Glean from "../../../../src/core/glean";
 import PingType from "../../../../src/core/pings/ping_type";
 import { collectAndStorePing } from "../../../../src/core/pings/maker";
-import PingUploader from "../../../../src/core/upload";
+import PingUploader, { Policy } from "../../../../src/core/upload";
 import { UploadResultStatus } from "../../../../src/core/upload/uploader";
 
 const sandbox = sinon.createSandbox();
@@ -38,12 +38,16 @@ async function fillUpPingsDatabase(numPings: number): Promise<string[]> {
 }
 
 /**
- * Waits for the uploader on the Glean singleton to end its uploading job,
+ * Waits for a PingUploader to end its uploading job,
  * if it's actualy doing any.
+ *
+ * By default will sait for the uploader on the Glean singleton.
+ *
+ * @param uploader The uploader to wait for.
  */
-async function waitForGleanUploader(): Promise<void> {
-  if (Glean["pingUploader"]["currentJob"]) {
-    await Glean["pingUploader"]["currentJob"];
+async function waitForUploader(uploader = Glean["pingUploader"]): Promise<void> {
+  if (uploader["currentJob"]) {
+    await uploader["currentJob"];
   }
 }
 
@@ -104,7 +108,7 @@ describe("PingUploader", function() {
   it("if multiple pings are enqueued subsequently, we don't attempt to upload each ping more than once", async function () {
     const spy = sandbox.spy(Glean.platform.uploader, "post");
     await fillUpPingsDatabase(100);
-    await waitForGleanUploader();
+    await waitForUploader();
     assert.strictEqual(spy.callCount, 100);
   });
 
@@ -132,7 +136,7 @@ describe("PingUploader", function() {
     // as the default exported mock already returns a success response always.
     await fillUpPingsDatabase(10);
 
-    await waitForGleanUploader();
+    await waitForUploader();
     assert.deepStrictEqual(await Context.pingsDatabase.getAllPings(), {});
     assert.strictEqual(Glean["pingUploader"]["queue"].length, 0);
   });
@@ -145,7 +149,7 @@ describe("PingUploader", function() {
     }));
     await fillUpPingsDatabase(10);
 
-    await waitForGleanUploader();
+    await waitForUploader();
     assert.deepStrictEqual(await Context.pingsDatabase.getAllPings(), {});
     assert.strictEqual(Glean["pingUploader"]["queue"].length, 0);
   });
@@ -158,7 +162,7 @@ describe("PingUploader", function() {
     }));
     await fillUpPingsDatabase(1);
 
-    await waitForGleanUploader();
+    await waitForUploader();
     // Ping should still be there.
     const allPings = await Context.pingsDatabase.getAllPings();
     assert.deepStrictEqual(Object.keys(allPings).length, 1);
@@ -195,15 +199,40 @@ describe("PingUploader", function() {
     }));
     await fillUpPingsDatabase(1);
 
-    await waitForGleanUploader();
+    await waitForUploader();
     assert.strictEqual(stub.callCount, 3);
+  });
+
+  it("pings which exceed max ping body size are not sent", async function () {
+    // Create a new ping uploader with a very low max ping body size,
+    // so that virtually any ping body will throw an error.
+    const uploader = new PingUploader(
+      new Configuration(),
+      Glean.platform,
+      Context.pingsDatabase,
+      new Policy(
+        3, // maxRecoverableFailures
+        1 // maxPingBodySize
+      )
+    );
+
+    // Overwrite the Glean ping uploader with the test one.
+    Context.pingsDatabase.attachObserver(uploader);
+
+    const spy = sandbox.spy(Glean.platform.uploader, "post");
+    // Add a bunch of pings to the database, in order to trigger upload attempts on the uploader.
+    await fillUpPingsDatabase(10);
+    await waitForUploader(uploader);
+
+    // Check that none of those pings were actually sent.
+    assert.strictEqual(spy.callCount, 0);
   });
 
   it("correctly build ping request", async function () {
     const postSpy = sandbox.spy(Glean.platform.uploader, "post");
 
     const expectedDocumentId = (await fillUpPingsDatabase(1))[0];
-    await waitForGleanUploader();
+    await waitForUploader();
 
     const url = postSpy.firstCall.args[0].split("/");
     const appId = url[url.length - 4];


### PR DESCRIPTION
Fun fact: [we basically never reach this limit with glean-core](https://sql.telemetry.mozilla.org/queries/80821/source).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint && npm run lint:circular-deps` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
