### PR TITLE
Bug 1738208 - Add runtime type check to args passed to setUploadEnabled API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#965](https://github.com/mozilla/glean.js/pull/965): Attempt to infer the Python virtualenv folder from the environment before falling back to the default `.venv`.
   * Users may provide a folder name through the `VIRTUAL_ENV` environment variable.
   * If the user is inside an active virtualenv the `VIRTUAL_ENV` environment variable is already set by Python. See: https://docs.python.org/3/library/venv.html.
+* [#968](https://github.com/mozilla/glean.js/pull/968): Add runtime arguments type checking to `Glean.setUploadEnabled` API.
 
 # v0.25.0 (2021-11-15)
 

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -356,6 +356,15 @@ class Glean {
    * @param flag When true, enable metric collection.
    */
   static setUploadEnabled(flag: boolean): void {
+    if (!isBoolean(flag)) {
+      log(
+        LOG_TAG,
+        "Unable to change upload state, new value must be a boolean. Ignoring.",
+        LoggingLevel.Error
+      );
+      return;
+    }
+
     Context.dispatcher.launch(async () => {
       if (!Context.initialized) {
         log(

--- a/glean/tests/unit/core/glean.spec.ts
+++ b/glean/tests/unit/core/glean.spec.ts
@@ -605,4 +605,18 @@ describe("Glean", function() {
     await Glean.testResetGlean(testAppId, true);
     assert.strictEqual(Context.initialized, true);
   });
+
+  it("setUploadEnabled does nothing in case a non-boolean value is passed to it", async function() {
+    // Set the current upload value to false,
+    // strings are "truthy", this way we can be sure calling with the wrong type dod not work.
+    Glean.setUploadEnabled(false);
+    await Context.dispatcher.testBlockOnQueue();
+    assert.strictEqual(Context.uploadEnabled, false);
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    Glean.setUploadEnabled("not a boolean");
+    await Context.dispatcher.testBlockOnQueue();
+    assert.strictEqual(Context.uploadEnabled, false);
+  });
 });


### PR DESCRIPTION
The metrics public APIs already do type checking. The pings `submit` API also checks if reason is valid. Other Glean singletons APIs also do validation of arguments.

The only API missing was uploadEnabled really. 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] ~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~
