### PR TITLE
Bug 1728128 - Ensure events database is initialized at a time when metrics can be recorded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@
 * [#661](https://github.com/mozilla/glean.js/pull/661): Include unminified version of library on Qt/QML builds.
 * [#647](https://github.com/mozilla/glean.js/pull/647): Implement the Text metric type.
 * [#681](https://github.com/mozilla/glean.js/pull/681): BUGFIX: Fix error in scanning events database upon initialization on Qt/QML.
-  * This bug prevents the changes introduced in [#526](https://github.com/mozilla/glean.js/pull/526) from working properly.
-* [#614](https://github.com/mozilla/glean.js/pull/614): Implement the String List metric type.
+  * This bug prevents the changes introduced in [#526](https://github.com/mozilla/glean.js/pull/526) from working properly in Qt/QML.
+* [#692](https://github.com/mozilla/glean.js/pull/692): BUGFIX: Ensure events database is initialized at a time Glean is already able to record metrics.
+  * This bug also prevents the changes introduced in [#526](https://github.com/mozilla/glean.js/pull/526) from working properly in all platforms.
 
 # v0.18.1 (2021-07-22)
 

--- a/glean/src/core/context.ts
+++ b/glean/src/core/context.ts
@@ -8,6 +8,10 @@ import type EventsDatabase from "./metrics/events_database/index.js";
 import type PingsDatabase from "./pings/database.js";
 import type ErrorManager from "./error/index.js";
 import Dispatcher from "./dispatcher.js";
+import log, { LoggingLevel } from "./log.js";
+import { isUndefined } from "./utils.js";
+
+const LOG_TAG = "core.Context";
 
 /**
  * This class holds all of the Glean singleton's state and internal dependencies.
@@ -26,19 +30,17 @@ export class Context {
 
   private _dispatcher!: Dispatcher | null;
 
+  // The following group of properties are all set on Glean.initialize
+  // Attempting to get them before initialize Glean will throw an error.
   private _uploadEnabled!: boolean;
   private _metricsDatabase!: MetricsDatabase;
   private _eventsDatabase!: EventsDatabase;
   private _pingsDatabase!: PingsDatabase;
-  // The reason this was added to the Context,
-  // is to avoid a circular dependency between
-  // the ErrorManager's module and the CounterMetricType module.
   private _errorManager!: ErrorManager;
-
   private _applicationId!: string;
-  private _initialized: boolean;
-
   private _debugOptions!: DebugOptions;
+
+  private _initialized: boolean;
 
   // The moment the current Glean.js session started.
   private _startTime: Date;
@@ -89,11 +91,17 @@ export class Context {
     return Context.instance._dispatcher;
   }
 
-  static set dispatcher(dispatcher: Dispatcher) {
-    Context.instance._dispatcher = dispatcher;
-  }
-
   static get uploadEnabled(): boolean {
+    if (isUndefined(Context.instance._uploadEnabled)) {
+      log(
+        LOG_TAG,
+        [
+          "Attempted to access Context.uploadEnabled before it was set. This may cause unexpected behaviour.",
+        ],
+        LoggingLevel.Error
+      );
+    }
+
     return Context.instance._uploadEnabled;
   }
 
@@ -102,6 +110,16 @@ export class Context {
   }
 
   static get metricsDatabase(): MetricsDatabase {
+    if (isUndefined(Context.instance._metricsDatabase)) {
+      log(
+        LOG_TAG,
+        [
+          "Attempted to access Context.metricsDatabase before it was set. This may cause unexpected behaviour.",
+        ],
+        LoggingLevel.Error
+      );
+    }
+
     return Context.instance._metricsDatabase;
   }
 
@@ -110,6 +128,16 @@ export class Context {
   }
 
   static get eventsDatabase(): EventsDatabase {
+    if (isUndefined(Context.instance._eventsDatabase)) {
+      log(
+        LOG_TAG,
+        [
+          "Attempted to access Context.eventsDatabase before it was set. This may cause unexpected behaviour.",
+        ],
+        LoggingLevel.Error
+      );
+    }
+
     return Context.instance._eventsDatabase;
   }
 
@@ -118,6 +146,16 @@ export class Context {
   }
 
   static get pingsDatabase(): PingsDatabase {
+    if (isUndefined(Context.instance._pingsDatabase)) {
+      log(
+        LOG_TAG,
+        [
+          "Attempted to access Context.pingsDatabase before it was set. This may cause unexpected behaviour.",
+        ],
+        LoggingLevel.Error
+      );
+    }
+
     return Context.instance._pingsDatabase;
   }
 
@@ -126,6 +164,16 @@ export class Context {
   }
 
   static get errorManager(): ErrorManager {
+    if (isUndefined(Context.instance._errorManager)) {
+      log(
+        LOG_TAG,
+        [
+          "Attempted to access Context.errorManager before it was set. This may cause unexpected behaviour.",
+        ],
+        LoggingLevel.Error
+      );
+    }
+
     return Context.instance._errorManager;
   }
 
@@ -134,6 +182,16 @@ export class Context {
   }
 
   static get applicationId(): string {
+    if (isUndefined(Context.instance._applicationId)) {
+      log(
+        LOG_TAG,
+        [
+          "Attempted to access Context.applicationId before it was set. This may cause unexpected behaviour.",
+        ],
+        LoggingLevel.Error
+      );
+    }
+
     return Context.instance._applicationId;
   }
 
@@ -150,6 +208,16 @@ export class Context {
   }
 
   static get debugOptions(): DebugOptions {
+    if (isUndefined(Context.instance._debugOptions)) {
+      log(
+        LOG_TAG,
+        [
+          "Attempted to access Context.debugOptions before it was set. This may cause unexpected behaviour.",
+        ],
+        LoggingLevel.Error
+      );
+    }
+
     return Context.instance._debugOptions;
   }
 
@@ -158,6 +226,6 @@ export class Context {
   }
 
   static get startTime(): Date {
-    return Context._instance._startTime;
+    return Context.instance._startTime;
   }
 }

--- a/glean/src/core/context.ts
+++ b/glean/src/core/context.ts
@@ -9,7 +9,6 @@ import type PingsDatabase from "./pings/database.js";
 import type ErrorManager from "./error/index.js";
 import Dispatcher from "./dispatcher.js";
 import log, { LoggingLevel } from "./log.js";
-import { isUndefined } from "./utils.js";
 
 const LOG_TAG = "core.Context";
 
@@ -31,7 +30,7 @@ export class Context {
   private _dispatcher: Dispatcher;
 
   // The following group of properties are all set on Glean.initialize
-  // Attempting to get them before initialize Glean will throw an error.
+  // Attempting to get them before they are set will log an error.
   private _uploadEnabled!: boolean;
   private _metricsDatabase!: MetricsDatabase;
   private _eventsDatabase!: EventsDatabase;
@@ -64,9 +63,7 @@ export class Context {
    *
    * Resets the Context to an uninitialized state.
    */
-  static async testUninitialize(): Promise<void> {
-    // Clear the dispatcher queue.
-    await Context.instance._dispatcher?.testUninitialize();
+  static testUninitialize(): void {
     Context._instance = undefined;
   }
 
@@ -75,7 +72,7 @@ export class Context {
   }
 
   static get uploadEnabled(): boolean {
-    if (isUndefined(Context.instance._uploadEnabled)) {
+    if (typeof Context.instance._uploadEnabled === "undefined") {
       log(
         LOG_TAG,
         [
@@ -93,7 +90,7 @@ export class Context {
   }
 
   static get metricsDatabase(): MetricsDatabase {
-    if (isUndefined(Context.instance._metricsDatabase)) {
+    if (typeof Context.instance._metricsDatabase === "undefined") {
       log(
         LOG_TAG,
         [
@@ -111,7 +108,7 @@ export class Context {
   }
 
   static get eventsDatabase(): EventsDatabase {
-    if (isUndefined(Context.instance._eventsDatabase)) {
+    if (typeof Context.instance._eventsDatabase === "undefined") {
       log(
         LOG_TAG,
         [
@@ -129,7 +126,7 @@ export class Context {
   }
 
   static get pingsDatabase(): PingsDatabase {
-    if (isUndefined(Context.instance._pingsDatabase)) {
+    if (typeof Context.instance._pingsDatabase === "undefined") {
       log(
         LOG_TAG,
         [
@@ -147,7 +144,7 @@ export class Context {
   }
 
   static get errorManager(): ErrorManager {
-    if (isUndefined(Context.instance._errorManager)) {
+    if (typeof Context.instance._errorManager === "undefined") {
       log(
         LOG_TAG,
         [
@@ -165,7 +162,7 @@ export class Context {
   }
 
   static get applicationId(): string {
-    if (isUndefined(Context.instance._applicationId)) {
+    if (typeof Context.instance._applicationId === "undefined") {
       log(
         LOG_TAG,
         [
@@ -191,7 +188,7 @@ export class Context {
   }
 
   static get debugOptions(): DebugOptions {
-    if (isUndefined(Context.instance._debugOptions)) {
+    if (typeof Context.instance._debugOptions === "undefined") {
       log(
         LOG_TAG,
         [

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -528,7 +528,7 @@ class Glean {
       }
 
       // Get back to an uninitialized state.
-      await Context.testUninitialize();
+      Context.testUninitialize();
 
       // Deregister all plugins
       testResetEvents();

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -210,8 +210,12 @@ class Glean {
       return;
     }
 
+    Context.applicationId = sanitizeApplicationId(applicationId);
+
     // The configuration constructor will throw in case config has any incorrect prop.
     const correctConfig = new Configuration(config);
+    Context.debugOptions = correctConfig.debug;
+    Glean.instance._config = correctConfig;
 
     Context.metricsDatabase = new MetricsDatabase(Glean.platform.Storage);
     Context.eventsDatabase = new EventsDatabase(Glean.platform.Storage);

--- a/glean/src/core/upload/index.ts
+++ b/glean/src/core/upload/index.ts
@@ -14,6 +14,7 @@ import type {
   Observer as PingsDatabaseObserver,
   PingInternalRepresentation
 } from "../pings/database.js";
+import type PingsDatabase from "../pings/database.js";
 import {
   isDeletionRequest
 } from "../pings/database.js";
@@ -96,7 +97,7 @@ class PingUploader implements PingsDatabaseObserver {
   constructor(
     config: Configuration,
     platform: Platform,
-    private readonly pingsDatabase = Context.pingsDatabase,
+    private readonly pingsDatabase: PingsDatabase,
     private readonly policy = new Policy(),
     private readonly rateLimiter = new RateLimiter(RATE_LIMITER_INTERVAL_MS, MAX_PINGS_PER_INTERVAL)
   ) {

--- a/glean/tests/unit/core/context.spec.ts
+++ b/glean/tests/unit/core/context.spec.ts
@@ -69,11 +69,11 @@ describe("Context", function() {
     assert.ok(Context.pingsDatabase instanceof PingsDatabase);
   });
 
-  it("the dispatcher is always available", async function () {
+  it("the dispatcher is always available", function () {
     const originalDispatcher = Context.dispatcher;
     assert.notStrictEqual(originalDispatcher, null);
 
-    await Context.testUninitialize();
+    Context.testUninitialize();
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/glean/tests/unit/core/context.spec.ts
+++ b/glean/tests/unit/core/context.spec.ts
@@ -77,7 +77,7 @@ describe("Context", function() {
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    assert.strictEqual(Context.instance._dispatcher, null);
+    assert.strictEqual(Context._instance?._dispatcher, undefined);
 
     // Trying to access the dispatcher will instantiate a new one.
     const newDispatcher = Context.instance;

--- a/glean/tests/unit/core/glean.spec.ts
+++ b/glean/tests/unit/core/glean.spec.ts
@@ -566,7 +566,6 @@ describe("Glean", function() {
 
     // Check that Glean was able to record the `glean.restarted` event on initialization.
     const restartedEvent = getGleanRestartedEventMetric(["custom"]);
-    console.log(await restartedEvent.testGetValue("custom"));
     // We expect two events. One that was recorded when we recorded an event on the custom ping
     // for the first time and another once we re-initialized.
     assert.strictEqual((await restartedEvent.testGetValue("custom"))?.length, 2);

--- a/glean/tests/unit/core/glean.spec.ts
+++ b/glean/tests/unit/core/glean.spec.ts
@@ -301,11 +301,9 @@ describe("Glean", function() {
 
   it("deletion request ping is sent when toggling upload status between runs", async function() {
     Glean.setUploadEnabled(true);
-    await Context.dispatcher.testBlockOnQueue();
 
-    // Can't use testResetGlean here because it clears all stores
-    // and when there is no client_id at all stored, a deletion ping is also not sent.
-    await Glean.testUninitialize();
+    // Un-initialize, but don't clear the stores.
+    await Glean.testUninitialize(false);
 
     const mockUploader = new WaitableUploader();
     const pingBody = mockUploader.waitForPingSubmission("deletion-request");

--- a/glean/tests/unit/core/metrics/labeled.spec.ts
+++ b/glean/tests/unit/core/metrics/labeled.spec.ts
@@ -433,8 +433,7 @@ describe("LabeledMetric", function() {
     }
 
     // Reset glean without clearing the storage.
-    await Glean.testUninitialize();
-    await Glean.testInitialize("gleanjs.unit.test", true);
+    await Glean.testResetGlean(testAppId, true, undefined, false);
 
     // Try to store another label.
     labeledCounterMetric["new_label"].add(40);

--- a/glean/tests/unit/core/pings/ping_type.spec.ts
+++ b/glean/tests/unit/core/pings/ping_type.spec.ts
@@ -12,6 +12,7 @@ import Glean from "../../../../src/core/glean";
 import { Context } from "../../../../src/core/context";
 import { stopGleanUploader } from "../../../utils";
 import type { JSONObject } from "../../../../src/core/utils";
+import TestPlatform from "../../../../src/platform/test";
 
 const sandbox = sinon.createSandbox();
 
@@ -100,14 +101,15 @@ describe("PingType", function() {
   it("no pings are submitted if Glean has not been initialized", async function() {
     await Glean.testUninitialize();
 
+    const spy = sandbox.spy(TestPlatform.uploader, "post");
     const ping = new PingType({
       name: "custom",
       includeClientId: true,
       sendIfEmpty: false,
     });
     await submitSync(ping);
-    const storedPings = await Context.pingsDatabase["store"].get();
-    assert.strictEqual(storedPings, undefined);
+
+    assert.ok(!spy.calledOnce);
   });
 
   it("runs a validator with no metrics tests", async function() {


### PR DESCRIPTION
After tests, I confirmed none of the sample apps were recording the `glean.restarted` event when Glean was initialized :/ That was the case, because we were calling `eventsDatabase.initialize` before setting `Context.uploadEnabled`. That meant `Context.uploadEnabled` was `undefined` upon events database initialization and `undefined` being a falsy value, `.shouldRecord()` was returning `false`, which resulted in the `glean.restarted` and `execution_counter` metrics not being recorded.

In 8324569 I fix that and in 4cb6118 I add a test to ensure that if this behaviour ever changes we will see test failures.

The commits in between these two commits are there to make sure the test _does_ fail if the behaviour is changed. I actually found a bug in the way we were reseting Glean in tests. We were not reseting all the preoperties in the `Context`, only a few. That would prevent the test I added from actually failing when it had to. 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] ~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~
   - This is a bugfix, I guess a CHANGELOG entry is documentation enough.
