### PR TITLE
Bug 1738118 - Make sure Context.uploadEnabled always has a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * [#856](https://github.com/mozilla/glean.js/pull/860): Implement the `PlatformInfo` module for the web platform.
   * Out of `os`, `os_version`, `architecture` and `locale`, on the web platform, we can only retrive `os` and `locale` information. The other information will default to the known value `Unknown` for all pings coming from this platform.
 * [#856](https://github.com/mozilla/glean.js/pull/856): Expose the `@mozilla/glean/web` entry point for using Glean.js in websites.
+* [#908](https://github.com/mozilla/glean.js/pull/908): BUGFIX: Guarantee internal `uploadEnabled` state always has a value.
+  * When `uploadEnabled` was set to `false` and then Glean was restarted with it still `false`, the internal `uploadEnabled` state was not being set. That should not cause particularly harmful behaviour, since `undefined` is still a "falsy" value. However, this would create a stream of loud and annoying log messages.
 
 # v0.23.0 (2021-10-12)
 

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -271,6 +271,7 @@ class Glean {
       // Clear application lifetime metrics.
       await Context.metricsDatabase.clear(Lifetime.Application);
 
+      Context.uploadEnabled = uploadEnabled;
       // The upload enabled flag may have changed since the last run, for
       // example by the changing of a config file.
       if (uploadEnabled) {

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -8,7 +8,7 @@ import { Configuration } from "./config.js";
 import MetricsDatabase from "./metrics/database.js";
 import PingsDatabase from "./pings/database.js";
 import PingUploader from "./upload/index.js";
-import { isUndefined, sanitizeApplicationId } from "./utils.js";
+import { isBoolean, isString, isUndefined, sanitizeApplicationId } from "./utils.js";
 import { CoreMetrics } from "./internal_metrics.js";
 import EventsDatabase from "./metrics/events_database/index.js";
 import UUIDMetricType from "./metrics/types/uuid.js";
@@ -193,6 +193,24 @@ class Glean {
       return;
     }
 
+    if (!isString(applicationId)) {
+      log(
+        LOG_TAG,
+        "Unable to initialize Glean, applicationId must be a string.",
+        LoggingLevel.Error
+      );
+      return;
+    }
+
+    if (!isBoolean(uploadEnabled)) {
+      log(
+        LOG_TAG,
+        "Unable to initialize Glean, uploadEnabled must be a boolean.",
+        LoggingLevel.Error
+      );
+      return;
+    }
+
     if (applicationId.length === 0) {
       log(
         LOG_TAG,
@@ -205,7 +223,7 @@ class Glean {
     if (!Glean.instance._platform) {
       log(
         LOG_TAG,
-        "Unable to initialize Glean, environment has not been set.",
+        "Unable to initialize Glean, platform has not been set.",
         LoggingLevel.Error
       );
       return;

--- a/glean/tests/unit/core/glean.spec.ts
+++ b/glean/tests/unit/core/glean.spec.ts
@@ -569,6 +569,22 @@ describe("Glean", function() {
     // We expect two events. One that was recorded when we recorded an event on the custom ping
     // for the first time and another once we re-initialized.
     assert.strictEqual((await restartedEvent.testGetValue("custom"))?.length, 2);
+  });
 
+  it("glean is not initialized if uploadEnabled or applicationId are not the right type", async function() {
+    await Glean.testUninitialize();
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    await Glean.testResetGlean(["not", "string"], true);
+    assert.strictEqual(Context.initialized, false);
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    await Glean.testResetGlean(testAppId, "not boolean");
+    assert.strictEqual(Context.initialized, false);
+
+    await Glean.testResetGlean(testAppId, true);
+    assert.strictEqual(Context.initialized, true);
   });
 });

--- a/glean/tests/utils.ts
+++ b/glean/tests/utils.ts
@@ -73,7 +73,7 @@ export class WaitableUploader extends Uploader {
         resolve(result);
       };
 
-      setTimeout(() => reject(), 2000);
+      setTimeout(() => reject(), 1000);
     });
   }
 
@@ -95,7 +95,7 @@ export class WaitableUploader extends Uploader {
         resolve(pingBody as JSONObject);
       };
 
-      setTimeout(() => reject(), 2000);
+      setTimeout(() => reject(), 1000);
     });
   }
 


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] ~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~
   - This is a bugfix, changelog entry is enough.
