### PR TITLE
Fix linting issue in metrics.yaml

### DIFF
--- a/glean/src/metrics.yaml
+++ b/glean/src/metrics.yaml
@@ -227,7 +227,8 @@ glean.internal.metrics:
     send_in_pings:
       - glean_internal_info
     description: |
-      The version of the Glean SDK at the time the ping was collected (e.g. 25.0.0).
+      The version of the Glean SDK at the time the ping was collected
+      (e.g. 25.0.0).
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1556966
     data_reviews:


### PR DESCRIPTION
From the probe-scraper:

```
docker-compose run app python -m probe_scraper.check_repositoriesCreating probe-scraper_app_run ... done

Summary of validation errors:

1 repositories had problems


Errors found in glean-js:

230:81: line too long (84 > 80 characters) (line-length)
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint && npm run lint:circular-deps` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
