### PR TITLE
No bug - Make CI jobs depend on one another

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           name: Build docs
           command: npm --prefix ./glean run build:docs
 
-  webext-sample-tests:
+  sample-webext-test:
     docker:
       - image: cimg/python:3.8.8-node
     steps:
@@ -118,7 +118,7 @@ jobs:
           command: |
             export PATH=.:$PATH && npm --prefix ./samples/browser/webext/typescript run test
 
-  node-sample-tests:
+  sample-node-test:
     docker:
       - image: cimg/python:3.8.8-node
     steps:
@@ -140,7 +140,7 @@ jobs:
           command: |
             export PATH=.:$PATH && npm --prefix ./samples/node run test
 
-  qt-sample-tests:
+  sample-qt-test:
     docker:
       - image: cimg/python:3.8.8-node
     steps:
@@ -253,20 +253,30 @@ workflows:
   ci:
     jobs:
       - lint
-      - test
-      - build
-      - webext-sample-tests
-      - node-sample-tests
-      - qt-sample-tests
+      - build:
+          requires:
+            - lint
+      - test:
+          requires:
+            - build
+      - sample-webext-test:
+          requires:
+            - test
+      - sample-node-test:
+          requires:
+            - test
+      - sample-qt-test:
+          requires:
+            - test
       - hold:
           type: approval
           requires:
             - lint
-            - test
             - build
-            - webext-sample-tests
-            - node-sample-tests
-            - qt-sample-tests
+            - test
+            - sample-webext-test
+            - sample-node-test
+            - sample-qt-test
           filters:
             branches:
               ignore:


### PR DESCRIPTION
So that we don't run CI jobs when it does not really make sense to run them.

+ Change `samples-*` job names so they show up in an organized manner on the GitHub interface. This is just me being annoying.