### PR TITLE
No bug - Skip auto assign for dependabot PRs

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -7,5 +7,6 @@ reviewers:
   - brizental
   - mdboom
   - chutten
-
 numberOfReviewers: 1
+skipKeywords:
+  - Bump


### PR DESCRIPTION
All dependabot PRs start with the word "Bump". 

There are way too many dependabot PRs basically everyday, it will get annoying soon if auto assign keeps asking people for review on them.
