### PR TITLE
Add chutten and mdboom to the Glean.js reviewers rotation

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -5,5 +5,7 @@ reviewers:
   - Dexterp37
   - travis79
   - brizental
+  - mdboom
+  - chutten
 
 numberOfReviewers: 1


### PR DESCRIPTION
As discussed in today's meeting.