### PR TITLE
Bug 1712914 - Remove debug options from configuration object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.26.0...main)
 
+* [#967](https://github.com/mozilla/glean.js/pull/967): **BREAKING CHANGE**: Remove `debug` option from Glean configuration option.
+  * The `Glean.setDebugViewTag`, `Glean.setSourceTags` and `Glean.setLogPings` should be used instead. Note that these APIs can safely be called prior to initialization.
+
 # v0.26.0 (2021-11-19)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.25.0...v0.26.0)

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -326,11 +326,15 @@ class Glean {
   }
 
   static get debugViewTag(): string | undefined {
-    return Glean.instance._config?.debug.debugViewTag;
+    if (Glean.instance._config?.debugViewTag) {
+      return Glean.instance._config?.debugViewTag;
+    }
   }
 
   static get sourceTags(): string | undefined {
-    return Glean.instance._config?.debug.sourceTags?.toString();
+    if (Glean.instance._config?.debug.sourceTags) {
+      return Glean.instance._config?.debug.sourceTags?.toString();
+    }
   }
 
   static get platform(): Platform {
@@ -416,13 +420,8 @@ class Glean {
    *        This value must satify the regex `^[a-zA-Z0-9-]{1,20}$` otherwise it will be ignored.
    */
   static setDebugViewTag(value: string): void {
-    if (!Configuration.validateDebugViewTag(value)) {
-      log(LOG_TAG, `Invalid \`debugViewTag\` ${value}. Ignoring.`, LoggingLevel.Error);
-      return;
-    }
-
     Context.dispatcher.launch(() => {
-      Glean.instance._config.debug.debugViewTag = value;
+      Glean.instance._config.debugViewTag = value;
 
       // The dispatcher requires that dispatched functions return promises.
       return Promise.resolve();
@@ -442,13 +441,8 @@ class Glean {
    *        Individual tags must match the regex: "[a-zA-Z0-9-]{1,20}".
    */
   static setSourceTags(value: string[]): void {
-    if (!Configuration.validateSourceTags(value)) {
-      log(LOG_TAG, `Invalid \`sourceTags\` ${value.toString()}. Ignoring.`, LoggingLevel.Error);
-      return;
-    }
-
     Context.dispatcher.launch(() => {
-      Glean.instance._config.debug.sourceTags = value;
+      Glean.instance._config.sourceTags = value;
 
       // The dispatcher requires that dispatched functions return promises.
       return Promise.resolve();

--- a/glean/tests/unit/core/config.spec.ts
+++ b/glean/tests/unit/core/config.spec.ts
@@ -31,58 +31,23 @@ describe("config", function() {
     assert.throws(() => new Configuration({ serverEndpoint: wrongEndpoint }));
   });
 
-  it("validateSourceTags works correctly", function () {
+  it("validation of sourceTags works correctly", function () {
+    const config = new Configuration();
+
     // Invalid values
-    assert.ok(!Configuration.validateSourceTags([]));
-    assert.ok(!Configuration.validateSourceTags([""]));
-    assert.ok(!Configuration.validateSourceTags(["1", "2", "3", "4", "5", "6"]));
-    assert.ok(!Configuration.validateSourceTags(["!nv@lid-val*e"]));
-    assert.ok(!Configuration.validateSourceTags(["glean-test1", "test2"]));
+    config.sourceTags = [];
+    assert.deepStrictEqual([], config.sourceTags);
+    config.sourceTags = [""];
+    assert.deepStrictEqual([], config.sourceTags);
+    config.sourceTags = ["1", "2", "3", "4", "5", "6"];
+    assert.deepStrictEqual([], config.sourceTags);
+    config.sourceTags = ["!nv@lid-val*e"];
+    assert.deepStrictEqual([], config.sourceTags);
+    config.sourceTags = ["glean-test1", "test2"];
+    assert.deepStrictEqual([], config.sourceTags);
 
     // Valid values
-    assert.ok(Configuration.validateSourceTags(["5"]));
-  });
-
-  it("sanitizeDebugOptions works correctly", function() {
-    // Invalid values
-    assert.deepStrictEqual(Configuration.sanitizeDebugOptions({
-      debugViewTag: ""
-    }), {});
-    assert.deepStrictEqual(Configuration.sanitizeDebugOptions({
-      sourceTags: []
-    }), {});
-    assert.deepStrictEqual(Configuration.sanitizeDebugOptions({
-      debugViewTag: "",
-      sourceTags: ["ok"]
-    }), { sourceTags: ["ok"] });
-    assert.deepStrictEqual(Configuration.sanitizeDebugOptions({
-      debugViewTag: "",
-      logPings: true,
-      sourceTags: ["ok"]
-    }), { sourceTags: ["ok"], logPings: true });
-
-    // Valid values
-    assert.deepStrictEqual(Configuration.sanitizeDebugOptions({}), {});
-    assert.deepStrictEqual(
-      Configuration.sanitizeDebugOptions({ logPings: true }),
-      { logPings: true }
-    );
-    assert.deepStrictEqual(
-      Configuration.sanitizeDebugOptions({ debugViewTag: "ok" }),
-      { debugViewTag: "ok" }
-    );
-    assert.deepStrictEqual(
-      Configuration.sanitizeDebugOptions({ sourceTags: ["ok"] }),
-      { sourceTags: ["ok"] }
-    );
-  });
-
-  it("validation functions are not called when debug view and source tags are not present", function () {
-    const sourceTagsSpy = sandbox.spy(Configuration, "validateSourceTags");
-    const debugViewTagSpy = sandbox.spy(Configuration, "validateDebugViewTag");
-
-    Configuration.sanitizeDebugOptions({});
-    assert.strictEqual(sourceTagsSpy.callCount, 0);
-    assert.strictEqual(debugViewTagSpy.callCount, 0);
+    config.sourceTags = ["5"];
+    assert.deepStrictEqual(["5"], config.sourceTags);
   });
 });

--- a/glean/tests/unit/core/context.spec.ts
+++ b/glean/tests/unit/core/context.spec.ts
@@ -51,13 +51,6 @@ describe("Context", function() {
     assert.strictEqual(Context.initialized, false);
   });
 
-  it("debugOptions contain the expected value", async function () {
-    assert.deepStrictEqual(Context.debugOptions, {});
-
-    await Glean.testResetGlean("new-id", true, { debug: { logPings: true }});
-    assert.deepStrictEqual(Context.debugOptions, { logPings: true });
-  });
-
   it("databases contain the expected values", function () {
     assert.notStrictEqual(Context.metricsDatabase, undefined);
     assert.ok(Context.metricsDatabase instanceof MetricsDatabase);

--- a/glean/tests/unit/core/glean.spec.ts
+++ b/glean/tests/unit/core/glean.spec.ts
@@ -369,13 +369,6 @@ describe("Glean", function() {
   it("setting log pings works before and after and on initialize", async function () {
     await Glean.testUninitialize();
 
-    // Setting on initialize.
-    await Glean.testInitialize(testAppId, true, { debug: { logPings: true } });
-    await Context.dispatcher.testBlockOnQueue();
-    assert.ok(Glean.logPings);
-
-    await Glean.testUninitialize();
-
     // Setting before initialize.
     Glean.setLogPings(true);
     await Glean.testInitialize(testAppId, true);
@@ -392,11 +385,6 @@ describe("Glean", function() {
 
     const testTag = "test";
 
-    // Setting on initialize.
-    await Glean.testInitialize(testAppId, true, { debug: { debugViewTag: testTag } });
-    await Context.dispatcher.testBlockOnQueue();
-    assert.strictEqual(Glean.debugViewTag, testTag);
-
     await Glean.testUninitialize();
 
     // Setting before initialize.
@@ -411,29 +399,26 @@ describe("Glean", function() {
     assert.strictEqual(Glean.debugViewTag, anotherTestTag);
   });
 
-  it("attempting to set an invalid debug view tag is ignored and no task is dispatched", function () {
-    const dispatchSpy = sandbox.spy(Context.dispatcher, "launch");
-
+  it("attempting to set an invalid debug view tag is ignored", async function () {
     const invaligTag = "inv@l!d_t*g";
     Glean.setDebugViewTag(invaligTag);
+    await Context.dispatcher.testBlockOnQueue();
     assert.strictEqual(Glean.debugViewTag, undefined);
-    assert.ok(dispatchSpy.notCalled);
   });
 
   it("setting source tags on initialize works", async function () {
     await Glean.testUninitialize();
-    await Glean.testInitialize(testAppId, true, { debug: { sourceTags: ["1", "2", "3", "4", "5"] } });
+    await Glean.testInitialize(testAppId, true);
+    Glean.setSourceTags(["1", "2", "3", "4", "5"]);
     await Context.dispatcher.testBlockOnQueue();
     assert.strictEqual(Glean.sourceTags, "1,2,3,4,5");
   });
 
-  it("attempting to set invalid source tags is ignored and no task is dispatched", function () {
-    const dispatchSpy = sandbox.spy(Context.dispatcher, "launch");
-
+  it("attempting to set invalid source tags is ignored", async function () {
     const invaligTags = ["inv@l!d_t*g"];
     Glean.setSourceTags(invaligTags);
+    await Context.dispatcher.testBlockOnQueue();
     assert.strictEqual(Glean.sourceTags, undefined);
-    assert.ok(dispatchSpy.notCalled);
   });
 
   it("testResetGlean correctly resets", async function () {

--- a/glean/tests/unit/core/pings/maker.spec.ts
+++ b/glean/tests/unit/core/pings/maker.spec.ts
@@ -175,12 +175,8 @@ describe("PingMaker", function() {
     // Disable ping uploading for it not to interfere with this tests.
     await stopGleanUploader();
 
-    await Glean.testResetGlean(testAppId, true, {
-      debug: {
-        logPings: true
-      },
-      plugins: [ new MockPlugin() ]
-    });
+    await Glean.testResetGlean(testAppId, true, { plugins: [ new MockPlugin() ] });
+    Glean.setLogPings(true);
 
     const ping = new PingType({
       name: "ping",
@@ -216,12 +212,8 @@ describe("PingMaker", function() {
       }
     }
 
-    await Glean.testResetGlean(testAppId, true, {
-      debug: {
-        logPings: true
-      },
-      plugins: [ new ThrowingPlugin() ]
-    });
+    await Glean.testResetGlean(testAppId, true, { plugins: [ new ThrowingPlugin() ] });
+    Glean.setLogPings(true);
 
     const ping = new PingType({
       name: "ping",

--- a/glean/tests/unit/plugins/encryption.spec.ts
+++ b/glean/tests/unit/plugins/encryption.spec.ts
@@ -89,9 +89,6 @@ describe("PingEncryptionPlugin", function() {
         plugins: [
           new PingEncryptionPlugin(await exportJWK(publicKey))
         ],
-        debug: {
-          logPings: true
-        },
         httpClient,
       },
     );

--- a/samples/browser/webext/src/index.ts
+++ b/samples/browser/webext/src/index.ts
@@ -8,7 +8,8 @@ import Glean from "@mozilla/glean/webext";
 import { submission } from "./generated/pings";
 import { webextStarted, popupOpened } from "./generated/sample";
 
-Glean.initialize("web-extension", true, { debug: { logPings: true }});
+Glean.setLogPings(true);
+Glean.initialize("web-extension", true);
 webextStarted.set();
 
 // Listen for messages from the popup.


### PR DESCRIPTION
The reason for this change is to be consistent with the other SDKs. None of them allow to pass debug options on init.

Best to make this change now that we don't have that many users.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] ~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~
  - This was never documented specifically because we did not want people to use it.
