### PR TITLE
No bug - Return unrecoverable result in case unable to build ping request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.27.0...main)
 
+* [#984](https://github.com/mozilla/glean.js/pull/984): BUGFIX: Return correct upload result in case an error happens while building a ping request.
+
 # v0.27.0 (2021-11-22)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.26.0...v0.27.0)

--- a/glean/src/core/upload/index.ts
+++ b/glean/src/core/upload/index.ts
@@ -281,7 +281,7 @@ class PingUploader implements PingsDatabaseObserver {
       log(LOG_TAG, [ "Error trying to build ping request:", e ], LoggingLevel.Warn);
       // An unrecoverable failure will make sure the offending ping is removed from the queue and
       // deleted from the database, which is what we want here.
-      return new UploadResult(UploadResultStatus.RecoverableFailure);
+      return new UploadResult(UploadResultStatus.UnrecoverableFailure);
     }
   }
 

--- a/glean/tests/unit/core/upload/index.spec.ts
+++ b/glean/tests/unit/core/upload/index.spec.ts
@@ -226,6 +226,9 @@ describe("PingUploader", function() {
 
     // Check that none of those pings were actually sent.
     assert.strictEqual(spy.callCount, 0);
+
+    // Check that queue is empty and all large pings were discarded.
+    assert.strictEqual(uploader["processing"].length, 0);
   });
 
   it("correctly build ping request", async function () {


### PR DESCRIPTION
This is a bug in the implementation and a surprising one at that.
That is a comment right above the line I just fixed saying "we want
an unrecoverable failure here..." which is followed by returning
a recoverable failure.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] ~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~
