### PR TITLE
Bug 1728808 - Implement a PlatformInfo module that works in Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.19.0...main)
 
+* [#696](https://github.com/mozilla/glean.js/pull/696): Expose Node.js entry point `@mozilla/glean/node`.
+* [#695](https://github.com/mozilla/glean.js/pull/695): Implement PlatformInfo module for the Node.js platform.
+
 # v0.19.0 (2021-09-03)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.18.1...v0.19.0)

--- a/glean/src/core/platform_info.ts
+++ b/glean/src/core/platform_info.ts
@@ -13,14 +13,19 @@ export const enum KnownOperatingSystems {
   NetBSD = "NetBSD",
   OpenBSD = "OpenBSD",
   Solaris = "Solaris",
+  Unknown = "Unknown",
+
   // ChromeOS is not listed in the Glean SDK because it is not a possibility there.
   ChromeOS = "ChromeOS",
+
   // The following additions might be reported by Qt.
   TvOS = "tvOS", // https://developer.apple.com/tvos/
   Qnx = "QNX", // BlackBerry QNX
   Wasm = "Wasm",
-  // The Qt-specific additions end here.
-  Unknown = "Unknown",
+
+  // The following additions might be reported by Node.js
+  SunOS = "sunOS",
+  AIX = "IBM_AIX",
 }
 
 interface PlatformInfo {

--- a/glean/src/platform/node/index.ts
+++ b/glean/src/platform/node/index.ts
@@ -2,6 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Placeholding with the Test Platform for now
-// until we implement each component of the Node platform.
-export { default } from "../test/index.js";
+import PlatformInfo from "./platform_info.js";
+import type Platform from "../index.js";
+
+// We will still use the TestPlatform as a placeholder
+// for the other Node.js modules that have not been implemented yet.
+import TestPlatform from "../test/index.js";
+
+const NodePlatform: Platform = {
+  ...TestPlatform,
+  info: PlatformInfo,
+};
+
+export default NodePlatform;

--- a/glean/src/platform/node/index.ts
+++ b/glean/src/platform/node/index.ts
@@ -7,11 +7,13 @@ import type Platform from "../index.js";
 
 // We will still use the TestPlatform as a placeholder
 // for the other Node.js modules that have not been implemented yet.
+// See Bug 1728810 (Uploader) and Bug 1728807 (Storage).
 import TestPlatform from "../test/index.js";
 
 const NodePlatform: Platform = {
   ...TestPlatform,
   info: PlatformInfo,
+  name: "node"
 };
 
 export default NodePlatform;

--- a/glean/src/platform/node/platform_info.ts
+++ b/glean/src/platform/node/platform_info.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import os from "os";
+
+import type PlatformInfo from "../../core/platform_info.js";
+import { KnownOperatingSystems } from "../../core/platform_info.js";
+
+const NodePlatformInfo: PlatformInfo = {
+  async os(): Promise<KnownOperatingSystems> {
+    // Possible values are listed in https://nodejs.org/api/process.html#process_process_platform
+    switch(process.platform) {
+    case "darwin":
+      return Promise.resolve(KnownOperatingSystems.MacOS);
+    case "win32":
+      return Promise.resolve(KnownOperatingSystems.Windows);
+    case "android":
+      return Promise.resolve(KnownOperatingSystems.Android);
+    case "freebsd":
+      return Promise.resolve(KnownOperatingSystems.FreeBSD);
+    case "linux":
+      return Promise.resolve(KnownOperatingSystems.Linux);
+    case "openbsd":
+      return Promise.resolve(KnownOperatingSystems.OpenBSD);
+    case "aix":
+      return Promise.resolve(KnownOperatingSystems.AIX);
+    default:
+      return Promise.resolve(KnownOperatingSystems.Unknown);
+    }
+  },
+
+  async osVersion(): Promise<string> {
+    // Note: `os.release()` returns the _kernel_, not OS version.
+    // That is the best Node.js will give us, so we will take it.
+    return Promise.resolve(os.release() || "Unknown");
+  },
+
+  async arch(): Promise<string> {
+    return Promise.resolve(os.arch() || "Unknown");
+  },
+
+  async locale(): Promise<string> {
+    return Promise.resolve(Intl.DateTimeFormat().resolvedOptions().locale || "und");
+  }
+};
+
+export default NodePlatformInfo;


### PR DESCRIPTION
This is what the ping looks like when sent from Node.js in my computer.

```json
(Glean.core.Pings.Maker) {
  "ping_info": {
    "seq": 0,
    "start_time": "2021-09-03T12:08+02:00",
    "end_time": "2021-09-03T12:08+02:00"
  },
  "client_info": {
    "telemetry_sdk_build": "0.19.0",
    "client_id": "7f7aacd9-7d4d-4ca5-bc69-2ab9f2705e08",
    "first_run_date": "2021-09-03+02:00",
    "os": "Darwin",
    "os_version": "20.6.0",
    "architecture": "x64",
    "locale": "en-US",
    "app_build": "Unknown",
    "app_display_version": "Unknown"
  }
}
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] ~**Tests**: This PR includes thorough tests or an explanation of why it does not~
   - Not really sure how to write a test for this, but I guess in this manual testing is enough.
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] ~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~
