### PR TITLE
Bug 1734730 - Fix docs build and add build CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,21 @@ jobs:
           name: Run integration tests
           command: export PATH=.:$PATH && npm --prefix ./glean run test:integration
 
+  build:
+    docker:
+      - image: cimg/python:3.9.4-node
+    steps:
+      - checkout
+      - run:
+          name: Install JavaScript dependencies
+          command: npm --prefix ./glean install
+      - run:
+          name: Build library
+          command: npm --prefix ./glean run build
+      - run:
+          name: Build docs
+          command: npm --prefix ./glean run build:docs
+
   webext-sample-tests:
     docker:
       - image: cimg/python:3.8.8-node
@@ -239,6 +254,7 @@ workflows:
     jobs:
       - lint
       - test
+      - build
       - webext-sample-tests
       - node-sample-tests
       - qt-sample-tests
@@ -247,6 +263,7 @@ workflows:
           requires:
             - lint
             - test
+            - build
             - webext-sample-tests
             - node-sample-tests
             - qt-sample-tests

--- a/glean/package.json
+++ b/glean/package.json
@@ -63,7 +63,7 @@
     "build:lib": "tsc -p ./tsconfig/lib.json",
     "build:types": "tsc -p ./tsconfig/types.json",
     "build:qt": "rm -rf dist/qt && webpack --config webpack.config.qt.js && ../bin/prepare-qml-module.sh",
-    "build:docs": "rm -rf dist/docs && typedoc src/ --out dist/docs --tsconfig tsconfig/docs.json --theme minimal",
+    "build:docs": "rm -rf dist/docs && typedoc src/**/*.ts src/**/**/*.ts src/**/**/**/*.ts --out dist/docs --tsconfig tsconfig/docs.json",
     "build:metrics-docs": "npm run cli -- translate src/metrics.yaml src/pings.yaml -o ../docs/reference/ --format markdown --allow-reserved",
     "publish:docs": "NODE_DEBUG=gh-pages gh-pages --dotfiles --message \"[skip ci] Updates\" --dist dist/docs",
     "prepublishOnly": "cp ../README.md ./README.md && run-s build:cli build:lib build:types",

--- a/glean/package.json
+++ b/glean/package.json
@@ -63,7 +63,7 @@
     "build:lib": "tsc -p ./tsconfig/lib.json",
     "build:types": "tsc -p ./tsconfig/types.json",
     "build:qt": "rm -rf dist/qt && webpack --config webpack.config.qt.js && ../bin/prepare-qml-module.sh",
-    "build:docs": "rm -rf dist/docs && typedoc src/**/*.ts src/**/**/*.ts src/**/**/**/*.ts --out dist/docs --tsconfig tsconfig/docs.json",
+    "build:docs": "rm -rf dist/docs && typedoc --entryPointStrategy expand ./src --out dist/docs --tsconfig tsconfig/docs.json",
     "build:metrics-docs": "npm run cli -- translate src/metrics.yaml src/pings.yaml -o ../docs/reference/ --format markdown --allow-reserved",
     "publish:docs": "NODE_DEBUG=gh-pages gh-pages --dotfiles --message \"[skip ci] Updates\" --dist dist/docs",
     "prepublishOnly": "cp ../README.md ./README.md && run-s build:cli build:lib build:types",


### PR DESCRIPTION
This probably got broken during one of dependabots updates, so now I added a CI job for us to know when dependabot breaks the build commands.