### PR TITLE
Bug 1734879 - Accept arch and os version as init params on Qt

### DIFF
--- a/glean/src/core/config.ts
+++ b/glean/src/core/config.ts
@@ -29,6 +29,16 @@ export interface ConfigurationInterface {
   plugins?: Plugin[],
   // The HTTP client implementation to use for uploading pings.
   httpClient?: Uploader,
+  // Qt-only fields
+  //
+  // These values are not easily accessible from QML,
+  // so we expose them as init fields for the caller to fill them out.
+  //
+  // The architecture of the device (e.g. "arm", "x86").
+  readonly architecture?: string,
+  // The user-visible version of the operating system (e.g. "1.2.3").
+  // If the version detection fails, this metric gets set to Unknown.
+  readonly osVersion?: string,
 }
 
 // Important: the `Configuration` should only be used internally by the Glean singleton.
@@ -41,6 +51,12 @@ export class Configuration implements ConfigurationInterface {
   readonly appDisplayVersion?: string;
   // The server pings are sent to.
   readonly serverEndpoint: string;
+  // The architecture of the device (e.g. "arm", "x86").
+  readonly architecture?: string;
+  // The user-visible version of the operating system (e.g. "1.2.3").
+  // If the version detection fails, this metric gets set to Unknown.
+  readonly osVersion?: string;
+
   // Debug configuration.
   debug: DebugOptions;
   // The HTTP client implementation to use for uploading pings.
@@ -50,6 +66,8 @@ export class Configuration implements ConfigurationInterface {
     this.channel = config?.channel;
     this.appBuild = config?.appBuild;
     this.appDisplayVersion = config?.appDisplayVersion;
+    this.architecture = config?.architecture;
+    this.osVersion = config?.osVersion;
 
     this.debug = Configuration.sanitizeDebugOptions(config?.debug);
 

--- a/glean/src/core/internal_metrics.ts
+++ b/glean/src/core/internal_metrics.ts
@@ -114,8 +114,8 @@ export class CoreMetrics {
     await this.initializeClientId();
     await this.initializeFirstRunDate();
     await StringMetricType._private_setUndispatched(this.os, await platform.info.os());
-    await StringMetricType._private_setUndispatched(this.osVersion, await platform.info.osVersion());
-    await StringMetricType._private_setUndispatched(this.architecture, await platform.info.arch());
+    await StringMetricType._private_setUndispatched(this.osVersion, await platform.info.osVersion(config.osVersion));
+    await StringMetricType._private_setUndispatched(this.architecture, await platform.info.arch(config.architecture));
     await StringMetricType._private_setUndispatched(this.locale, await platform.info.locale());
     await StringMetricType._private_setUndispatched(this.appBuild, config.appBuild || "Unknown");
     await StringMetricType._private_setUndispatched(this.appDisplayVersion, config.appDisplayVersion || "Unknown");

--- a/glean/src/core/platform_info.ts
+++ b/glean/src/core/platform_info.ts
@@ -39,16 +39,18 @@ interface PlatformInfo {
   /**
    * Gets and returns the current OS system version.
    *
+   * @param fallback A fallback value in case Glean is unable to retrive this value from the environment.
    * @returns The current OS version.
    */
-  osVersion(): Promise<string>;
+  osVersion(fallback?: string): Promise<string>;
 
   /**
    * Gets and returnst the current system architecture.
    *
+   * @param fallback A fallback value in case Glean is unable to retrive this value from the environment.
    * @returns The current system architecture.
    */
-  arch(): Promise<string>;
+  arch(fallback?: string): Promise<string>;
 
   /**
    * Gets and returnst the current system / browser locale.

--- a/glean/src/index/base.ts
+++ b/glean/src/index/base.ts
@@ -6,6 +6,12 @@ import Glean from "../core/glean.js";
 import type { ConfigurationInterface } from "../core/config.js";
 import type Platform from "../platform/index.js";
 
+// Strip the configuration interface of the Qt-only fields.
+type RestictedConfigurationInterface = Omit<
+  ConfigurationInterface,
+  "architecture" | "osVersion"
+>;
+
 export default (platform: Platform): {
   initialize(
     applicationId: string,
@@ -36,7 +42,7 @@ export default (platform: Platform): {
     initialize(
       applicationId: string,
       uploadEnabled: boolean,
-      config?: ConfigurationInterface
+      config?: RestictedConfigurationInterface
     ): void {
       Glean.setPlatform(platform);
       Glean.initialize(applicationId, uploadEnabled, config);
@@ -132,7 +138,7 @@ export default (platform: Platform): {
     async testResetGlean(
       applicationId: string,
       uploadEnabled = true,
-      config?: ConfigurationInterface
+      config?: RestictedConfigurationInterface
     ): Promise<void> {
       return Glean.testResetGlean(applicationId, uploadEnabled, config);
     }

--- a/glean/src/platform/qt/platform_info.ts
+++ b/glean/src/platform/qt/platform_info.ts
@@ -36,14 +36,14 @@ const QtPlatformInfo: PlatformInfo = {
     }
   },
 
-  async osVersion(): Promise<string> {
+  async osVersion(fallback?: string): Promise<string> {
     // This data point is not available in Qt QML.
-    return Promise.resolve("Unknown");
+    return Promise.resolve(fallback || "Unknown");
   },
 
-  async arch(): Promise<string> {
+  async arch(fallback?: string): Promise<string> {
     // This data point is not available in Qt QML.
-    return Promise.resolve("Unknown");
+    return Promise.resolve(fallback || "Unknown");
   },
 
   async locale(): Promise<string> {


### PR DESCRIPTION
I know we discussed making these values enums maybe, but for os version that is just not possible and for architecture that would be hard, see https://doc.qt.io/qt-5/qsysinfo.html#currentCpuArchitecture, we don't have a list of all the possible values returned by the Qt function that retrieves that value.

I think this is fine though, because different from what we thought yesterday, GLAM does not use the architecture field for creating filters, it uses only OS and channel.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] ~**Tests**: This PR includes thorough tests or an explanation of why it does not~
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
