### PR TITLE
Bug 1693487 - Accept booleans and numbers as event extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#580](https://github.com/mozilla/glean.js/pull/580): Limit size of pings database to 250 pings or 10MB.
 * [#580](https://github.com/mozilla/glean.js/pull/580): BUGFIX: Pending pings at startup up are uploaded from oldest to newest.
 * [#607](https://github.com/mozilla/glean.js/pull/607): Record an error when incoherent timestamps are calculated for events after a restart.
+* [#630](https://github.com/mozilla/glean.js/pull/630): Accept booleans and numbers as event extras.
 
 # v0.18.1 (2021-07-22)
 

--- a/glean/package-lock.json
+++ b/glean/package-lock.json
@@ -795,23 +795,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.0.tgz",
-      "integrity": "sha512-HPq7XAaDMM3DpmuijxLV9Io8/6pQnliiXMQUcAdjpJJSR+fdmbD/zHCd7hMkjJn04UQtCQBtshgxClzg6NIS2w==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "4.29.0",
-        "@typescript-eslint/visitor-keys": "4.29.0"
-      },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/types": {
       "version": "4.29.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.0.tgz",
@@ -9058,16 +9041,6 @@
             "eslint-visitor-keys": "^2.0.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/scope-manager": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.0.tgz",
-      "integrity": "sha512-HPq7XAaDMM3DpmuijxLV9Io8/6pQnliiXMQUcAdjpJJSR+fdmbD/zHCd7hMkjJn04UQtCQBtshgxClzg6NIS2w==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.29.0",
-        "@typescript-eslint/visitor-keys": "4.29.0"
       }
     },
     "@typescript-eslint/types": {

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -19,7 +19,7 @@ const LOG_TAG = "CLI";
 const VIRTUAL_ENVIRONMENT_DIR = ".venv";
 
 // The version of glean_parser to install from PyPI.
-const GLEAN_PARSER_VERSION = "3.7.0";
+const GLEAN_PARSER_VERSION = "3.8.0";
 
 // This script runs a given Python module as a "main" module, like
 // `python -m module`. However, it first checks that the installed

--- a/glean/src/core/metrics/events_database/index.ts
+++ b/glean/src/core/metrics/events_database/index.ts
@@ -278,7 +278,7 @@ class EventsDatabase {
    * 1. Sorts event by execution counter and timestamp;
    * 2. Applies offset to events timestamps;
    * 3. Removes the first event if it is a `glean.restarted` event;
-   * 4. Removes reserved extra keys.
+   * 4. Removes reserved extra keys and stringifies all extras values.
    *
    * @param pingName The name of the ping for which the payload is being prepared.
    * @param pingData An unsorted list of events.
@@ -368,7 +368,7 @@ class EventsDatabase {
       );
     }
 
-    return sortedEvents.map((e) => RecordedEvent.toJSONObject(e.withoutReservedExtras()));
+    return sortedEvents.map((e) => RecordedEvent.toJSONObject(e.payload()));
   }
 
   /**

--- a/glean/src/core/metrics/events_database/recorded_event.ts
+++ b/glean/src/core/metrics/events_database/recorded_event.ts
@@ -5,8 +5,9 @@
 import { GLEAN_RESERVED_EXTRA_KEYS } from "../../constants.js";
 import type { JSONObject } from "../../utils.js";
 
-// An helper type for the 'extra' map.
-export type ExtraMap = Record<string, string>;
+export type ExtraValues = string | boolean | number;
+// A helper type for the 'extra' map.
+export type ExtraMap = Record<string, ExtraValues>;
 
 // Represents the recorded data for a single event.
 export class RecordedEvent {
@@ -53,7 +54,7 @@ export class RecordedEvent {
    * @param key The key to add.
    * @param value The value of the key.
    */
