### PR TITLE
Bug 1727269 - Run the size benchmark against a full main checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,7 @@ jobs:
       - run:
           name: Get and post build sizes to GitHub PR
           command: |
-            npm --prefix ./benchmarks install
-            npm --prefix ./benchmarks run size:report
+            ./benchmarks/run.sh
 
   check-qt-js:
     docker:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,19 @@
+# Glean.js size benchmarks
+
+Compare the size of the different Glean bundles across the local `main` branch and the current checkout.
+
+## How to run
+
+To run a local report:
+
+```
+npm run size:report:dry
+```
+
+To run the report and post the results to a GitHub pull request:
+
+```
+npm run size:report
+```
+
+_Note: This requires a `GITHUB_TOKEN` and the CircleCI environment to know which PR to post to._

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -6,15 +6,14 @@
   "type": "module",
   "scripts": {
     "link:glean": "cd ../glean && npm i && npm run build && npm link && cd ../benchmarks && npm link @mozilla/glean",
-    "link:glean:main": "git stash && git checkout main && npm run link:glean && git checkout @{-1} && git stash apply",
     "size:build:webext": "webpack --config ./size/webext/webpack.config.js",
     "size:build:webext:main": "npm run size:build:webext -- -o dist/size/webext/main",
     "size:build:qt": "mkdir -p ./dist/size/qt/ && cp ../glean/dist/qt/org/mozilla/Glean/glean.lib.js ./dist/size/qt/",
     "size:build:qt:main": "mkdir -p ./dist/size/qt/ && cp ../glean/dist/qt/org/mozilla/Glean/glean.lib.js ./dist/size/qt/glean.main.lib.js",
     "size:build": "run-s link:glean size:build:webext size:build:qt",
-    "size:build:main": "run-s link:glean:main size:build:webext:main size:build:qt:main",
-    "size:report:dry": "run-s size:build size:build:main && DRY_RUN=1 node --experimental-json-modules size/report.js",
-    "size:report": "run-s size:build:main size:build && node --experimental-json-modules size/report.js"
+    "size:build:main": "run-s link:glean size:build:webext:main size:build:qt:main",
+    "size:report:dry": "DRY_RUN=1 ./run.sh",
+    "size:report": "./run.sh"
   },
   "author": "The Glean Team <glean-team@mozilla.com>",
   "license": "MPL-2.0",

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -xe
+
+WORKSPACE_ROOT="$( cd "$(dirname "$0")/.." ; pwd -P )"
+cd "$WORKSPACE_ROOT"
+
+# Benchmark the main branch
+tmpdir=$(mktemp -d)
+git worktree add --force "${tmpdir}" main
+pushd "${tmpdir}"
+npm --prefix ./benchmarks install
+npm --prefix ./benchmarks run size:build:main
+cp -a "${tmpdir}/benchmarks/dist" "${WORKSPACE_ROOT}/benchmarks"
+popd
+git worktree remove --force "${tmpdir}"
+
+# Benchmark the current code
+npm --prefix ./benchmarks install
+npm --prefix ./benchmarks run size:build
+
+# Post the details
+node --experimental-json-modules benchmarks/size/report.js


### PR DESCRIPTION
Instead of switching back and forth between branches this uses an
additional worktree.
This guarantees that the benchmark runs fully against code in the main
branch first, then fully against code in the current checkout.

This requires that the report code in the latest checkout needs to be
able to consume the report from the `main` branch,
so be careful when changing its format.

---

I decided to do this in an external script.
That seems to be easier than to cram this into individual npm scripts.

~~Also note: this will only start working properly AFTER this PR has been merged and can't be tested on this PR.~~