### PR TITLE
Wrap description line before 80-char limit

### DIFF
--- a/glean/src/metrics.yaml
+++ b/glean/src/metrics.yaml
@@ -386,7 +386,8 @@ glean:
     description: |
       Event that signals an application restart.
 
-      **This event is included in all pings (custom or otherwise) that contain events.**
+      **This event is included in all pings (custom or otherwise)
+      that contain events.**
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1716724
     data_reviews:


### PR DESCRIPTION
The Glinter yaml check otherwise fails, e.g. in probe-scraper.

---

See e.g. https://app.circleci.com/pipelines/github/mozilla/probe-scraper/663/workflows/b1b2f155-9e0f-4934-98ab-d17cbf417975/jobs/1094