### PR TITLE
Bug 1740772 - Expose Uploader, UploadResult and UploadResultStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * [#924](https://github.com/mozilla/glean.js/pull/924): Only HTTPS server endpoints outside of testing mode.
   * In testing mode HTTP may be used. No other protocols are allowed.
+* [#951](https://github.com/mozilla/glean.js/pull/951): Expose Uploader, UploadResult and UploadResultStatus.
+  * These are necessary for creating custom uploaders. Especially from TypeScript.
 
 # v0.24.0 (2021-11-04)
 

--- a/glean/src/index/node.ts
+++ b/glean/src/index/node.ts
@@ -6,4 +6,5 @@ import platform from "../platform/node/index.js";
 import base from "./base.js";
 
 export { ErrorType } from "../core/error/error_type.js";
+export { default as Uploader, UploadResult, UploadResultStatus } from "../core/upload/uploader.js";
 export default base(platform);

--- a/glean/src/index/web.ts
+++ b/glean/src/index/web.ts
@@ -6,4 +6,5 @@ import platform from "../platform/browser/web/index.js";
 import base from "./base.js";
 
 export { ErrorType } from "../core/error/error_type.js";
+export { default as Uploader, UploadResult, UploadResultStatus } from "../core/upload/uploader.js";
 export default base(platform);

--- a/glean/src/index/webext.ts
+++ b/glean/src/index/webext.ts
@@ -6,4 +6,5 @@ import platform from "../platform/browser/webext/index.js";
 import base from "./base.js";
 
 export { ErrorType } from "../core/error/error_type.js";
+export { default as Uploader, UploadResult, UploadResultStatus } from "../core/upload/uploader.js";
 export default base(platform);


### PR DESCRIPTION
Left Qt out of this on purpose, seems to be a bit more involved to
expose these over there and no one is currently asking for it.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] ~**Tests**: This PR includes thorough tests or an explanation of why it does not~
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
   - I filed a follow up bug for this: https://bugzilla.mozilla.org/show_bug.cgi?id=1741133. Using custom uploader is really under documented so the bug is more generic.
