### PR TITLE
Bug 1726769 - Include development version in Qt/QML build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#658](https://github.com/mozilla/glean.js/pull/658): Implement rate limiting for ping upload.
   * Only up to 15 ping submissions every 60 seconds are now allowed.
 * [#658](https://github.com/mozilla/glean.js/pull/658): BUGFIX: Unblock ping uploading jobs after the maximum of upload failures are hit for a given uploading window.
+* [#661](https://github.com/mozilla/glean.js/pull/661): Include unminified version of library on Qt/QML builds.
 
 # v0.18.1 (2021-07-22)
 

--- a/glean/package-lock.json
+++ b/glean/package-lock.json
@@ -789,23 +789,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.2.tgz",
-      "integrity": "sha512-mfHmvlQxmfkU8D55CkZO2sQOueTxLqGvzV+mG6S/6fIunDiD2ouwsAoiYCZYDDK73QCibYjIZmGhpvKwAB5BOA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "4.29.2",
-        "@typescript-eslint/visitor-keys": "4.29.2"
-      },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/types": {
       "version": "4.29.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.2.tgz",
@@ -9075,16 +9058,6 @@
             "eslint-visitor-keys": "^2.0.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/scope-manager": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.2.tgz",
-      "integrity": "sha512-mfHmvlQxmfkU8D55CkZO2sQOueTxLqGvzV+mG6S/6fIunDiD2ouwsAoiYCZYDDK73QCibYjIZmGhpvKwAB5BOA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "4.29.2",
-        "@typescript-eslint/visitor-keys": "4.29.2"
       }
     },
     "@typescript-eslint/types": {

--- a/glean/src/platform/qt/storage.ts
+++ b/glean/src/platform/qt/storage.ts
@@ -180,7 +180,14 @@ class QMLStore implements Store {
 
   async get(index: StorageIndex): Promise<JSONValue | undefined> {
     const obj = (await this._getFullResultObject(index)) || {};
-    return getValueFromNestedObject(obj, index);
+    try {
+      return getValueFromNestedObject(obj, index);
+    } catch(e) {
+      log(LOG_TAG, [
+        "Error getting value from database.",
+        JSON.stringify((e as Error).message)
+      ]);
+    }
   }
 
   async update(

--- a/glean/webpack.config.qt.js
+++ b/glean/webpack.config.qt.js
@@ -9,8 +9,6 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const OUTPUT = "glean.lib.js";
-
 /**
  * Hacky plugin that removes ".js" extensions from imports before resolving.
  *
@@ -40,51 +38,77 @@ class TsResolvePlugin {
  * and not anywhere else.
  */
 class RemoveUseStrictPlugin {
+  constructor(output) {
+    this.output = output;
+  }
+
   apply(compiler) {
     compiler.hooks.shouldEmit.tap("RemoveUseStrictPlugin", compilation => {
-      compilation.assets[OUTPUT]._value = compilation.assets[OUTPUT]._value.replace("\"use strict\";", "");
+      if (compilation.assets[this.output]._children) {
+        compilation.assets[this.output]._children[0]._value = compilation.assets[this.output]._children[0]._value.replace("\"use strict\";", "");
+      } else {
+        compilation.assets[this.output]._value = compilation.assets[this.output]._value?.replace("\"use strict\";", "");
+      }
       return true;
     });
   }
 }
 
-export default {
-  entry: "./src/index/qt.ts",
+// eslint-disable-next-line
+function getBaseConfig(output) {
+  return {
+    entry: "./src/index/qt.ts",
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          loader: "ts-loader",
+          exclude: /node_modules/,
+          options: {
+            onlyCompileBundledFiles: true,
+            // This path is resolved relative to the entry file, ./src/index/qt.ts
+            // See: https://github.com/TypeStrong/ts-loader#configfile
+            configFile: "../../tsconfig/qt.json"
+          },
+        },
+      ],
+    },
+    resolve: {
+      modules: ["node_modules"],
+      extensions: [ ".tsx", ".ts", ".js" ],
+      plugins: [
+        new TsResolvePlugin()
+      ]
+    },
+    plugins: [
+      new RemoveUseStrictPlugin(output),
+    ],
+    output: {
+      path: path.resolve(__dirname, "dist/qt/org/mozilla/Glean"),
+      filename: output,
+      libraryTarget: "var",
+      library: "Glean",
+    }
+  };
+}
+
+const productionConfig = {
+  ...getBaseConfig("glean.lib.js"),
   mode: "production",
   optimization: {
     usedExports: true,
     providedExports: true,
     sideEffects: true,
   },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        loader: "ts-loader",
-        exclude: /node_modules/,
-        options: {
-          onlyCompileBundledFiles: true,
-          // This path is resolved relative to the entry file, ./src/index/qt.ts
-          // See: https://github.com/TypeStrong/ts-loader#configfile
-          configFile: "../../tsconfig/qt.json"
-        },
-      },
-    ],
-  },
-  resolve: {
-    modules: ["node_modules"],
-    extensions: [ ".tsx", ".ts", ".js" ],
-    plugins: [
-      new TsResolvePlugin()
-    ]
-  },
-  plugins: [
-    new RemoveUseStrictPlugin(),
-  ],
-  output: {
-    path: path.resolve(__dirname, "dist/qt/org/mozilla/Glean"),
-    filename: OUTPUT,
-    libraryTarget: "var",
-    library: "Glean",
-  }
 };
+
+const developmentConfig = {
+  ...getBaseConfig("glean.dev.js"),
+  mode: "development",
+  devtool: false
+};
+
+export default [
+  productionConfig,
+  developmentConfig
+];


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] ~**Tests**: This PR includes thorough tests or an explanation of why it does not~
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - I'll file a follow up to document how to use the development version. It requires changing the `glean.js` file inside the Qt library folder, which is... kinda horrible, but at this point, better than nothing.
  - https://bugzilla.mozilla.org/show_bug.cgi?id=1727352