-  addExtra(key: string, value: string): void {
+  addExtra(key: string, value: ExtraValues): void {
     if (!this.extra) {
       this.extra = {};
     }

--- a/glean/src/core/metrics/events_database/recorded_event.ts
+++ b/glean/src/core/metrics/events_database/recorded_event.ts
@@ -48,6 +48,20 @@ export class RecordedEvent {
     );
   }
 
+  private static withTransformedExtras(
+    e: RecordedEvent,
+    transformFn: (extras: ExtraMap) => ExtraMap
+  ): RecordedEvent {
+    const extras = e.extra || {};
+    const transformedExtras = transformFn(extras);
+    return new RecordedEvent(
+      e.category,
+      e.name,
+      e.timestamp,
+      (transformedExtras && Object.keys(transformedExtras).length > 0) ? transformedExtras : undefined
+    );
+  }
+
   /**
    * Add another extra key to a RecordedEvent object.
    *
@@ -69,19 +83,38 @@ export class RecordedEvent {
    * @returns A new RecordedEvent object.
    */
   withoutReservedExtras(): RecordedEvent {
-    const extras = this.extra || {};
-    const filteredExtras = Object.keys(extras)
-      .filter(key => !GLEAN_RESERVED_EXTRA_KEYS.includes(key))
-      .reduce((obj: ExtraMap, key) => {
-        obj[key] = extras[key];
-        return obj;
-      }, {});
+    return RecordedEvent.withTransformedExtras(
+      this,
+      (extras: ExtraMap): ExtraMap => {
+        return Object.keys(extras)
+          .filter(key => !GLEAN_RESERVED_EXTRA_KEYS.includes(key))
+          .reduce((obj: ExtraMap, key) => {
+            obj[key] = extras[key];
+            return obj;
+          }, {});
+      }
+    );
+  }
 
-    return new RecordedEvent(
-      this.category,
-      this.name,
-      this.timestamp,
-      (filteredExtras && Object.keys(filteredExtras).length > 0) ? filteredExtras : undefined
+  /**
+   * Generate a new RecordedEvent object,
+   * in the format expected on ping payloads.
+   *
+   * Strips reserved extra keys
+   * and stringifies all event extras.
+   *
+   * @returns A new RecordedEvent object.
+   */
+  payload(): RecordedEvent {
+    return RecordedEvent.withTransformedExtras(
+      this.withoutReservedExtras(),
+      (extras: ExtraMap): ExtraMap => {
+        return Object.keys(extras)
+          .reduce((extra: Record<string, string>, key) => {
+            extra[key] = extras[key].toString();
+            return extra;
+          }, {});
+      }
     );
   }
 }

--- a/glean/tests/integration/schema/metrics.yaml
+++ b/glean/tests/integration/schema/metrics.yaml
@@ -139,9 +139,15 @@ for_testing:
     send_in_pings:
       - testing
     extra_keys:
-      sample:
-        description: |
-          Sample extra key.
+      sample_string:
+        description: Sample string extra key.
+        type: string
+      sample_boolean:
+        description: Sample boolean extra key.
+        type: boolean
+      sample_quantity:
+        description: Sample quantity extra key.
+        type: quantity
   quantity:
     type: quantity
     description: |

--- a/glean/tests/integration/schema/schema.spec.ts
+++ b/glean/tests/integration/schema/schema.spec.ts
@@ -60,7 +60,11 @@ describe("schema", function() {
     metrics.boolean.set(false);
     metrics.counter.add(10);
     metrics.datetime.set();
-    metrics.event.record({ sample: "hey" });
+    metrics.event.record({
+      sample_string: "hey",
+      sample_boolean: false,
+      sample_quantity: 42,
+    });
     metrics.labeledBoolean["a_label"].set(true);
     metrics.labeledCounter["a_label"].add();
     metrics.labeledString["a_label"].set("ho");

--- a/glean/tests/unit/core/metrics/events_database.spec.ts
+++ b/glean/tests/unit/core/metrics/events_database.spec.ts
@@ -199,7 +199,7 @@ describe("EventsDatabase", function() {
       // We need to use `getAndValidatePingData` here,
       // because the public function will strip reserved extra keys.
       const rawRecordedEvent = (await db["getAndValidatePingData"](ping))[0];
-      assert.strictEqual(rawRecordedEvent.extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], "1");
+      assert.strictEqual(rawRecordedEvent.extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], 1);
     }
   });
 
