### PR TITLE
Bug 1707891 - Implement shutdown API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.17.0...main)
 
+* [#542](https://github.com/mozilla/glean.js/pull/542): Implement `shutdown` API.
+
 # v0.17.0 (2021-07-16)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.16.0...v0.17.0)

--- a/glean/src/core/dispatcher.ts
+++ b/glean/src/core/dispatcher.ts
@@ -35,7 +35,7 @@ const enum Commands {
   Stop,
   // The dispatcher should stop executing the queued tasks and clear the queue.
   Clear,
-  // The dispatcher will clear the queue and go on Shutdown state.
+  // The dispatcher will clear the queue and go into the Shutdown state.
   Shutdown,
   // Exactly like a normal Task, but spawned for tests.
   TestTask,
@@ -312,13 +312,13 @@ class Dispatcher {
    *
    * 1. Executes all tasks launched prior to this one.
    * 2. Clears the queue of any tasks launched after this one.
-   * 3. Puts the dispatcher in a `Shutdown` stated.
+   * 3. Puts the dispatcher in the `Shutdown` state.
    *
    * # Note
    *
    * - This is a command like any other, if the dispatcher is uninitialized
    *   it will get executed when the dispatcher is initialized.
-   * - If the dispatcher is stopped it is resumed and all pending tasks are executed.
+   * - If the dispatcher is stopped, it is resumed and all pending tasks are executed.
    *
    * @returns A promise which resolves once shutdown is complete.
    */

--- a/glean/src/core/dispatcher.ts
+++ b/glean/src/core/dispatcher.ts
@@ -19,6 +19,10 @@ export const enum DispatcherState {
   Processing,
   // The dispatcher is stopped, tasks queued will not be immediatelly processed.
   Stopped,
+  // The dispatcher is shutdown, attempting to queue tasks while in this state is a no-op.
+  //
+  // This state is irreversible.
+  Shutdown,
 }
 
 // The possible commands to be processed by the dispatcher.
@@ -31,6 +35,8 @@ const enum Commands {
   Stop,
   // The dispatcher should stop executing the queued tasks and clear the queue.
   Clear,
+  // The dispatcher will clear the queue and go on Shutdown state.
+  Shutdown,
   // Exactly like a normal Task, but spawned for tests.
   TestTask,
 }
@@ -102,6 +108,7 @@ class Dispatcher {
       case(Commands.Stop):
         this.state = DispatcherState.Stopped;
         return;
+      case(Commands.Shutdown):
       case(Commands.Clear):
         // Unblock test resolvers before clearing the queue.
         this.queue.forEach(c => {
@@ -111,7 +118,12 @@ class Dispatcher {
         });
 
         this.queue = [];
-        this.state = DispatcherState.Stopped;
+        if (nextCommand.command === Commands.Clear) {
+          this.state = DispatcherState.Stopped;
+        } else {
+          this.state = DispatcherState.Shutdown;
+        }
+
         return;
       case (Commands.TestTask):
         await this.executeTask(nextCommand.task);
@@ -175,6 +187,15 @@ class Dispatcher {
    * @returns Wheter or not the task was queued.
    */
   private launchInternal(command: Command, priorityTask = false): boolean {
+    if (this.state === DispatcherState.Shutdown) {
+      log(
+        LOG_TAG,
+        "Attempted to enqueue a new task but the dispatcher is shutdown. Ignoring.",
+        LoggingLevel.Warn
+      );
+      return false;
+    }
+
     if (!priorityTask && this.state === DispatcherState.Uninitialized) {
       if (this.queue.length >= this.maxPreInitQueueSize) {
         log(
@@ -287,6 +308,27 @@ class Dispatcher {
   }
 
   /**
+   * Shutsdown the dispatcher.
+   *
+   * 1. Executes all tasks launched prior to this one.
+   * 2. Clears the queue of any tasks launched after this one.
+   * 3. Puts the dispatcher in a `Shutdown` stated.
+   *
+   * # Note
+   *
+   * - This is a command like any other, if the dispatcher is uninitialized
+   *   it will get executed when the dispatcher is initialized.
+   * - If the dispatcher is stopped it is resumed and all pending tasks are executed.
+   *
+   * @returns A promise which resolves once shutdown is complete.
+   */
+  shutdown(): Promise<void> {
+    this.launchInternal({ command: Commands.Shutdown });
+    this.resume();
+    return this.currentJob || Promise.resolve();
+  }
+
+  /**
    * Test-Only API**
    *
    * Returns a promise that resolves once the current task execution in finished.
@@ -329,6 +371,11 @@ class Dispatcher {
    * and return the dispatcher back to an idle state.
    *
    * This is important in order not to hang forever in case the dispatcher is stopped.
+   *
+   * # Errors
+   *
+   * This function will reject in case the task is not launched.
+   * Make sure the dispatcher is initialized or is not shutdown in these cases.
    *
    * @param task The task to launch.
    * @returns A promise which only resolves once the task is done being executed

--- a/glean/src/core/dispatcher.ts
+++ b/glean/src/core/dispatcher.ts
@@ -71,7 +71,7 @@ class Dispatcher {
   // This is `undefined` in case there is no ongoing execution of tasks.
   private currentJob?: Promise<void>;
 
-  constructor(readonly maxPreInitQueueSize = 100) {
+  constructor(readonly maxPreInitQueueSize = 100, readonly logTag = LOG_TAG) {
     this.queue = [];
     this.state = DispatcherState.Uninitialized;
   }
@@ -94,7 +94,7 @@ class Dispatcher {
     try {
       await task();
     } catch(e) {
-      log(LOG_TAG, ["Error executing task:", e], LoggingLevel.Error);
+      log(this.logTag, ["Error executing task:", e], LoggingLevel.Error);
     }
   }
 
@@ -161,7 +161,7 @@ class Dispatcher {
         })
         .catch(error => {
           log(
-            LOG_TAG,
+            this.logTag,
             [
               "IMPOSSIBLE: Something went wrong while the dispatcher was executing the tasks queue.",
               error
@@ -189,7 +189,7 @@ class Dispatcher {
   private launchInternal(command: Command, priorityTask = false): boolean {
     if (this.state === DispatcherState.Shutdown) {
       log(
-        LOG_TAG,
+        this.logTag,
         "Attempted to enqueue a new task but the dispatcher is shutdown. Ignoring.",
         LoggingLevel.Warn
       );
@@ -199,7 +199,7 @@ class Dispatcher {
     if (!priorityTask && this.state === DispatcherState.Uninitialized) {
       if (this.queue.length >= this.maxPreInitQueueSize) {
         log(
-          LOG_TAG,
+          this.logTag,
           "Unable to enqueue task, pre init queue is full.",
           LoggingLevel.Warn
         );
@@ -247,7 +247,7 @@ class Dispatcher {
   flushInit(task?: Task): void {
     if (this.state !== DispatcherState.Uninitialized) {
       log(
-        LOG_TAG,
+        this.logTag,
         "Attempted to initialize the Dispatcher, but it is already initialized. Ignoring.",
         LoggingLevel.Warn
       );

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -115,7 +115,7 @@ class Glean {
    */
   private static async clearMetrics(): Promise<void> {
     // Stop ongoing upload jobs and clear pending pings queue.
-    await Glean.pingUploader.clearPendingPingsQueue();
+    Glean.pingUploader.clearPendingPingsQueue();
 
     // There is only one metric that we want to survive after clearing all
     // metrics: first_run_date. Here, we store its value
@@ -281,11 +281,6 @@ class Glean {
       }
 
       await Context.pingsDatabase.scanPendingPings();
-
-      // Even though this returns a promise, there is no need to block on it returning.
-      //
-      // On the contrary we _want_ the uploading tasks to be executed async.
-      void Glean.pingUploader.triggerUpload();
     });
   }
 
@@ -491,11 +486,13 @@ class Glean {
     // Deregister all plugins
     testResetEvents();
 
-    // Stop ongoing jobs and clear pending pings queue.
+    // Await ongoing jobs and clear pending pings queue.
     if (Glean.pingUploader) {
+      await Glean.pingUploader.testBlockOnPingsQueue();
+
       // The first time tests run, before Glean is initialized, we are
       // not guaranteed to have an uploader. Account for this.
-      await Glean.pingUploader.clearPendingPingsQueue();
+      Glean.pingUploader.clearPendingPingsQueue();
     }
   }
 

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -414,6 +414,27 @@ class Glean {
   }
 
   /**
+   * Finishes executing all pending tasks
+   * and shutsdown both Glean's dispatcher and ping uploader.
+   *
+   * # Important
+   *
+   * This is irreversible.
+   * Only a restart will return Glean back to an idle state.
+   *
+   * @returns A promise which resolves once the shutdown is complete.
+   */
+  static async shutdown(): Promise<void> {
+    // Order here matters!
+    //
+    // The main dispatcher needs to be shutdown first,
+    // because some of its tasks may enqueue new tasks on the ping uploader dispatcher
+    // and we want these uploading tasks to also be executed prior to complete shutdown.
+    await Context.dispatcher.shutdown();
+    await Glean.pingUploader.shutdown();
+  }
+
+  /**
    * Sets the current environment.
    *
    * This function **must** be called before Glean.initialize.

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -415,7 +415,7 @@ class Glean {
 
   /**
    * Finishes executing all pending tasks
-   * and shutsdown both Glean's dispatcher and ping uploader.
+   * and shuts down both Glean's dispatcher and the ping uploader.
    *
    * # Important
    *
@@ -427,7 +427,7 @@ class Glean {
   static async shutdown(): Promise<void> {
     // Order here matters!
     //
-    // The main dispatcher needs to be shutdown first,
+    // The main dispatcher needs to be shut down first,
     // because some of its tasks may enqueue new tasks on the ping uploader dispatcher
     // and we want these uploading tasks to also be executed prior to complete shutdown.
     await Context.dispatcher.shutdown();

--- a/glean/src/core/upload/index.ts
+++ b/glean/src/core/upload/index.ts
@@ -77,7 +77,7 @@ class PingUploader implements PingsDatabaseObserver {
   private dispatcher: Dispatcher;
   // The object that concretely handles the ping transmission.
   private readonly uploader: Uploader;
-  // PlatfornInfo object containing OS information used to build ping request headers.
+  // PlatformInfo object containing OS information used to build ping request headers.
   private readonly platformInfo: PlatformInfo;
   // The server address we are sending pings to.
   private readonly serverEndpoint: string;
@@ -324,7 +324,7 @@ class PingUploader implements PingsDatabaseObserver {
   }
 
   /**
-   * Shutsdown internal dispatcher, after executing all previously enqueued ping requests.
+   * Shuts down internal dispatcher, after executing all previously enqueued ping requests.
    *
    * This is irreversible.
    *
@@ -343,7 +343,7 @@ class PingUploader implements PingsDatabaseObserver {
     // Create and initialize a new dispatcher so we don't need to wait
     // on the previous one finishing execution.
     //
-    // It will only finish execution of the current task, all other queues tasks are dropped.
+    // It will only finish execution of the current task, all other queued tasks are dropped.
     this.dispatcher = createAndInitializeDispatcher();
   }
 

--- a/glean/src/core/upload/index.ts
+++ b/glean/src/core/upload/index.ts
@@ -8,6 +8,7 @@ import type Platform from "../../platform/index.js";
 import type { Configuration } from "../config.js";
 import { GLEAN_VERSION } from "../constants.js";
 import { Context } from "../context.js";
+import Dispatcher from "../dispatcher.js";
 import log, { LoggingLevel } from "../log.js";
 import type { Observer as PingsDatabaseObserver, PingInternalRepresentation } from "../pings/database.js";
 import type PingsDatabase from "../pings/database.js";
@@ -17,6 +18,17 @@ import type Uploader from "./uploader.js";
 import { UploadResultStatus } from "./uploader.js";
 
 const LOG_TAG = "core.Upload";
+
+/**
+ * Create and initialize a dispatcher for the PingUplaoder.
+ *
+ * @returns The created dispatcher instance.
+ */
+function createAndInitializeDispatcher(): Dispatcher {
+  const dispatcher = new Dispatcher(100, `${LOG_TAG}.Dispatcher`);
+  dispatcher.flushInit();
+  return dispatcher;
+}
 
 /**
  * Policies for ping storage, uploading and requests.
@@ -33,19 +45,10 @@ export class Policy {
 }
 
 interface QueuedPing extends PingInternalRepresentation {
-  identifier: string
-}
-
-/**
- * The possible status of the ping uploader.
- */
-const enum PingUploaderStatus {
-  // Not currently uploading pings.
-  Idle,
-  // Currently uploading pings.
-  Uploading,
-  // Currently processing a signal to stop uploading pings.
-  Cancelling,
+  // The UUID identifier for this ping.
+  readonly identifier: string,
+  // How may times there has been a failed upload attempt for this ping.
+  retries: number,
 }
 
 // Error to be thrown in case the final ping body is larger than MAX_PING_BODY_SIZE.
@@ -68,17 +71,15 @@ class PingBodyOverflowError extends Error {
  * we bail out before uploading all enqued pings.
  */
 class PingUploader implements PingsDatabaseObserver {
-  // A FIFO queue of pings.
-  private queue: QueuedPing[];
-  // The current status of the uploader.
-  private status: PingUploaderStatus;
-  // A promise that represents the current uploading job.
-  // This is `undefined` in case there is no current uploading job.
-  private currentJob?: Promise<void>;
+  // A list of pings currently being processed.
+  private processing: QueuedPing[];
+  // Local dispathcer instance to handle execution of ping requests.
+  private dispatcher: Dispatcher;
   // The object that concretely handles the ping transmission.
   private readonly uploader: Uploader;
-
+  // PlatfornInfo object containing OS information used to build ping request headers.
   private readonly platformInfo: PlatformInfo;
+  // The server address we are sending pings to.
   private readonly serverEndpoint: string;
 
   constructor(
@@ -87,14 +88,16 @@ class PingUploader implements PingsDatabaseObserver {
     private readonly pingsDatabase: PingsDatabase,
     private readonly policy = new Policy
   ) {
-    this.queue = [];
-    this.status = PingUploaderStatus.Idle;
+    this.processing = [];
     // Initialize the ping uploader with either the platform defaults or a custom
     // provided uploader from the configuration object.
     this.uploader = config.httpClient ? config.httpClient : platform.uploader;
     this.platformInfo = platform.info;
     this.serverEndpoint = config.serverEndpoint;
     this.pingsDatabase = pingsDatabase;
+
+    // Initialize the dispatcher immediatelly.
+    this.dispatcher = createAndInitializeDispatcher();
   }
 
   /**
@@ -106,22 +109,36 @@ class PingUploader implements PingsDatabaseObserver {
    */
   private enqueuePing(ping: QueuedPing): void {
     let isDuplicate = false;
-    for (const queuedPing of this.queue) {
+    for (const queuedPing of this.processing) {
       if (queuedPing.identifier === ping.identifier) {
         isDuplicate = true;
       }
     }
 
-    !isDuplicate && this.queue.push(ping);
-  }
+    if (!isDuplicate) {
+      // Add the ping to the list of pings being processsed.
+      this.processing.push(ping);
+      // Dispatch the uploading task.
+      this.dispatcher.launch(async (): Promise<void> => {
+        const status = await this.attemptPingUpload(ping);
+        const shouldRetry = await this.processPingUploadResponse(ping.identifier, status);
 
-  /**
-   * Gets and removes from the queue the next ping in line to be uploaded.
-   *
-   * @returns The next ping or `undefined` if no pings are enqueued.
-   */
-  private getNextPing(): QueuedPing | undefined {
-    return this.queue.shift();
+        if (shouldRetry) {
+          ping.retries++;
+          this.enqueuePing(ping);
+        }
+
+        if (ping.retries >= this.policy.maxRecoverableFailures) {
+          log(
+            LOG_TAG,
+            `Reached maximum recoverable failures for ping "${JSON.stringify(ping.name)}". You are done.`,
+            LoggingLevel.Info
+          );
+          this.dispatcher.stop();
+          ping.retries = 0;
+        }
+      });
+    }
   }
 
   /**
@@ -217,6 +234,15 @@ class PingUploader implements PingsDatabaseObserver {
   }
 
   /**
+   * Removes a ping from the processing list.
+   *
+   * @param identifier The identifier of the ping to be removed.
+   */
+  private concludePingProcessing(identifier: string): void {
+    this.processing = this.processing.filter(ping => ping.identifier !== identifier);
+  }
+
+  /**
    * Processes the response from an attempt to upload a ping.
    *
    * Based on the HTTP status of said response,
@@ -253,10 +279,13 @@ class PingUploader implements PingsDatabaseObserver {
    * @returns Whether or not to retry the upload attempt.
    */
   private async processPingUploadResponse(identifier: string, response: UploadResult): Promise<boolean> {
+    this.concludePingProcessing(identifier);
+
     const { status, result } = response;
     if (status && status >= 200 && status < 300) {
       log(LOG_TAG, `Ping ${identifier} succesfully sent ${status}.`, LoggingLevel.Info);
       await this.pingsDatabase.deletePing(identifier);
+      this.processing;
       return false;
     }
 
@@ -281,84 +310,6 @@ class PingUploader implements PingsDatabaseObserver {
     return true;
   }
 
-  private async triggerUploadInternal(): Promise<void> {
-    let retries = 0;
-    let nextPing = this.getNextPing();
-    while(nextPing && this.status !== PingUploaderStatus.Cancelling) {
-      const status = await this.attemptPingUpload(nextPing);
-      const shouldRetry = await this.processPingUploadResponse(nextPing.identifier, status);
-      if (shouldRetry) {
-        retries++;
-        this.enqueuePing(nextPing);
-      }
-
-      if (retries >= this.policy.maxRecoverableFailures) {
-        log(
-          LOG_TAG,
-          "Reached maximum recoverable failures for the current uploading window. You are done.",
-          LoggingLevel.Info
-        );
-        return;
-      }
-
-      nextPing = this.getNextPing();
-    }
-  }
-
-  /**
-   * Triggers the uploading of all enqueued pings.
-   *
-   * If upload is already ongoing, this is a no-op.
-   *
-   * # Notes
-   *
-   * 1. If three retriable failures happen in a row the uploader will stop retrying.
-   * 2. Uploading only works when Glean has been initialized.
-   *    Otherwise it will reach maximum retriable failures and bail out.
-   */
-  async triggerUpload(): Promise<void> {
-    if (this.status !== PingUploaderStatus.Idle) {
-      return;
-    }
-
-    this.status = PingUploaderStatus.Uploading;
-    try {
-      this.currentJob = this.triggerUploadInternal();
-      await this.currentJob;
-    } finally {
-      this.status = PingUploaderStatus.Idle;
-    }
-  }
-
-  /**
-   * Cancels ongoing upload.
-   *
-   * Does nothing in case another cancel signal has already been issued
-   * or if the uploader is current idle.
-   *
-   * @returns A promise that resolves once the current uploading job is succesfully cancelled.
-   */
-  async cancelUpload(): Promise<void> {
-    if (this.status === PingUploaderStatus.Uploading) {
-      this.status = PingUploaderStatus.Cancelling;
-      await this.currentJob;
-    }
-
-    return;
-  }
-
-  /**
-   * Clear the pending pings queue.
-   *
-   * Will cancel any ongoing work before clearing.
-   *
-   * @returns A promise that resolves once we are done clearing.
-   */
-  async clearPendingPingsQueue(): Promise<void> {
-    await this.cancelUpload();
-    this.queue = [];
-  }
-
   /**
    * Enqueues a new ping and trigger uploading of enqueued pings.
    *
@@ -368,8 +319,32 @@ class PingUploader implements PingsDatabaseObserver {
    * @param ping An object containing the newly recorded ping path, payload and optionally headers.
    */
   update(identifier: string, ping: PingInternalRepresentation): void {
-    this.enqueuePing({ identifier, ...ping });
-    void this.triggerUpload();
+    this.dispatcher.resume();
+    this.enqueuePing({ identifier, retries: 0, ...ping });
+  }
+
+  /**
+   * Clears the pending pings queue.
+   */
+  clearPendingPingsQueue(): void {
+    this.dispatcher.clear();
+    this.processing = [];
+    // Create and initialize a new dispatcher so we don't need to wait
+    // on the previous one finishing execution.
+    //
+    // It will only finish execution of the current task, all other queues tasks are dropped.
+    this.dispatcher = createAndInitializeDispatcher();
+  }
+
+  /**
+   * Test-Only API**
+   *
+   * Returns a promise that resolves once the current queue execution in finished.
+   *
+   * @returns The promise.
+   */
+  async testBlockOnPingsQueue(): Promise<void> {
+    return this.dispatcher.testBlockOnQueue();
   }
 }
 

--- a/glean/src/core/upload/index.ts
+++ b/glean/src/core/upload/index.ts
@@ -324,6 +324,17 @@ class PingUploader implements PingsDatabaseObserver {
   }
 
   /**
+   * Shutsdown internal dispatcher, after executing all previously enqueued ping requests.
+   *
+   * This is irreversible.
+   *
+   * @returns A promise that resolves once shutdown is complete.
+   */
+  shutdown(): Promise<void> {
+    return this.dispatcher.shutdown();
+  }
+
+  /**
    * Clears the pending pings queue.
    */
   clearPendingPingsQueue(): void {

--- a/glean/src/index/qt.js
+++ b/glean/src/index/qt.js
@@ -91,4 +91,15 @@ function setSourceTags(value) {
   Glean.Glean.default.setSourceTags(value);
 }
 
+/**
+ * Finishes executing any ongoing tasks and shutsdown Glean.
+ *
+ * This will attempt to send pending pings before resolving.
+ *
+ * @returns A promise which resolves once shutdown is complete.
+ */
+function shutdown() {
+  return Glean.shutdown();
+}
+
 const _private = Glean.Glean.default._private;

--- a/glean/src/index/qt.js
+++ b/glean/src/index/qt.js
@@ -92,7 +92,7 @@ function setSourceTags(value) {
 }
 
 /**
- * Finishes executing any ongoing tasks and shutsdown Glean.
+ * Finishes executing any ongoing tasks and shuts down Glean.
  *
  * This will attempt to send pending pings before resolving.
  *

--- a/glean/src/index/qt.ts
+++ b/glean/src/index/qt.ts
@@ -102,7 +102,7 @@ export default {
   },
 
   /**
-   * Finishes executing any ongoing tasks and shutsdown Glean.
+   * Finishes executing any ongoing tasks and shuts down Glean.
    *
    * This will attempt to send pending pings before resolving.
    *

--- a/glean/src/index/qt.ts
+++ b/glean/src/index/qt.ts
@@ -101,6 +101,17 @@ export default {
     Glean.setSourceTags(value);
   },
 
+  /**
+   * Finishes executing any ongoing tasks and shutsdown Glean.
+   *
+   * This will attempt to send pending pings before resolving.
+   *
+   * @returns A promise which resolves once shutdown is complete.
+   */
+  shutdown(): Promise<void> {
+    return Glean.shutdown();
+  },
+
   ErrorType,
 
   _private: {

--- a/glean/src/index/webext.ts
+++ b/glean/src/index/webext.ts
@@ -74,6 +74,17 @@ export default {
   },
 
   /**
+   * Finishes executing any ongoing tasks and shutsdown Glean.
+   *
+   * This will attempt to send pending pings before resolving.
+   *
+   * @returns A promise which resolves once shutdown is complete.
+   */
+  shutdown(): Promise<void> {
+    return Glean.shutdown();
+  },
+
+  /**
    * Sets the `sourceTags` debug option.
    *
    * Ping tags will show in the destination datasets, after ingestion.

--- a/glean/src/index/webext.ts
+++ b/glean/src/index/webext.ts
@@ -74,7 +74,7 @@ export default {
   },
 
   /**
-   * Finishes executing any ongoing tasks and shutsdown Glean.
+   * Finishes executing any ongoing tasks and shuts down Glean.
    *
    * This will attempt to send pending pings before resolving.
    *

--- a/glean/tests/integration/schema/schema.spec.ts
+++ b/glean/tests/integration/schema/schema.spec.ts
@@ -5,16 +5,13 @@
 import https from "https";
 import { validate } from "jsonschema";
 
-import type { UploadResult } from "../../../src/core/upload/uploader";
-import type Uploader from "../../../src/core/upload/uploader";
 import type { JSONObject } from "../../../src/core/utils";
 import Glean from "../../../src/core/glean";
-import { UploadResultStatus } from "../../../src/core/upload/uploader";
+import { WaitableUploader } from "../../utils";
 
 // Generated files.
 import * as metrics from "./generated/forTesting";
 import * as pings from "./generated/pings";
-import { unzipPingPayload } from "../../utils";
 
 const GLEAN_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/main/schemas/glean/glean/glean.1.schema.json";
 
@@ -41,45 +38,6 @@ function fetchSchema(): Promise<JSONObject> {
   });
 }
 
-/**
- * A Glean mock HTTP which allows one to wait for a specific ping submission.
- */
-class WaitableHttpClient implements Uploader {
-  private waitingFor?: string;
-  private waitResolver?: (pingBody: JSONObject) => void;
-
-  /**
-   * Returns a promise that resolves once a ping is submitted or times out after a 2s wait.
-   *
-   * @param name The name of the ping to wait for.
-   * @returns A promise that resolves once a ping is submitted or times out after a 2s wait.
-   */
-  waitForPingSubmission(name: string): Promise<JSONObject> {
-    this.waitingFor = name;
-    return new Promise<JSONObject>((resolve, reject) => {
-      this.waitResolver = (pingBody: JSONObject) => {
-        this.waitingFor = undefined;
-        // Uncomment for debugging the ping payload.
-        // console.log(JSON.stringify(pingBody, null, 2));
-        resolve(pingBody);
-      };
-
-      setTimeout(() => reject(), 2000);
-    });
-  }
-
-  post(url: string, body: string): Promise<UploadResult> {
-    if (this.waitingFor && url.includes(this.waitingFor)) {
-      this.waitResolver?.(unzipPingPayload(body));
-    }
-
-    return Promise.resolve({
-      result: UploadResultStatus.Success,
-      status: 200
-    });
-  }
-}
-
 describe("schema", function() {
   const testAppId = `gleanjs.test.${this.title}`;
   let pingSchema: JSONObject | null;
@@ -90,7 +48,7 @@ describe("schema", function() {
   });
 
   it("validate generated ping is valid against glean schema", async function () {
-    const httpClient = new WaitableHttpClient();
+    const httpClient = new WaitableUploader();
     await Glean.testResetGlean(testAppId, true, { httpClient });
 
     // Record something for each metric type.
@@ -125,7 +83,7 @@ describe("schema", function() {
   });
 
   it("validate that the deletion-request is valid against glean schema", async function () {
-    const httpClient = new WaitableHttpClient();
+    const httpClient = new WaitableUploader();
     await Glean.testResetGlean(testAppId, true, { httpClient });
 
     const deletionPingBody = httpClient.waitForPingSubmission("deletion-request");

--- a/glean/tests/unit/core/glean.spec.ts
+++ b/glean/tests/unit/core/glean.spec.ts
@@ -516,7 +516,7 @@ describe("Glean", function() {
     const postSpy = sandbox.spy(Glean.platform.uploader, "post");
 
     // `setUploadEnabled` is a task dispatched on the main dispatcher,
-    // inside this task an uploading task is dispatched to the ping uploader dispatcher.
+    // this task will dispatch an upload task to the upload dispatcher.
     //
     // We want to be sure the ping uploader dispatcher is not shutdown
     // before it can execute this final task.

--- a/glean/tests/unit/core/glean.spec.ts
+++ b/glean/tests/unit/core/glean.spec.ts
@@ -13,7 +13,7 @@ import CounterMetricType from "../../../src/core/metrics/types/counter";
 import PingType from "../../../src/core/pings/ping_type";
 import type { JSONObject } from "../../../src/core/utils";
 import { isObject } from "../../../src/core/utils";
-import WaitableUploader from "../../../tests/utils";
+import { stopGleanUploader, WaitableUploader } from "../../../tests/utils";
 import TestPlatform from "../../../src/platform/test";
 import Plugin from "../../../src/plugins";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
@@ -277,23 +277,23 @@ describe("Glean", function() {
   });
 
   it("deletion request ping is sent when toggling upload status between runs", async function() {
-    const mockUploader = new WaitableUploader();
-    const pingBody = mockUploader.waitForPingSubmission("test");
-
     Glean.setUploadEnabled(true);
     await Context.dispatcher.testBlockOnQueue();
 
     // Can't use testResetGlean here because it clears all stores
     // and when there is no client_id at all stored, a deletion ping is also not sent.
     await Glean.testUninitialize();
+
+    const mockUploader = new WaitableUploader();
+    const pingBody = mockUploader.waitForPingSubmission("deletion-request");
     await Glean.testInitialize(
       testAppId,
       false,
       {
         httpClient: mockUploader,
-      });
+      }
+    );
 
-    // TODO: Make this nicer once Bug 1691033 is resolved.
     await pingBody;
   });
 
@@ -313,7 +313,7 @@ describe("Glean", function() {
     await Glean.testInitialize(testAppId, false);
     await Context.dispatcher.testBlockOnQueue();
     // TODO: Make this nicer once we resolve Bug 1691033 is resolved.
-    await Glean["pingUploader"]["currentJob"];
+    await Glean["pingUploader"].testBlockOnPingsQueue();
 
     postSpy.resetHistory();
     assert.strictEqual(postSpy.callCount, 0);
@@ -431,11 +431,11 @@ describe("Glean", function() {
   //
   // Related to: https://github.com/mozilla-extensions/bergamot-browser-extension/issues/49
   it("verify that glean APIs are execute in a block when called inside an async function", async function() {
-    // Disable ping uploading for it not to interfere with this tests.
+    // Stop ping uploading for it not to interfere with this tests.
     //
     // This disables the uploading and deletion of pings from the pings database,
     // this allows us to query the database to check that our pings are as expected.
-    sandbox.stub(Glean["pingUploader"], "triggerUpload").callsFake(() => Promise.resolve());
+    await stopGleanUploader();
 
     const custom = new PingType({
       name: "custom",

--- a/glean/tests/unit/core/metrics/labeled.spec.ts
+++ b/glean/tests/unit/core/metrics/labeled.spec.ts
@@ -15,6 +15,7 @@ import LabeledMetricType from "../../../../src/core/metrics/types/labeled";
 import StringMetricType from "../../../../src/core/metrics/types/string";
 import PingType from "../../../../src/core/pings/ping_type";
 import type { JSONObject } from "../../../../src/core/utils";
+import { stopGleanUploader } from "../../../utils";
 
 const sandbox = sinon.createSandbox();
 
@@ -24,7 +25,7 @@ describe("LabeledMetric", function() {
   beforeEach(async function() {
     await Glean.testResetGlean(testAppId);
     // Disable ping uploading for it not to interfere with this tests.
-    sandbox.stub(Glean["pingUploader"], "triggerUpload").callsFake(() => Promise.resolve());
+    await stopGleanUploader();
   });
 
   afterEach(function () {

--- a/glean/tests/unit/core/pings/maker.spec.ts
+++ b/glean/tests/unit/core/pings/maker.spec.ts
@@ -12,6 +12,7 @@ import CoreEvents from "../../../../src/core/events";
 import Plugin from "../../../../src/plugins";
 import type { JSONObject } from "../../../../src/core/utils";
 import { Context } from "../../../../src/core/context";
+import { stopGleanUploader } from "../../../utils";
 
 const sandbox = sinon.createSandbox();
 
@@ -140,7 +141,7 @@ describe("PingMaker", function() {
 
   it("collect and store triggers the AfterPingCollection and deals with possible result correctly", async function () {
     // Disable ping uploading for it not to interfere with this tests.
-    sandbox.stub(Glean["pingUploader"], "triggerUpload").callsFake(() => Promise.resolve());
+    await stopGleanUploader();
 
     await Glean.testResetGlean(testAppId, true, { plugins: [ new MockPlugin() ]});
     const ping = new PingType({
@@ -161,7 +162,7 @@ describe("PingMaker", function() {
 
   it("ping payload is logged before it is modified by a plugin", async function () {
     // Disable ping uploading for it not to interfere with this tests.
-    sandbox.stub(Glean["pingUploader"], "triggerUpload").callsFake(() => Promise.resolve());
+    await stopGleanUploader();
 
     await Glean.testResetGlean(testAppId, true, {
       debug: {

--- a/glean/tests/unit/core/pings/ping_type.spec.ts
+++ b/glean/tests/unit/core/pings/ping_type.spec.ts
@@ -10,6 +10,7 @@ import CounterMetricType from "../../../../src/core/metrics/types/counter";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import Glean from "../../../../src/core/glean";
 import { Context } from "../../../../src/core/context";
+import { stopGleanUploader } from "../../../utils";
 
 const sandbox = sinon.createSandbox();
 
@@ -37,7 +38,7 @@ describe("PingType", function() {
 
   it("collects and stores ping on submit", async function () {
     // Disable ping uploading for it not to interfere with this tests.
-    sandbox.stub(Glean["pingUploader"], "triggerUpload").callsFake(() => Promise.resolve());
+    await stopGleanUploader();
 
     const ping = new PingType({
       name: "custom",
@@ -60,7 +61,7 @@ describe("PingType", function() {
 
   it("empty pings with send if empty flag are submitted", async function () {
     // Disable ping uploading for it not to interfere with this tests.
-    sandbox.stub(Glean["pingUploader"], "triggerUpload").callsFake(() => Promise.resolve());
+    await stopGleanUploader();
 
     const ping1 = new PingType({
       name: "ping1",

--- a/glean/tests/unit/plugins/encryption.spec.ts
+++ b/glean/tests/unit/plugins/encryption.spec.ts
@@ -11,7 +11,7 @@ import compactDecrypt from "jose/jwe/compact/decrypt";
 import Glean from "../../../src/core/glean";
 import PingType from "../../../src/core/pings/ping_type";
 import type { JSONObject } from "../../../src/core/utils";
-import WaitableUploader from "../../../tests/utils";
+import { WaitableUploader } from "../../../tests/utils";
 import PingEncryptionPlugin from "../../../src/plugins/encryption";
 import collectAndStorePing, { makePath } from "../../../src/core/pings/maker";
 import type { UploadResult} from "../../../src/core/upload/uploader";

--- a/glean/tests/utils.ts
+++ b/glean/tests/utils.ts
@@ -120,3 +120,23 @@ export class WaitableUploader implements Uploader {
     });
   }
 }
+
+/**
+ * Uploader implementation that counts how many times `post` was called.
+ */
+export class CounterUploader implements Uploader {
+  public count = 0;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async post(_url: string, _body: string): Promise<UploadResult> {
+    this.count++;
+    // Make this just a tiny bit slow.
+    await new Promise<void>(resolve => {
+      setTimeout(() => resolve(), 10 * Math.random());
+    });
+
+    return {
+      status: 200,
+      result: UploadResultStatus.Success
+    };
+  }
+}


### PR DESCRIPTION
The lack of this API causes a bug in Rally. See: https://bugzilla.mozilla.org/show_bug.cgi?id=1698934#c33

#### Note

I have confirmed that this fixes the issue and makes the test over on https://github.com/mozilla-rally/rally-core-addon/pull/678 pass.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint && npm run lint:circular-deps` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
   - https://github.com/mozilla/glean/pull/1722
