### PR TITLE
Bug 1727318 - Dispatcher can't be stopped while it's being shutdown

### DIFF
--- a/glean/src/core/dispatcher.ts
+++ b/glean/src/core/dispatcher.ts
@@ -30,7 +30,7 @@ const enum Commands {
   // The dispatcher will enqueue a new task.
   //
   // This command is always followed by a concrete task for the dispatcher to execute.
-  Task,
+  Task = "Task",
   // Same as the `Task` command,
   // but the task enqueued by this command is not cleared by the `Clear` command.
   //
@@ -39,15 +39,15 @@ const enum Commands {
   // `Shutdown` will still clear these tasks.
   //
   // Unless unavoidable, prefer using the normal `Task`.
-  PersistentTask,
+  PersistentTask = "PersistentTask",
   // The dispatcher should stop executing the queued tasks.
-  Stop,
+  Stop = "Stop",
   // The dispatcher should stop executing the queued tasks and clear the queue.
-  Clear,
+  Clear = "Clear",
   // The dispatcher will clear the queue and go into the Shutdown state.
-  Shutdown,
+  Shutdown = "Shutdown",
   // Exactly like a normal Task, but spawned for tests.
-  TestTask,
+  TestTask = "TestTask",
 }
 
 // A task the dispatcher knows how to execute.
@@ -75,7 +75,10 @@ class Dispatcher {
   private queue: Command[];
   // The current state of this dispatcher.
   private state: DispatcherState;
-  // A promise contianing the current execution promise.
+  // Whether or not the dispatcher is currently in the process of shutting down
+  // i.e. a Shutdown command is in the queue.
+  private shuttingDown = false;
+  // A promise containing the current execution promise.
   //
   // This is `undefined` in case there is no ongoing execution of tasks.
   private currentJob?: Promise<void>;
@@ -134,6 +137,7 @@ class Dispatcher {
         this.unblockTestResolvers();
         this.queue = [];
         this.state = DispatcherState.Shutdown;
+        this.shuttingDown = false;
         return;
       case(Commands.Clear):
         this.unblockTestResolvers();
@@ -320,9 +324,18 @@ class Dispatcher {
    * While stopped the dispatcher will still enqueue tasks but won't execute them.
    *
    * In order to re-start the dispatcher, call the `resume` method.
+   *
+   * # Note
+   *
+   * In case a Shutdown command has been launched before this command,
+   * this command will result in the queue being cleared.
    */
   stop(): void {
-    this.launchInternal({ command: Commands.Stop }, true);
+    if (this.shuttingDown) {
+      this.clear();
+    } else {
+      this.launchInternal({ command: Commands.Stop }, true);
+    }
   }
 
   /**
@@ -353,6 +366,7 @@ class Dispatcher {
    * @returns A promise which resolves once shutdown is complete.
    */
   shutdown(): Promise<void> {
+    this.shuttingDown = true;
     this.launchInternal({ command: Commands.Shutdown });
     this.resume();
     return this.currentJob || Promise.resolve();

--- a/glean/src/core/dispatcher.ts
+++ b/glean/src/core/dispatcher.ts
@@ -309,9 +309,11 @@ class Dispatcher {
    * # Note
    *
    * Even if the dispatcher is stopped this command will be executed.
+   *
+   * @param priorityTask Whether or not to launch the clear command as a priority task.
    */
-  clear(): void {
-    this.launchInternal({ command: Commands.Clear }, true);
+  clear(priorityTask = true): void {
+    this.launchInternal({ command: Commands.Clear }, priorityTask);
     this.resume();
   }
 
@@ -329,12 +331,15 @@ class Dispatcher {
    *
    * In case a Shutdown command has been launched before this command,
    * this command will result in the queue being cleared.
+   *
+   * @param priorityTask Whether or not to launch the clear command as a priority task.
+   * This is `true` by default.
    */
-  stop(): void {
+  stop(priorityTask = true): void {
     if (this.shuttingDown) {
-      this.clear();
+      this.clear(priorityTask);
     } else {
-      this.launchInternal({ command: Commands.Stop }, true);
+      this.launchInternal({ command: Commands.Stop }, priorityTask);
     }
   }
 

--- a/glean/src/core/upload/index.ts
+++ b/glean/src/core/upload/index.ts
@@ -26,9 +26,9 @@ import RateLimiter, { RateLimiterState } from "./rate_limiter.js";
 const LOG_TAG = "core.Upload";
 
 // Default rate limiter interval, in milliseconds.
-const RATE_LIMITER_INTERVAL_MS = 60 * 1000;
+export const RATE_LIMITER_INTERVAL_MS = 60 * 1000;
 // Default max pings per internal.
-const MAX_PINGS_PER_INTERVAL = 15;
+export const MAX_PINGS_PER_INTERVAL = 15;
 
 /**
  * Create and initialize a dispatcher for the PingUplaoder.
@@ -132,7 +132,9 @@ class PingUploader implements PingsDatabaseObserver {
     if (rateLimiterState === RateLimiterState.Incrementing) {
       this.dispatcher.resume();
     } else {
-      this.dispatcher.stop();
+      // Stop the dispatcher respecting the order of the dispatcher queue,
+      // to make sure the Stop command is enqueued _after_ previously enqueued requests.
+      this.dispatcher.stop(false);
 
       if (rateLimiterState === RateLimiterState.Throttled) {
         log(

--- a/glean/tests/unit/core/dispatcher.spec.ts
+++ b/glean/tests/unit/core/dispatcher.spec.ts
@@ -474,7 +474,7 @@ describe("Dispatcher", function() {
       return Promise.resolve();
     };
 
-    // Launch a group of tasks
+    // Launch a group of tasks.
     for (let i = 0; i < 5; i++) {
       dispatcher.launch(counterTask1);
     }
@@ -490,7 +490,7 @@ describe("Dispatcher", function() {
       executionCounter2++;
       return Promise.resolve();
     };
-    // Launch another group of tasks
+    // Launch another group of tasks.
     for (let i = 0; i < 5; i++) {
       dispatcher.launch(counterTask2);
     }

--- a/glean/tests/unit/core/dispatcher.spec.ts
+++ b/glean/tests/unit/core/dispatcher.spec.ts
@@ -10,7 +10,7 @@ import Dispatcher, { DispatcherState } from "../../../src/core/dispatcher";
 const sandbox = sinon.createSandbox();
 
 /**
- * A sample task which returns a promise that takes between 0 and 10 ms to resolve.
+ * A sample task which returns a promise that takes between 0 and 10ms to resolve.
  *
  * @returns The promise resolved when the timeout expires.
  */
@@ -462,6 +462,44 @@ describe("Dispatcher", function() {
     // After shutdown all previosu tasks are executed.
     await dispatcher.shutdown();
     assert.strictEqual(executionCounter, 10);
+  });
+
+  it("dispatcher can't be stopped while it's being shutdown, queue is actually cleared", async function () {
+    dispatcher = new Dispatcher();
+    dispatcher.flushInit();
+
+    let executionCounter1 = 0;
+    const counterTask1 = (): Promise<void> => {
+      executionCounter1++;
+      return Promise.resolve();
+    };
+
+    // Launch a group of tasks
+    for (let i = 0; i < 5; i++) {
+      dispatcher.launch(counterTask1);
+    }
+
+    // Launch a task that will also attempt to stop the dispatcher.
+    dispatcher.launch(async () => {
+      await new Promise<void>(resolve => setTimeout(() => resolve(), 100));
+      dispatcher.stop();
+    });
+
+    let executionCounter2 = 0;
+    const counterTask2 = (): Promise<void> => {
+      executionCounter2++;
+      return Promise.resolve();
+    };
+    // Launch another group of tasks
+    for (let i = 0; i < 5; i++) {
+      dispatcher.launch(counterTask2);
+    }
+
+    await dispatcher.shutdown();
+    // Tasks launched before the stop command were executed after shutdown.
+    assert.strictEqual(executionCounter1, 5);
+    // Tasks launched after were not.
+    assert.strictEqual(executionCounter2, 0);
   });
 
   it("persistent or otherwise, all tasks launched after shutdown are cleared", async function () {


### PR DESCRIPTION
I also found another bug on the rate limit implementaion while working on this bug, which is fixed in 5be95ad.

Detailed descriptions on the commit messages explain the changes made.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] ~**Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one~
   - I think CHANGELOG changes are unnecessary here. This is part of rate limiting implementation, which is already there.
- [ ] ~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~