@@ -271,8 +271,8 @@ describe("EventsDatabase", function() {
     // We expect only two events here, restarted and the above. Execution counter 1.
     const rawRecordedEvents1 = (await db["getAndValidatePingData"]("aPing"));
     assert.strictEqual(rawRecordedEvents1.length, 2);
-    assert.strictEqual(rawRecordedEvents1[0].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], "1");
-    assert.strictEqual(rawRecordedEvents1[1].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], "1");
+    assert.strictEqual(rawRecordedEvents1[0].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], 1);
+    assert.strictEqual(rawRecordedEvents1[1].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], 1);
 
     // Fake restart Glean and record a new event.
     const restartedDb = new EventsDatabase(Glean.platform.Storage);
@@ -288,15 +288,15 @@ describe("EventsDatabase", function() {
     // the next two events are this run's restart event + the event we just recorded and both are execution counter 2.
     const rawRecordedEvents2 = (await db["getAndValidatePingData"]("aPing"))
       .sort((a, b) => {
-        const executionCounterA = parseInt(a.extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY] || "0");
-        const executionCounterB = parseInt(b.extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY] || "0");
+        const executionCounterA = a.extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY] as number;
+        const executionCounterB = b.extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY] as number;
         return executionCounterA - executionCounterB;
       });
     assert.strictEqual(rawRecordedEvents2.length, 4);
-    assert.strictEqual(rawRecordedEvents2[0].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], "1");
-    assert.strictEqual(rawRecordedEvents2[1].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], "1");
-    assert.strictEqual(rawRecordedEvents2[2].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], "2");
-    assert.strictEqual(rawRecordedEvents2[3].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], "2");
+    assert.strictEqual(rawRecordedEvents2[0].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], 1);
+    assert.strictEqual(rawRecordedEvents2[1].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], 1);
+    assert.strictEqual(rawRecordedEvents2[2].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], 2);
+    assert.strictEqual(rawRecordedEvents2[3].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], 2);
 
     ping.submit();
     // Sanity check that the execution counter was cleared.
@@ -311,8 +311,8 @@ describe("EventsDatabase", function() {
     // We expect only two events again, the other have been cleared, execution counter 1.
     const rawRecordedEvents3 = (await db["getAndValidatePingData"]("aPing"));
     assert.strictEqual(rawRecordedEvents3.length, 2);
-    assert.strictEqual(rawRecordedEvents3[0].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], "1");
-    assert.strictEqual(rawRecordedEvents3[1].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], "1");
+    assert.strictEqual(rawRecordedEvents3[0].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], 1);
+    assert.strictEqual(rawRecordedEvents3[1].extra?.[GLEAN_EXECUTION_COUNTER_EXTRA_KEY], 1);
   });
 
   it("reserved extra properties are removed from the recorded events", async function () {

--- a/samples/qt-qml-app/requirements.txt
+++ b/samples/qt-qml-app/requirements.txt
@@ -1,3 +1,3 @@
 PySide2==5.15.2
 shiboken2==5.15.2
-glean_parser==3.7.0
+glean_parser==3.8.0


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - This behaviour [is already documented on the Glean book](https://mozilla.github.io/glean/book/reference/metrics/event.html), although looking at the docs I think they might benefit from having examples for quantity and boolean extra types too. I'll follow-up with a PR to the Glean book updating it.

~**Opening as a draft: I'll make the necessary changes to glean_parser and then update glean_parser in this PR before it is ready.**~
