### PR TITLE
Bug 1741581 - Attempt to get virtualenv name from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.25.0...main)
 
+* [#965](https://github.com/mozilla/glean.js/pull/965): Attempt to infer the Python virtualenv folder from the environment before falling back to the default `.venv`.
+  * Users may provide a folder name through the `VIRTUAL_ENV` environment variable.
+  * If the user is inside an active virtualenv the `VIRTUAL_ENV` environment variable is already set by Python. See: https://docs.python.org/3/library/venv.html.
+
 # v0.25.0 (2021-11-15)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.24.0...v0.25.0)

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -14,9 +14,16 @@ import log, { LoggingLevel } from "./core/log.js";
 
 const LOG_TAG = "CLI";
 
-// The name of the directory which will contain the Python virtual environment
+// The name of the directory which contains / will contain the Python virtual environment
 // used to run the glean-parser.
-const VIRTUAL_ENVIRONMENT_DIR = ".venv";
+//
+// > When a virtual environment is active, the VIRTUAL_ENV environment variable
+// > is set to the path of the virtual environment. This can be used to check if
+// > one is running inside a virtual environment.
+//
+// See: https://docs.python.org/3/library/venv.html
+// (Also applies to envs created using virtualenv though)
+const VIRTUAL_ENVIRONMENT_DIR = process.env.VIRTUAL_ENV?.split("/").slice(-1)[0] || ".venv";
 
 // The version of glean_parser to install from PyPI.
 const GLEAN_PARSER_VERSION = "4.1.1";


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] ~**Tests**: This PR includes thorough tests or an explanation of why it does not~
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
   - https://bugzilla.mozilla.org/show_bug.cgi?id=1741829
