### PR TITLE
Fix publish step

### DIFF
--- a/glean/package.json
+++ b/glean/package.json
@@ -66,7 +66,7 @@
     "build:docs": "rm -rf dist/docs && typedoc src/ --out dist/docs --tsconfig tsconfig/docs.json --theme minimal",
     "build:metrics-docs": "npm run cli -- translate src/metrics.yaml src/pings.yaml -o ../docs/reference/ --format markdown --allow-reserved",
     "publish:docs": "NODE_DEBUG=gh-pages gh-pages --dotfiles --message \"[skip ci] Updates\" --dist dist/docs",
-    "prepublishOnly": "cp ../README.md ./README.md && run-s build:cli build:webext",
+    "prepublishOnly": "cp ../README.md ./README.md && run-s build:cli build:lib build:types",
     "postpublish": "rm ./README.md",
     "cli": "node --loader=ts-node/esm src/cli.ts"
   },


### PR DESCRIPTION
On tagging 0.21.0 the `publish to npm` step failed in CI due to `npm build:webext` not being available.

This commit https://github.com/mozilla/glean.js/commit/d73a93f777a3e7525be778e8ee9baae72f237abd#diff-509bb202baa8df0d26bbf11ae91491e2b3a9ae00a1b7528aa215ad5941c9909cL79 removed `build:webext` but did not remove the call to it in the `prePublishOnly` script.

Also, worth noting that refs to `build:webext` are in `benchmarks/package.json` but I have not fixed those in this PR as I don't know the best replacement.