### PR TITLE
Bug 1719315 - Implement the URL metric type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.16.0...main)
 
+* [#529](https://github.com/mozilla/glean.js/pull/529): Implement the URL metric type.
+
 # v0.16.0 (2021-07-06)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.15.0...v0.16.0)

--- a/benchmarks/size/webext/max.js
+++ b/benchmarks/size/webext/max.js
@@ -13,6 +13,7 @@ import QuantityMetricType from "@mozilla/glean/webext/private/metrics/quantity";
 import StringMetricType from "@mozilla/glean/webext/private/metrics/string";
 import TimespanMetricType from "@mozilla/glean/webext/private/metrics/timespan";
 import UUIDMetricType from "@mozilla/glean/webext/private/metrics/uuid";
+import URLMetricType from "@mozilla/glean/webext/private/metrics/url";
 // Plugins
 import PingEncryptionPlugin from "@mozilla/glean/webext/plugins/encryption";
 

--- a/docs/adding_a_new_metric_type.md
+++ b/docs/adding_a_new_metric_type.md
@@ -169,6 +169,9 @@ async function testGetValue(ping: string = this.sendInPings[0]): Promise<string 
 
 > **Note**: All testing functions must start with the prefix `test`.
 
+The `testGetNumRecordedErrors` function does not need to be implemeted individually per metric
+type as it is already implemented on the `MetricType` super class.
+
 ## Testing
 
 Tests for metric type implementations live under the `glean/tests/unit/core/metrics/types` folder. Create a new

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -19,7 +19,7 @@ const LOG_TAG = "CLI";
 const VIRTUAL_ENVIRONMENT_DIR = ".venv";
 
 // The version of glean_parser to install from PyPI.
-const GLEAN_PARSER_VERSION = "3.5.0";
+const GLEAN_PARSER_VERSION = "3.7.0";
 
 // This script runs a given Python module as a "main" module, like
 // `python -m module`. However, it first checks that the installed

--- a/glean/src/core/metrics/types/timespan.ts
+++ b/glean/src/core/metrics/types/timespan.ts
@@ -197,7 +197,7 @@ class TimespanMetricType extends MetricType {
         await Context.errorManager.record(
           this,
           ErrorType.InvalidState,
-          "Timespan not running"
+          "Timespan not running."
         );
         return;
       }

--- a/glean/src/core/metrics/types/url.ts
+++ b/glean/src/core/metrics/types/url.ts
@@ -126,6 +126,11 @@ class UrlMetricType extends MetricType {
    *
    * Gets the currently stored value as a string.
    *
+   * # Note
+   *
+   * Although URL metrics are URI encoded in the ping payload,
+   * this function will return the unencoded URL for convenience.
+   *
    * This doesn't clear the stored value.
    *
    * TODO: Only allow this function to be called on test mode (depends on Bug 1682771).

--- a/glean/src/core/metrics/types/url.ts
+++ b/glean/src/core/metrics/types/url.ts
@@ -15,7 +15,7 @@ const URL_MAX_LENGTH = 2048;
 // This regex only validates that the `scheme` part of the URL is spec compliant
 // and is followed by a ":". After that anything is accepted.
 //
-// Reference: https://url.spec.whatwg.org/#url-scheme-string.
+// Reference: https://url.spec.whatwg.org/#url-scheme-string
 const URL_VALIDATION_REGEX = /^[a-zA-Z][a-zA-Z0-9-\+\.]*:(.*)$/;
 
 /**
@@ -41,7 +41,7 @@ export class UrlMetric extends Metric<string, string> {
    * 3. The URL must not be a data URL.
    * 4. Every URL must start with a valid scheme.
    *
-   * Note**: We explicitly to not validate if the URL is fully spec compliant,
+   * **Note**: We explicitly do not validate if the URL is fully spec compliant,
    * the above validations are all that is done.
    *
    * @param v The value to validate.

--- a/glean/src/core/metrics/types/url.ts
+++ b/glean/src/core/metrics/types/url.ts
@@ -41,11 +41,11 @@ export class UrlMetric extends Metric<string, string> {
    * 3. The URL must not be a data URL.
    * 4. Every URL must start with a valid scheme.
    *
-   * **Note**: We explicitly do not validate if the URL is fully spec compliant,
+   * Note: We explicitly do not validate if the URL is fully spec compliant,
    * the above validations are all that is done.
    *
    * @param v The value to validate.
-   * @returns Whether or not v is a
+   * @returns Whether or not v is a valid URL-like string.
    */
   validate(v: unknown): v is string {
     if (!isString(v)) {

--- a/glean/src/core/metrics/types/url.ts
+++ b/glean/src/core/metrics/types/url.ts
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { CommonMetricData } from "../index.js";
+import { isString } from "../../utils.js";
+import { MetricType } from "../index.js";
+import { Context } from "../../context.js";
+import { Metric } from "../metric.js";
+import { ErrorType } from "../../error/error_type.js";
+
+// The maximum number of characters a URL Metric may have, before encoding.
+const URL_MAX_LENGTH = 2048;
+
+// This regex only validates that the `scheme` part of the URL is spec compliant
+// and is followed by a ":". After that anything is accepted.
+//
+// Reference: https://url.spec.whatwg.org/#url-scheme-string.
+const URL_VALIDATION_REGEX = /^[a-zA-Z][a-zA-Z0-9-\+\.]*:(.*)$/;
+
+/**
+ * Error thrown when there is a URL validation error that also yields error recording.
+ */
+class UrlMetricError extends Error {
+  constructor(readonly type: ErrorType, message?: string) {
+    super(message);
+    this.name = "UrlMetricError";
+  }
+}
+
+export class UrlMetric extends Metric<string, string> {
+  constructor(v: unknown) {
+    super(v);
+  }
+
+  /**
+   * Validates that a given value is a valid URL metric value.
+   *
+   * 1. The URL must be a string.
+   * 2. The URL must have a maximum length of URL_MAX_LENGTH characters before the encoding.
+   * 3. The URL must not be a data URL.
+   * 4. Every URL must start with a valid scheme.
+   *
+   * Note**: We explicitly to not validate if the URL is fully spec compliant,
+   * the above validations are all that is done.
+   *
+   * @param v The value to validate.
+   * @returns Whether or not v is a
+   */
+  validate(v: unknown): v is string {
+    if (!isString(v)) {
+      return false;
+    }
+
+    if (v.length > URL_MAX_LENGTH) {
+      throw new UrlMetricError(
+        ErrorType.InvalidOverflow,
+        `URL length ${v.length} exceeds maximum of ${URL_MAX_LENGTH}.`
+      );
+    }
+
+    if (v.startsWith("data:")) {
+      throw new UrlMetricError(ErrorType.InvalidValue, "URL metric does not support data URLs.");
+    }
+
+
+    if (!URL_VALIDATION_REGEX.test(v)) {
+      throw new UrlMetricError(
+        ErrorType.InvalidValue, `"${v}" does not start with a valid URL scheme.`
+      );
+    }
+
+    return true;
+  }
+
+  payload(): string {
+    return encodeURI(this._inner);
+  }
+}
+
+/**
+ * A URL metric.
+ */
+class UrlMetricType extends MetricType {
+  constructor(meta: CommonMetricData) {
+    super("url", meta);
+  }
+
+  /**
+   * Sets to a specified value.
+   *
+   * @param url the value to set.
+   */
+  set(url: string): void {
+    Context.dispatcher.launch(async () => {
+      if (!this.shouldRecord(Context.uploadEnabled)) {
+        return;
+      }
+
+      try {
+        const metric = new UrlMetric(url);
+        await Context.metricsDatabase.record(this, metric);
+      } catch (e) {
+        if (e instanceof UrlMetricError) {
+          await Context.errorManager.record(
+            this,
+            e.type,
+            e.message
+          );
+        }
+      }
+    });
+  }
+
+  /**
+   * Sets to a specified URL value.
+   *
+   * @param url the value to set.
+   */
+  setUrl(url: URL): void {
+    this.set(url.toString());
+  }
+
+  /**
+   * Test-only API.**
+   *
+   * Gets the currently stored value as a string.
+   *
+   * This doesn't clear the stored value.
+   *
+   * TODO: Only allow this function to be called on test mode (depends on Bug 1682771).
+   *
+   * @param ping the ping from which we want to retrieve this metrics value from.
+   *        Defaults to the first value in `sendInPings`.
+   * @returns The value found in storage or `undefined` if nothing was found.
+   */
+  async testGetValue(ping: string = this.sendInPings[0]): Promise<string | undefined> {
+    let metric: string | undefined;
+    await Context.dispatcher.testLaunch(async () => {
+      metric = await Context.metricsDatabase.getMetric<string>(ping, this);
+    });
+    return metric;
+  }
+}
+
+export default UrlMetricType;

--- a/glean/src/core/metrics/utils.ts
+++ b/glean/src/core/metrics/utils.ts
@@ -13,6 +13,7 @@ import { DatetimeMetric } from "./types/datetime.js";
 import { QuantityMetric } from "./types/quantity.js";
 import { StringMetric } from "./types/string.js";
 import { TimespanMetric } from "./types/timespan.js";
+import { UrlMetric } from "./types/url.js";
 import { UUIDMetric } from "./types/uuid.js";
 
 /**
@@ -30,6 +31,7 @@ const METRIC_MAP: {
   "quantity": QuantityMetric,
   "string": StringMetric,
   "timespan": TimespanMetric,
+  "url": UrlMetric,
   "uuid": UUIDMetric,
 });
 

--- a/glean/src/index/qt.ts
+++ b/glean/src/index/qt.ts
@@ -19,6 +19,7 @@ import QuantityMetricType from "../core/metrics/types/quantity.js";
 import StringMetricType from "../core/metrics/types/string.js";
 import TimespanMetricType from "../core/metrics/types/timespan.js";
 import UUIDMetricType from "../core/metrics/types/uuid.js";
+import URLMetricType from "../core/metrics/types/url.js";
 
 export default {
   /**
@@ -112,6 +113,7 @@ export default {
     QuantityMetricType,
     StringMetricType,
     TimespanMetricType,
-    UUIDMetricType
+    UUIDMetricType,
+    URLMetricType
   }
 };

--- a/glean/tests/integration/schema/metrics.yaml
+++ b/glean/tests/integration/schema/metrics.yaml
@@ -156,3 +156,16 @@ for_testing:
     send_in_pings:
       - testing
     unit: sample
+  url:
+    type: url
+    description: |
+      Sample url metric.
+    bugs:
+      - https://bugzilla.mozilla.org/000000
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=000000#c3
+    notification_emails:
+      - me@mozilla.com
+    expires: never
+    send_in_pings:
+      - testing

--- a/glean/tests/integration/schema/schema.spec.ts
+++ b/glean/tests/integration/schema/schema.spec.ts
@@ -110,6 +110,7 @@ describe("schema", function() {
     metrics.string.set("let's go");
     metrics.timespan.setRawNanos(10 * 10**6);
     metrics.uuid.generateAndSet();
+    metrics.url.set("glean://test");
     /* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 
     // Set up the http client to catch the ping we will submit.

--- a/glean/tests/unit/core/metrics/url.spec.ts
+++ b/glean/tests/unit/core/metrics/url.spec.ts
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import assert from "assert";
+import { Context } from "../../../../src/core/context";
+import { ErrorType } from "../../../../src/core/error/error_type";
+
+import Glean from "../../../../src/core/glean";
+import { Lifetime } from "../../../../src/core/metrics/lifetime";
+import UrlMetricType from "../../../../src/core/metrics/types/url";
+
+describe("UrlMetric", function() {
+  const testAppId = `gleanjs.test.${this.title}`;
+
+  beforeEach(async function() {
+    await Glean.testResetGlean(testAppId);
+  });
+
+  it("attempting to get the value of a metric that hasn't been recorded doesn't error", async function() {
+    const metric = new UrlMetricType({
+      category: "aCategory",
+      name: "aUrlMetric",
+      sendInPings: ["aPing", "twoPing", "threePing"],
+      lifetime: Lifetime.Ping,
+      disabled: false
+    });
+
+    assert.strictEqual(await metric.testGetValue("aPing"), undefined);
+  });
+
+  it("attempting to set when glean upload is disabled is a no-op", async function() {
+    Glean.setUploadEnabled(false);
+
+    const metric = new UrlMetricType({
+      category: "aCategory",
+      name: "aUrlMetric",
+      sendInPings: ["aPing", "twoPing", "threePing"],
+      lifetime: Lifetime.Ping,
+      disabled: false
+    });
+
+    metric.set("glean://test");
+    assert.strictEqual(await metric.testGetValue("aPing"), undefined);
+  });
+
+  it("ping payload is correct", async function() {
+    const metric = new UrlMetricType({
+      category: "aCategory",
+      name: "aUrlMetric",
+      sendInPings: ["aPing"],
+      lifetime: Lifetime.Ping,
+      disabled: false
+    });
+
+    metric.set("glean://test");
+    assert.strictEqual(await metric.testGetValue("aPing"), "glean://test");
+
+    const snapshot = await Context.metricsDatabase.getPingMetrics("aPing", true);
+    assert.deepStrictEqual(snapshot, {
+      "url": {
+        "aCategory.aUrlMetric": "glean://test"
+      }
+    });
+  });
+
+  it("payload is URI encoded", async function () {
+    const metric = new UrlMetricType({
+      category: "aCategory",
+      name: "aUrlMetric",
+      sendInPings: ["aPing"],
+      lifetime: Lifetime.Ping,
+      disabled: false
+    });
+
+    metric.set("https://mozilla.org/?x=шеллы");
+    assert.strictEqual(await metric.testGetValue("aPing"), "https://mozilla.org/?x=шеллы");
+
+    const snapshot = await Context.metricsDatabase.getPingMetrics("aPing", true);
+    assert.deepStrictEqual(snapshot, {
+      "url": {
+        "aCategory.aUrlMetric": "https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B"
+      }
+    });
+  });
+
+  it("set properly sets the value in all pings", async function() {
+    const metric = new UrlMetricType({
+      category: "aCategory",
+      name: "aUrlMetric",
+      sendInPings: ["aPing", "twoPing", "threePing"],
+      lifetime: Lifetime.Ping,
+      disabled: false
+    });
+
+    metric.set("glean://test");
+    assert.strictEqual(await metric.testGetValue("aPing"), "glean://test");
+    assert.strictEqual(await metric.testGetValue("twoPing"), "glean://test");
+    assert.strictEqual(await metric.testGetValue("threePing"), "glean://test");
+  });
+
+  it("setUrl properly sets the value in all pings", async function() {
+    const metric = new UrlMetricType({
+      category: "aCategory",
+      name: "aUrlMetric",
+      sendInPings: ["aPing", "twoPing", "threePing"],
+      lifetime: Lifetime.Ping,
+      disabled: false
+    });
+
+    metric.setUrl(new URL("glean://test"));
+    assert.strictEqual(await metric.testGetValue("aPing"), "glean://test");
+    assert.strictEqual(await metric.testGetValue("twoPing"), "glean://test");
+    assert.strictEqual(await metric.testGetValue("threePing"), "glean://test");
+  });
+
+  it("does not record when URL exceeds MAX_URL_LENGTH and records errors", async function () {
+    const metric = new UrlMetricType({
+      category: "aCategory",
+      name: "aUrlMetric",
+      sendInPings: ["aPing"],
+      lifetime: Lifetime.Ping,
+      disabled: false
+    });
+
+    const testUrl = `glean://${"testing".repeat(2000)}`;
+    metric.set(testUrl);
+    metric.setUrl(new URL(testUrl));
+
+    assert.strictEqual(await metric.testGetValue("aPing"), undefined);
+    assert.strictEqual(
+      await metric.testGetNumRecordedErrors(ErrorType.InvalidOverflow), 2
+    );
+  });
+
+  it("does not record data URLs and records errors", async function () {
+    const metric = new UrlMetricType({
+      category: "aCategory",
+      name: "aUrlMetric",
+      sendInPings: ["aPing"],
+      lifetime: Lifetime.Ping,
+      disabled: false
+    });
+
+    metric.set("data:application/json");
+    metric.setUrl(new URL("data:application/json"));
+
+    assert.strictEqual(await metric.testGetValue("aPing"), undefined);
+    assert.strictEqual(
+      await metric.testGetNumRecordedErrors(ErrorType.InvalidValue), 2
+    );
+  });
+
+  it("url schema validation works as designed and records errors", async function () {
+    const metric = new UrlMetricType({
+      category: "aCategory",
+      name: "aUrlMetric",
+      sendInPings: ["aPing"],
+      lifetime: Lifetime.Ping,
+      disabled: false
+    });
+
+    const incorrects = [
+      "",
+      // Scheme may only start with upper or lowercase ASCII alpha[^1] character.
+      // [1]: https://infra.spec.whatwg.org/#ascii-alpha
+      "1glean://test",
+      "-glean://test",
+      // Scheme may only have ASCII alphanumeric characters or the `-`, `.`, `+` characters.
+      "шеллы://test",
+      "g!lean://test",
+      "g=lean://test",
+      // Scheme must be followed by `:` character.
+      "glean//test",
+    ];
+
+    const corrects = [
+      // The minimum URL
+      "g:",
+      // Empty body is fine
+      "glean://",
+      // "//" is actually not even necessary
+      "glean:",
+      "glean:test",
+      "glean:test.com",
+      // Scheme may only have ASCII alphanumeric characters or the `-`, `.`, `+` characters.
+      "g-lean://test",
+      "g+lean://test",
+      "g.lean://test",
+      // Query parameters are fine
+      "glean://test?hello=world",
+      // Finally, some actual real world URLs
+      "https://infra.spec.whatwg.org/#ascii-alpha",
+      "https://infra.spec.whatwg.org/#ascii-alpha?test=for-glean"
+    ];
+
+    for (const incorrect of incorrects) {
+      metric.set(incorrect);
+      assert.strictEqual(await metric.testGetValue("aPing"), undefined);
+    }
+    assert.strictEqual(
+      await metric.testGetNumRecordedErrors(ErrorType.InvalidValue), incorrects.length
+    );
+
+
+    for (const correct of corrects) {
+      metric.set(correct);
+      assert.strictEqual(await metric.testGetValue("aPing"), correct);
+    }
+  });
+});

--- a/samples/qt-qml-app/pings.yaml
+++ b/samples/qt-qml-app/pings.yaml
@@ -22,3 +22,5 @@ custom:
     - https://bugzilla.mozilla.org/show_bug.cgi?id=1587095#c6
   notification_emails:
     - glean-team@mozilla.com
+  no_lint:
+    - REDUNDANT_PING

--- a/samples/qt-qml-app/requirements.txt
+++ b/samples/qt-qml-app/requirements.txt
@@ -1,3 +1,3 @@
 PySide2==5.15.2
 shiboken2==5.15.2
-glean_parser==3.5.0
+glean_parser==3.7.0

--- a/samples/web-extension/javascript/src/pings.yaml
+++ b/samples/web-extension/javascript/src/pings.yaml
@@ -22,3 +22,5 @@ custom:
     - https://bugzilla.mozilla.org/show_bug.cgi?id=1587095#c6
   notification_emails:
     - glean-team@mozilla.com
+  no_lint:
+    - REDUNDANT_PING

--- a/samples/web-extension/typescript/src/pings.yaml
+++ b/samples/web-extension/typescript/src/pings.yaml
@@ -18,3 +18,5 @@ custom:
     - https://bugzilla.mozilla.org/show_bug.cgi?id=1587095#c6
   notification_emails:
     - glean-team@mozilla.com
+  no_lint:
+    - REDUNDANT_PING


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint && npm run lint:circular-deps` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - https://github.com/mozilla/glean/pull/1715

...Also missing:

- [x] glean_parser changes
  - https://github.com/mozilla/glean_parser/pull/361
  - https://github.com/mozilla/glean_parser/releases/tag/v3.7.0
- [x] mozilla-pipeline-schemas changes
  - https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/689

Both these changes block this PR, before them the integration tests will not pass.