### PR TITLE
Bug 1729629: Remove URI encoding for the url metric type

### DIFF
--- a/glean/src/core/metrics/types/url.ts
+++ b/glean/src/core/metrics/types/url.ts
@@ -9,7 +9,7 @@ import { Context } from "../../context.js";
 import { Metric } from "../metric.js";
 import { ErrorType } from "../../error/error_type.js";
 
-// The maximum number of characters a URL Metric may have, before encoding.
+// The maximum number of characters a URL Metric may have.
 const URL_MAX_LENGTH = 2048;
 
 // This regex only validates that the `scheme` part of the URL is spec compliant
@@ -37,7 +37,7 @@ export class UrlMetric extends Metric<string, string> {
    * Validates that a given value is a valid URL metric value.
    *
    * 1. The URL must be a string.
-   * 2. The URL must have a maximum length of URL_MAX_LENGTH characters before the encoding.
+   * 2. The URL must have a maximum length of URL_MAX_LENGTH characters.
    * 3. The URL must not be a data URL.
    * 4. Every URL must start with a valid scheme.
    *
@@ -74,7 +74,7 @@ export class UrlMetric extends Metric<string, string> {
   }
 
   payload(): string {
-    return encodeURI(this._inner);
+    return this._inner;
   }
 }
 
@@ -128,7 +128,6 @@ class UrlMetricType extends MetricType {
    *
    * # Note
    *
-   * Although URL metrics are URI encoded in the ping payload,
    * this function will return the unencoded URL for convenience.
    *
    * This doesn't clear the stored value.

--- a/glean/tests/unit/core/metrics/url.spec.ts
+++ b/glean/tests/unit/core/metrics/url.spec.ts
@@ -79,7 +79,7 @@ describe("UrlMetric", function() {
     const snapshot = await Context.metricsDatabase.getPingMetrics("aPing", true);
     assert.deepStrictEqual(snapshot, {
       "url": {
-        "aCategory.aUrlMetric": "https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B"
+        "aCategory.aUrlMetric": "https://mozilla.org/?x=шеллы"
       }
     });
   });


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
