### PR TITLE
No bug - Update dependabot.yml and make it less annoying (for samples)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,16 @@ updates:
   - package-ecosystem: "npm"
     directory: "/samples/browser/webext/javascript"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/samples/browser/web"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/samples/node"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/glean/tests/unit/platform/utils/webext/sample"
     schedule:
-      interval: "daily"
-  - package-ecosystem: "pip"
-    directory: "/samples/qt-qml-app"
-    schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
We made many changes to the samples, but forgot to update dependabot.yml. 

I took this opportunity to lower the amount of dependabot PRs per day. That was getting annoying.