### PR TITLE
Bug 1742093 - Refactor upload management logic to be exactly like in glean-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.27.0...main)
 
 * [#984](https://github.com/mozilla/glean.js/pull/984): BUGFIX: Return correct upload result in case an error happens while building a ping request.
+* [#988](https://github.com/mozilla/glean.js/pull/988): BUGFIX: Enforce rate limitation at upload time, not at ping submission time.
+  * Note: This change required a big refactoring of the internal uploading logic.
 
 # v0.27.0 (2021-11-22)
 

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -7,7 +7,7 @@ import type { ConfigurationInterface } from "./config.js";
 import { Configuration } from "./config.js";
 import MetricsDatabase from "./metrics/database.js";
 import PingsDatabase from "./pings/database.js";
-import PingUploader from "./upload/index.js";
+import PingUploadManager from "./upload/manager.js";
 import { isBoolean, isString, isUndefined, sanitizeApplicationId } from "./utils.js";
 import { CoreMetrics } from "./internal_metrics.js";
 import EventsDatabase from "./metrics/events_database/index.js";
@@ -39,7 +39,7 @@ class Glean {
   // The ping uploader. Note that we need to use the definite assignment assertion
   // because initialization will not happen in the constructor, but in the `initialize`
   // method.
-  private _pingUploader!: PingUploader;
+  private _pingUploader!: PingUploadManager;
   // The Glean configuration object.
   private _config!: Configuration;
 
@@ -62,7 +62,7 @@ class Glean {
     return Glean._instance;
   }
 
-  private static get pingUploader(): PingUploader {
+  private static get pingUploader(): PingUploadManager {
     return Glean.instance._pingUploader;
   }
 
@@ -238,7 +238,7 @@ class Glean {
     Context.pingsDatabase = new PingsDatabase();
     Context.errorManager = new ErrorManager();
 
-    Glean.instance._pingUploader = new PingUploader(correctConfig, Context.pingsDatabase);
+    Glean.instance._pingUploader = new PingUploadManager(correctConfig, Context.pingsDatabase);
 
     Context.pingsDatabase.attachObserver(Glean.pingUploader);
 

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -240,8 +240,6 @@ class Glean {
 
     Glean.instance._pingUploader = new PingUploadManager(correctConfig, Context.pingsDatabase);
 
-    Context.pingsDatabase.attachObserver(Glean.pingUploader);
-
     if (config?.plugins) {
       for (const plugin of config.plugins) {
         registerPluginToEvent(plugin);
@@ -460,11 +458,11 @@ class Glean {
   static async shutdown(): Promise<void> {
     // Order here matters!
     //
-    // The main dispatcher needs to be shut down first,
-    // because some of its tasks may enqueue new tasks on the ping uploader dispatcher
+    // The dispatcher needs to be shutdown first,
+    // because some of its tasks may enqueue new pings to upload
     // and we want these uploading tasks to also be executed prior to complete shutdown.
     await Context.dispatcher.shutdown();
-    await Glean.pingUploader.shutdown();
+    await Glean.pingUploader.blockOnOngoingUploads();
   }
 
   /**

--- a/glean/src/core/upload/manager.ts
+++ b/glean/src/core/upload/manager.ts
@@ -107,7 +107,7 @@ class PingUploadManager implements PingsDatabaseObserver {
       }
 
       this.waitAttemptCount++;
-      if (this.waitAttemptCount >= this.policy.maxWaitAttempts) {
+      if (this.waitAttemptCount > this.policy.maxWaitAttempts) {
         return uploadTaskFactory.done();
       }
 

--- a/glean/src/core/upload/manager.ts
+++ b/glean/src/core/upload/manager.ts
@@ -67,7 +67,7 @@ class PingBodyOverflowError extends Error {
  * If three retriable upload failures are hit in a row,
  * we bail out before uploading all enqued pings.
  */
-class PingUploader implements PingsDatabaseObserver {
+class PingUploadManager implements PingsDatabaseObserver {
   // A list of pings currently being processed.
   private processing: QueuedPing[];
   // Local dispathcer instance to handle execution of ping requests.
@@ -401,4 +401,4 @@ class PingUploader implements PingsDatabaseObserver {
   }
 }
 
-export default PingUploader;
+export default PingUploadManager;

--- a/glean/src/core/upload/manager.ts
+++ b/glean/src/core/upload/manager.ts
@@ -2,277 +2,143 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { gzipSync, strToU8 } from "fflate";
-
 import type { Configuration } from "../config.js";
-import { GLEAN_VERSION } from "../constants.js";
-import { Context } from "../context.js";
-import Dispatcher from "../dispatcher.js";
-import log, { LoggingLevel } from "../log.js";
 import type {
   Observer as PingsDatabaseObserver,
   PingInternalRepresentation
 } from "../pings/database.js";
 import type PingsDatabase from "../pings/database.js";
-import {
-  isDeletionRequest
-} from "../pings/database.js";
-import type PlatformInfo from "../platform_info.js";
-import type Uploader from "./uploader.js";
-import { UploadResult, UploadResultStatus } from "./uploader.js";
+import type { UploadResult } from "./uploader.js";
+import type { UploadTask} from "./task.js";
+import { Context } from "../context.js";
+import log, { LoggingLevel } from "../log.js";
+import { isDeletionRequest } from "../pings/database.js";
 import RateLimiter, { RateLimiterState } from "./rate_limiter.js";
+import { UploadResultStatus } from "./uploader.js";
+import PingUploadWorker from "./worker.js";
 import Policy from "./policy.js";
+import uploadTaskFactory, { UploadTaskTypes } from "./task.js";
 
-const LOG_TAG = "core.Upload";
+const LOG_TAG = "core.Upload.PingUploadManager";
 
-// Default rate limiter interval, in milliseconds.
-export const RATE_LIMITER_INTERVAL_MS = 60 * 1000;
-// Default max pings per internal.
-export const MAX_PINGS_PER_INTERVAL = 40;
-
-/**
- * Create and initialize a dispatcher for the PingUplaoder.
- *
- * @returns The created dispatcher instance.
- */
-function createAndInitializeDispatcher(): Dispatcher {
-  const dispatcher = new Dispatcher(100, `${LOG_TAG}.Dispatcher`);
-  dispatcher.flushInit();
-  return dispatcher;
-}
-
-interface QueuedPing extends PingInternalRepresentation {
+export interface QueuedPing extends PingInternalRepresentation {
   // The UUID identifier for this ping.
   readonly identifier: string,
-  // How may times there has been a failed upload attempt for this ping.
-  retries: number,
-}
-
-// Error to be thrown in case the final ping body is larger than MAX_PING_BODY_SIZE.
-class PingBodyOverflowError extends Error {
-  constructor(message?: string) {
-    super(message);
-    this.name = "PingBodyOverflow";
-  }
 }
 
 /**
- * A ping uploader. Manages a queue of pending pings to upload.
+ * A ping upload manager. Manages a queue of pending pings to upload.
  *
  * Observes the pings database
- * and whenever that is updated we trigger uploading of all enqueued pings.
- *
- * # Note
- *
- * If three retriable upload failures are hit in a row,
- * we bail out before uploading all enqued pings.
+ * and whenever that is updated the newly recorded ping is enqueued.
  */
 class PingUploadManager implements PingsDatabaseObserver {
-  // A list of pings currently being processed.
-  private processing: QueuedPing[];
-  // Local dispathcer instance to handle execution of ping requests.
-  private dispatcher: Dispatcher;
-  // The object that concretely handles the ping transmission.
-  private readonly uploader: Uploader;
-  // PlatformInfo object containing OS information used to build ping request headers.
-  private readonly platformInfo: PlatformInfo;
-  // The server address we are sending pings to.
-  private readonly serverEndpoint: string;
-  // Whether or not uploading is currently stopped due to limits having been hit.
-  private stopped = false;
+  // A FIFO queue storing a `QueuedPing` for each pending ping.
+  private queue: QueuedPing[];
+  // A worker that will take care of actually uploading pings.
+  private worker: PingUploadWorker;
+
+  // The number of times a recoverable failure has been processed by this.processPingUploadResponse.
+  private recoverableFailureCount = 0;
+  // The number of times this.getUploadTasks has returned a Wait_UploadTask in a row.
+  private waitAttemptCount = 0;
 
   constructor(
     config: Configuration,
     private readonly pingsDatabase: PingsDatabase,
     private readonly policy = new Policy(),
-    private readonly rateLimiter = new RateLimiter(RATE_LIMITER_INTERVAL_MS, MAX_PINGS_PER_INTERVAL)
+    private readonly rateLimiter = new RateLimiter(),
   ) {
-    this.processing = [];
-    // Initialize the ping uploader with either the platform defaults or a custom
-    // provided uploader from the configuration object.
-    this.uploader = config.httpClient ? config.httpClient : Context.platform.uploader;
-    this.platformInfo = Context.platform.info;
-    this.serverEndpoint = config.serverEndpoint;
+    this.queue = [];
 
-    // Initialize the dispatcher immediatelly.
-    this.dispatcher = createAndInitializeDispatcher();
+    this.worker = new PingUploadWorker(
+      // Initialize the ping upload worker with either the platform defaults or a custom
+      // provided uploader from the configuration object.
+      config.httpClient ? config.httpClient : Context.platform.uploader,
+      config.serverEndpoint,
+      policy,
+    );
+
+    pingsDatabase.attachObserver(this);
   }
 
   /**
-   * Enqueues a new ping at the end of the line.
+   * Enqueues a new ping at the end of the queue.
    *
    * Will not enqueue if a ping with the same identifier is already enqueued.
    *
    * @param ping The ping to enqueue.
    */
   private enqueuePing(ping: QueuedPing): void {
-    for (const queuedPing of this.processing) {
+    for (const queuedPing of this.queue) {
       if (queuedPing.identifier === ping.identifier) {
         return;
       }
     }
 
-    // Add the ping to the list of pings being processsed.
-    this.processing.push(ping);
+    this.queue.push(ping);
+  }
 
-    const { state: rateLimiterState, remainingTime } = this.rateLimiter.getState();
-    if (rateLimiterState === RateLimiterState.Incrementing) {
-      this.dispatcher.resume();
-      this.stopped = false;
-    } else {
-      if(!this.stopped) {
-        // Stop the dispatcher respecting the order of the dispatcher queue,
-        // to make sure the Stop command is enqueued _after_ previously enqueued requests.
-        this.dispatcher.stop(false);
-        this.stopped = true;
-      }
+  private getUploadTaskInternal(): UploadTask {
+    if (this.recoverableFailureCount >= this.policy.maxRecoverableFailures) {
+      return uploadTaskFactory.done();
+    }
 
-      if (rateLimiterState === RateLimiterState.Throttled) {
+    const { state, remainingTime } = this.rateLimiter.getState();
+    if (state !== RateLimiterState.Incrementing) {
+      if (state === RateLimiterState.Throttled) {
         log(
           LOG_TAG,
           [
-            "Succesfully submitted a ping, but Glean is currently throttled.",
+            "Glean is currently throttled.",
             `Pending pings may be uploaded in ${(remainingTime || 0) / 1000}s.`
           ],
           LoggingLevel.Debug
         );
-      }
-      else if (rateLimiterState === RateLimiterState.Stopped) {
+      } else if (state === RateLimiterState.Stopped) {
         log(
           LOG_TAG,
           [
-            "Succesfully submitted a ping,",
-            "but Glean has reached maximum recoverable upload failures for the current uploading window.",
+            "Glean has reached maximum recoverable upload failures for the current uploading window.",
             `May retry in ${(remainingTime || 0) / 1000}s.`
           ],
           LoggingLevel.Debug
         );
       }
-    }
 
-    // If the ping is a deletion-request ping, we want to enqueue it as a persistent task,
-    // so that clearing the queue does not clear it.
-    //
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const launchFn = isDeletionRequest(ping) ? this.dispatcher.launchPersistent : this.dispatcher.launch;
-
-    // Dispatch the uploading task.
-    launchFn.bind(this.dispatcher)(async (): Promise<void> => {
-      const status = await this.attemptPingUpload(ping);
-      const shouldRetry = await this.processPingUploadResponse(ping.identifier, status);
-
-      if (shouldRetry) {
-        ping.retries++;
-        this.enqueuePing(ping);
+      this.waitAttemptCount++;
+      if (this.waitAttemptCount >= this.policy.maxWaitAttempts) {
+        return uploadTaskFactory.done();
       }
 
-      if (ping.retries >= this.policy.maxRecoverableFailures) {
-        log(
-          LOG_TAG,
-          `Reached maximum recoverable failures for ping "${ping.identifier}". You are done.`,
-          LoggingLevel.Info
-        );
-        this.rateLimiter.stop();
-        this.dispatcher.stop();
-        ping.retries = 0;
-      }
-    });
+      return uploadTaskFactory.wait(remainingTime || 0);
+    }
+
+    const nextPing = this.queue.shift();
+    if (nextPing) {
+      return uploadTaskFactory.upload(nextPing);
+    }
+
+    return uploadTaskFactory.done();
   }
 
   /**
-   * Prepares a ping for uploader.
+   * Get the next `UploadTask`.
    *
-   * This includes:
-   *
-   * 1. Includes Glean required headers to the ping;
-   *    These are the headers described in https://mozilla.github.io/glean/book/user/pings/index.html?highlight=headers#submitted-headers
-   * 2. Stringifies the body.
-   *
-   * @param ping The ping to include the headers in.
-   * @returns The updated ping.
+   * @returns The next upload task.
    */
-  private async preparePingForUpload(ping: QueuedPing): Promise<{
-    headers: Record<string, string>,
-    payload: string | Uint8Array
-  }> {
-    let headers = ping.headers || {};
-    headers = {
-      ...ping.headers,
-      "Content-Type": "application/json; charset=utf-8",
-      "Date": (new Date()).toISOString(),
-      "X-Client-Type": "Glean.js",
-      "X-Client-Version": GLEAN_VERSION,
-      "X-Telemetry-Agent": `Glean/${GLEAN_VERSION} (JS on ${await this.platformInfo.os()})`
-    };
+  getUploadTask(): UploadTask {
+    const nextTask = this.getUploadTaskInternal();
 
-    const stringifiedBody = JSON.stringify(ping.payload);
-    // We prefer using `strToU8` instead of TextEncoder directly,
-    // because it will polyfill TextEncoder if it's not present in the environment.
-    // Environments that don't provide TextEncoder are IE and most importantly QML.
-    const encodedBody = strToU8(stringifiedBody);
-
-    let finalBody: string | Uint8Array;
-    let bodySizeInBytes: number;
-    try {
-      finalBody = gzipSync(encodedBody);
-      bodySizeInBytes = finalBody.length;
-      headers["Content-Encoding"] = "gzip";
-    } catch {
-      finalBody = stringifiedBody;
-      bodySizeInBytes = encodedBody.length;
+    if (nextTask.type !== UploadTaskTypes.Wait && this.waitAttemptCount > 0) {
+      this.waitAttemptCount = 0;
     }
 
-    if (bodySizeInBytes > this.policy.maxPingBodySize) {
-      throw new PingBodyOverflowError(
-        `Body for ping ${ping.identifier} exceeds ${this.policy.maxPingBodySize}bytes. Discarding.`
-      );
+    if (nextTask.type !== UploadTaskTypes.Upload && this.recoverableFailureCount > 0) {
+      this.recoverableFailureCount = 0;
     }
 
-    headers["Content-Length"] = bodySizeInBytes.toString();
-    return {
-      headers,
-      payload: finalBody
-    };
-  }
-
-  /**
-   * Attempts to upload a ping.
-   *
-   * @param ping The ping object containing headers and payload.
-   * @returns The status number of the response or `undefined` if unable to attempt upload.
-   */
-  private async attemptPingUpload(ping: QueuedPing): Promise<UploadResult> {
-    if (!Context.initialized) {
-      log(
-        LOG_TAG,
-        "Attempted to upload a ping, but Glean is not initialized yet. Ignoring.",
-        LoggingLevel.Warn
-      );
-      return new UploadResult(UploadResultStatus.RecoverableFailure);
-    }
-
-    try {
-      const finalPing = await this.preparePingForUpload(ping);
-      return await this.uploader.post(
-        `${this.serverEndpoint}${ping.path}`,
-        finalPing.payload,
-        finalPing.headers
-      );
-    } catch(e) {
-      log(LOG_TAG, [ "Error trying to build ping request:", e ], LoggingLevel.Warn);
-      // An unrecoverable failure will make sure the offending ping is removed from the queue and
-      // deleted from the database, which is what we want here.
-      return new UploadResult(UploadResultStatus.UnrecoverableFailure);
-    }
-  }
-
-  /**
-   * Removes a ping from the processing list.
-   *
-   * @param identifier The identifier of the ping to be removed.
-   */
-  private concludePingProcessing(identifier: string): void {
-    this.processing = this.processing.filter(ping => ping.identifier !== identifier);
+    return nextTask;
   }
 
   /**
@@ -307,18 +173,20 @@ class PingUploadManager implements PingsDatabaseObserver {
    *   _Known other errors:_
    *   500 - internal error
    *
-   * @param identifier The identifier of the ping uploaded.
+   * @param ping The ping that was just uploaded.
    * @param response The response of a ping upload attempt.
    * @returns Whether or not to retry the upload attempt.
    */
-  private async processPingUploadResponse(identifier: string, response: UploadResult): Promise<boolean> {
-    this.concludePingProcessing(identifier);
+  async processPingUploadResponse(ping: QueuedPing, response: UploadResult): Promise<void> {
+    const { identifier } = ping;
+    // Remove ping from queue list.
+    this.queue.filter(p => p.identifier !== identifier);
 
     const { status, result } = response;
     if (status && status >= 200 && status < 300) {
       log(LOG_TAG, `Ping ${identifier} succesfully sent ${status}.`, LoggingLevel.Info);
       await this.pingsDatabase.deletePing(identifier);
-      return false;
+      return;
     }
 
     if (result === UploadResultStatus.UnrecoverableFailure || (status && status >= 400 && status < 500)) {
@@ -328,41 +196,19 @@ class PingUploadManager implements PingsDatabaseObserver {
         LoggingLevel.Warn
       );
       await this.pingsDatabase.deletePing(identifier);
-      return false;
+      return;
     }
 
     log(
       LOG_TAG,
       [
         `Recoverable upload failure while attempting to send ping ${identifier}, will retry.`,
-        `Error was ${status ?? "no status"}.`
+        `Error was: ${status ?? "no status"}.`
       ],
       LoggingLevel.Warn
     );
-    return true;
-  }
-
-  /**
-   * Enqueues a new ping and trigger uploading of enqueued pings.
-   *
-   * This function is called by the PingDatabase everytime a new ping is added to the database.
-   *
-   * @param identifier The id of the ping that was just recorded.
-   * @param ping An object containing the newly recorded ping path, payload and optionally headers.
-   */
-  update(identifier: string, ping: PingInternalRepresentation): void {
-    this.dispatcher.resume();
-    this.enqueuePing({ identifier, retries: 0, ...ping });
-  }
-
-  /**
-   * Shuts down internal dispatcher,
-   * after executing all previously enqueued ping requests.
-   *
-   * @returns A promise that resolves once shutdown is complete.
-   */
-  shutdown(): Promise<void> {
-    return this.dispatcher.shutdown();
+    this.recoverableFailureCount++;
+    this.enqueuePing(ping);
   }
 
   /**
@@ -372,32 +218,42 @@ class PingUploadManager implements PingsDatabaseObserver {
    *
    * This will _drop_ pending pings still enqueued.
    * Only the `deletion-request` ping will still be processed.
+   *
+   * @returns A promise which resolves once the clearing is complete
+   *          and all upload attempts have been exhausted.
    */
   async clearPendingPingsQueue(): Promise<void> {
-    // Clears all tasks.
-    this.dispatcher.clear();
-    // Wait for remaining jobs and shutdown.
-    //
-    // The only jobs that may be left after clearing
-    // are `deletion-request` uploads.
-    await this.dispatcher.shutdown();
-    // At this poit we are sure the dispatcher queue is also empty,
-    // so we can empty the processing queue.
-    this.processing = [];
-
-    // Create and initialize a new dispatcher, since the `shutdown` state is irreversible.
-    this.dispatcher = createAndInitializeDispatcher();
+    this.queue = this.queue.filter(ping => isDeletionRequest(ping));
+    await this.blockOnOngoingUploads();
   }
 
   /**
-   * Test-Only API**
+   * Wait for uploading jobs to complete.
    *
-   * Returns a promise that resolves once the current queue execution in finished.
+   * This does not interfere in the jobs themselves.
    *
-   * @returns The promise.
+   * @returns A promise which resolves once current ongoing upload worker job is complete.
+   *         This should not hang for too long because of the upload limitations.
    */
-  async testBlockOnPingsQueue(): Promise<void> {
-    return this.dispatcher.testBlockOnQueue();
+  async blockOnOngoingUploads(): Promise<void> {
+    return this.worker.blockOnCurrentJob();
+  }
+
+  /**
+   * Enqueues a new ping and trigger uploading of enqueued pings.
+   *
+   * This function is called by the PingDatabase everytime a new ping is added to the database
+   * or when the database is being scanned.
+   *
+   * @param identifier The id of the ping that was just recorded.
+   * @param ping An object containing the newly recorded ping path, payload and optionally headers.
+   */
+  update(identifier: string, ping: PingInternalRepresentation): void {
+    this.enqueuePing({ identifier, ...ping });
+    this.worker.work(
+      () => this.getUploadTask(),
+      (ping: QueuedPing, result: UploadResult) => this.processPingUploadResponse(ping, result)
+    );
   }
 }
 

--- a/glean/src/core/upload/manager.ts
+++ b/glean/src/core/upload/manager.ts
@@ -81,30 +81,24 @@ class PingUploadManager implements PingsDatabaseObserver {
 
   private getUploadTaskInternal(): UploadTask {
     if (this.recoverableFailureCount >= this.policy.maxRecoverableFailures) {
+      log(
+        LOG_TAG,
+        "Glean has reached maximum recoverable upload failures for the current uploading window.",
+        LoggingLevel.Debug
+      );
       return uploadTaskFactory.done();
     }
 
     const { state, remainingTime } = this.rateLimiter.getState();
-    if (state !== RateLimiterState.Incrementing) {
-      if (state === RateLimiterState.Throttled) {
-        log(
-          LOG_TAG,
-          [
-            "Glean is currently throttled.",
-            `Pending pings may be uploaded in ${(remainingTime || 0) / 1000}s.`
-          ],
-          LoggingLevel.Debug
-        );
-      } else if (state === RateLimiterState.Stopped) {
-        log(
-          LOG_TAG,
-          [
-            "Glean has reached maximum recoverable upload failures for the current uploading window.",
-            `May retry in ${(remainingTime || 0) / 1000}s.`
-          ],
-          LoggingLevel.Debug
-        );
-      }
+    if (state === RateLimiterState.Throttled) {
+      log(
+        LOG_TAG,
+        [
+          "Glean is currently throttled.",
+          `Pending pings may be uploaded in ${(remainingTime || 0) / 1000}s.`
+        ],
+        LoggingLevel.Debug
+      );
 
       this.waitAttemptCount++;
       if (this.waitAttemptCount > this.policy.maxWaitAttempts) {

--- a/glean/src/core/upload/policy.ts
+++ b/glean/src/core/upload/policy.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Policies for ping storage, uploading and requests.
+ */
+export default class Policy {
+  constructor (
+    // The maximum recoverable failures allowed per uploading window.
+    //
+    // Limiting this is necessary to avoid infinite loops on requesting upload tasks.
+    readonly maxRecoverableFailures: number = 3,
+    // The maximum size in bytes a ping body may have to be eligible for upload.
+    readonly maxPingBodySize: number = 1024 * 1024 // 1MB
+  ) {}
+}
+

--- a/glean/src/core/upload/policy.ts
+++ b/glean/src/core/upload/policy.ts
@@ -7,6 +7,9 @@
  */
 export default class Policy {
   constructor (
+    // The maximum times a ping upload worker may get Wait_UploadTask responses
+    // when getting upload tasks.
+    readonly maxWaitAttempts: number = 3,
     // The maximum recoverable failures allowed per uploading window.
     //
     // Limiting this is necessary to avoid infinite loops on requesting upload tasks.

--- a/glean/src/core/upload/rate_limiter.ts
+++ b/glean/src/core/upload/rate_limiter.ts
@@ -15,18 +15,11 @@ export const MAX_PINGS_PER_INTERVAL = 40;
 export const enum RateLimiterState {
   // The RateLimiter has not reached the maximum count and is still incrementing.
   Incrementing,
-  // The RateLimiter has not reached the maximum count, but it is also not incrementing.
-  Stopped,
   // The RateLimiter has reached the maximum count for the current interval.
   Throttled,
 }
 
 class RateLimiter {
-  // Whether or not the RateLimiter is not counting any further for the current interval.
-  // This is different from the RateLimiter being throttled, because it may happen
-  // even if max count for the current interval has not been reached.
-  private stopped = false;
-
   constructor(
     // The duration of each interval, in millisecods.
     private interval: number = RATE_LIMITER_INTERVAL_MS,
@@ -58,7 +51,6 @@ class RateLimiter {
   private reset(): void {
     this.started = getMonotonicNow();
     this.count = 0;
-    this.stopped = false;
   }
 
   /**
@@ -97,13 +89,6 @@ class RateLimiter {
     }
 
     const remainingTime = this.interval - this.elapsed;
-    if (this.stopped) {
-      return {
-        state: RateLimiterState.Stopped,
-        remainingTime,
-      };
-    }
-
     if (this.count >= this.maxCount) {
       return {
         state: RateLimiterState.Throttled,
@@ -115,15 +100,6 @@ class RateLimiter {
     return {
       state: RateLimiterState.Incrementing
     };
-  }
-
-  /**
-   * Stops counting for the current interval, regardless of the max count being reached.
-   *
-   * The RateLimiter will still be reset when time interval is over.
-   */
-  stop(): void {
-    this.stopped = true;
   }
 }
 

--- a/glean/src/core/upload/rate_limiter.ts
+++ b/glean/src/core/upload/rate_limiter.ts
@@ -4,6 +4,11 @@
 
 import { isUndefined, getMonotonicNow } from "../utils.js";
 
+// Default rate limiter interval, in milliseconds.
+export const RATE_LIMITER_INTERVAL_MS = 60 * 1000;
+// Default max pings per internal.
+export const MAX_PINGS_PER_INTERVAL = 40;
+
 /**
  * An enum to represent the current state of the RateLimiter.
  */
@@ -24,9 +29,9 @@ class RateLimiter {
 
   constructor(
     // The duration of each interval, in millisecods.
-    private interval: number,
+    private interval: number = RATE_LIMITER_INTERVAL_MS,
     // The maximum count per interval.
-    private maxCount: number,
+    private maxCount: number = MAX_PINGS_PER_INTERVAL,
     // The count for the current interval.
     private count: number = 0,
     // The instant the current interval has started, in milliseconds.

--- a/glean/src/core/upload/task.ts
+++ b/glean/src/core/upload/task.ts
@@ -10,7 +10,7 @@ export const enum UploadTaskTypes {
   Upload = "upload",
 }
 
-// A flag signaling that worker doesn't need to request any more upload tasks at this moment.
+// A flag signaling that the worker doesn't need to request any more upload tasks at this moment.
 //
 // There are three possibilities for this scenario:
 // * Pending pings queue is empty, no more pings to request;

--- a/glean/src/core/upload/task.ts
+++ b/glean/src/core/upload/task.ts
@@ -21,7 +21,7 @@ export const enum UploadTaskTypes {
 //
 // An "uploading window" starts when a requester gets a new
 // `Upload_UploadTask` response and finishes when they
-// finally get a `Done_UploadTask` or `Wai_UploadTask` response.
+// finally get a `Done_UploadTask` or `Wait_UploadTask` response.
 type Done_UploadTask = {
   type: UploadTaskTypes.Done
 };

--- a/glean/src/core/upload/task.ts
+++ b/glean/src/core/upload/task.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { QueuedPing } from "./manager";
+
+export const enum UploadTaskTypes {
+  Done = "done",
+  Wait = "wait",
+  Upload = "upload",
+}
+
+// A flag signaling that worker doesn't need to request any more upload tasks at this moment.
+//
+// There are three possibilities for this scenario:
+// * Pending pings queue is empty, no more pings to request;
+// * Requester has gotten more than MAX_WAIT_ATTEMPTS `Wait_UploadTask` responses in a row;
+// * Requester has reported more than MAX_RECOVERABLE_FAILURES_PER_UPLOADING_WINDOW
+//   recoverable upload failures on the same uploading window (see below)
+//   and should stop requesting at this moment.
+//
+// An "uploading window" starts when a requester gets a new
+// `Upload_UploadTask` response and finishes when they
+// finally get a `Done_UploadTask` or `Wai_UploadTask` response.
+type Done_UploadTask = {
+  type: UploadTaskTypes.Done
+};
+
+// A flag signaling that the pending pings directories are not done being processed,
+// thus the worker should wait and come back later.
+//
+// Contains the amount of time in milliseconds
+// the requester should wait before requesting a new task.
+type Wait_UploadTask = {
+  type: UploadTaskTypes.Wait,
+  remainingTime: number,
+};
+
+// A flag signaling there are no remaining upload tasks and worker is done (for now).
+type Upload_UploadTask = {
+  type: UploadTaskTypes.Upload,
+  ping: QueuedPing,
+};
+
+// The possible upload tasks to be performed by a `PingUploadWorker`.
+//
+// When asking for the next ping request to upload,
+// the requester may receive one out of three possible tasks.
+export type UploadTask = Done_UploadTask | Wait_UploadTask | Upload_UploadTask;
+
+export default {
+  done: (): Done_UploadTask => ({
+    type: UploadTaskTypes.Done
+  }),
+
+  wait: (remainingTime: number): Wait_UploadTask => ({
+    type: UploadTaskTypes.Wait,
+    remainingTime,
+  }),
+
+  upload: (ping: QueuedPing): Upload_UploadTask => ({
+    type: UploadTaskTypes.Upload,
+    ping,
+  }),
+};

--- a/glean/src/core/upload/uploader.ts
+++ b/glean/src/core/upload/uploader.ts
@@ -48,7 +48,7 @@ export abstract class Uploader {
    * @param body The body of this post request. The body may be a stringified JSON or, most likely,
    *        a Uint8Array containing the gzipped version of said stringified JSON. We need to accept
    *        both in case the compression fails.
-   * @param headers Optional header to include in the request
+   * @param headers Optional headers to include in the request
    * @returns The status code of the response.
    */
   abstract post(url: string, body: string | Uint8Array, headers?: Record<string, string>): Promise<UploadResult>;

--- a/glean/src/core/upload/worker.ts
+++ b/glean/src/core/upload/worker.ts
@@ -1,0 +1,179 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gzipSync, strToU8 } from "fflate";
+
+import type { QueuedPing } from "./manager";
+import type Uploader from "./uploader.js";
+import type { UploadTask} from "./task.js";
+import { GLEAN_VERSION } from "../constants.js";
+import { Context } from "../context.js";
+import log, { LoggingLevel } from "../log.js";
+import Policy from "./policy.js";
+import { UploadResult, UploadResultStatus } from "./uploader.js";
+import { UploadTaskTypes } from "./task.js";
+
+const LOG_TAG = "core.Upload.PingUploadWorker";
+
+// Error to be thrown in case the final ping body is larger than MAX_PING_BODY_SIZE.
+class PingBodyOverflowError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "PingBodyOverflow";
+  }
+}
+
+class PingUploadWorker {
+  private currentJob?: Promise<void>;
+
+  constructor (
+    private readonly uploader: Uploader,
+    private readonly serverEndpoint: string,
+    private readonly policy = new Policy()
+  ) {}
+
+  /**
+   * Builds a ping request.
+   *
+   * This includes:
+   *
+   * 1. Includes Glean required headers to the ping;
+   *    These are the headers described in https://mozilla.github.io/glean/book/user/pings/index.html?highlight=headers#submitted-headers
+   * 2. Stringifies the body.
+   *
+   * @param ping The ping to include the headers in.
+   * @returns The updated ping.
+   */
+  private async buildPingRequest(ping: QueuedPing): Promise<{
+    headers: Record<string, string>,
+    payload: string | Uint8Array
+  }> {
+    let headers = ping.headers || {};
+    headers = {
+      ...ping.headers,
+      "Content-Type": "application/json; charset=utf-8",
+      "Date": (new Date()).toISOString(),
+      "X-Client-Type": "Glean.js",
+      "X-Client-Version": GLEAN_VERSION,
+      "X-Telemetry-Agent": `Glean/${GLEAN_VERSION} (JS on ${await Context.platform.info.os()})`
+    };
+
+    const stringifiedBody = JSON.stringify(ping.payload);
+    // We prefer using `strToU8` instead of TextEncoder directly,
+    // because it will polyfill TextEncoder if it's not present in the environment.
+    // Environments that don't provide TextEncoder are IE and most importantly QML.
+    const encodedBody = strToU8(stringifiedBody);
+
+    let finalBody: string | Uint8Array;
+    let bodySizeInBytes: number;
+    try {
+      finalBody = gzipSync(encodedBody);
+      bodySizeInBytes = finalBody.length;
+      headers["Content-Encoding"] = "gzip";
+    } catch {
+      finalBody = stringifiedBody;
+      bodySizeInBytes = encodedBody.length;
+    }
+
+    if (bodySizeInBytes > this.policy.maxPingBodySize) {
+      throw new PingBodyOverflowError(
+        `Body for ping ${ping.identifier} exceeds ${this.policy.maxPingBodySize}bytes. Discarding.`
+      );
+    }
+
+    headers["Content-Length"] = bodySizeInBytes.toString();
+    return {
+      headers,
+      payload: finalBody
+    };
+  }
+
+  /**
+   * Attempts to upload a ping.
+   *
+   * @param ping The ping object containing headers and payload.
+   * @returns The status number of the response or `undefined` if unable to attempt upload.
+   */
+  private async attemptPingUpload(ping: QueuedPing): Promise<UploadResult> {
+    try {
+      const finalPing = await this.buildPingRequest(ping);
+      return await this.uploader.post(
+        `${this.serverEndpoint}${ping.path}`,
+        finalPing.payload,
+        finalPing.headers
+      );
+    } catch(e) {
+      log(LOG_TAG, [ "Error trying to build ping request:", e ], LoggingLevel.Warn);
+      // An unrecoverable failure will make sure the offending ping is removed from the queue and
+      // deleted from the database, which is what we want here.
+      return new UploadResult(UploadResultStatus.UnrecoverableFailure);
+    }
+  }
+
+  /**
+   * Start a loop to get queued pings and attempt upload.
+   *
+   * @param getUploadTask A function that returns an UploadTask.
+   * @param processUploadResponse A function that processes an UploadResponse.
+   * @returns A promise whihc resolves on a Done_UploadTask is received.
+   */
+  private async workInternal(
+    getUploadTask: () => UploadTask,
+    processUploadResponse: (ping: QueuedPing, result: UploadResult) => Promise<void>,
+  ): Promise<void> {
+    while(true) {
+      const nextTask = getUploadTask();
+      switch (nextTask.type) {
+      case UploadTaskTypes.Upload:
+        const result = await this.attemptPingUpload(nextTask.ping);
+        await processUploadResponse(nextTask.ping, result);
+        continue;
+      // TODO(bug1727076): Actually set a timer to continue once timeout is complete.
+      // Note that the timer must be cleared in case an abort signal is issued.
+      case UploadTaskTypes.Wait:
+      case UploadTaskTypes.Done:
+        this.currentJob = undefined;
+        return;
+      }
+    }
+  }
+
+  /**
+   * Kick start non-blocking asynchronous internal loop to get and act on upload tasks.
+   *
+   * If a job is currently ongoing, this is a no-op.
+   *
+   * @param getUploadTask A function that returns an UploadTask.
+   * @param processUploadResponse A function that processes an UploadResponse.
+   */
+  work(
+    getUploadTask: () => UploadTask,
+    processUploadResponse: (ping: QueuedPing, result: UploadResult) => Promise<void>,
+  ): void {
+    if (!this.currentJob) {
+      this.currentJob = this.workInternal(getUploadTask, processUploadResponse);
+    }
+  }
+
+  /**
+   * Allows to wait for current job completion.
+   *
+   * # Warning
+   *
+   * Use only at times when you know it is not possible for this to hang too long
+   * i.e. at times when you know how many pings are enqueued.
+   *
+   * @returns A promise which resolves once the current ongoing job is complete.
+   *          If there is no ongoing job, the returned promise will resolve immediately.
+   */
+  async blockOnCurrentJob() {
+    if (this.currentJob) {
+      return this.currentJob;
+    }
+
+    return Promise.resolve();
+  }
+}
+
+export default PingUploadWorker;

--- a/glean/src/core/upload/worker.ts
+++ b/glean/src/core/upload/worker.ts
@@ -104,7 +104,7 @@ class PingUploadWorker {
         finalPing.headers
       );
     } catch(e) {
-      log(LOG_TAG, [ "Error trying to build ping request:", e ], LoggingLevel.Warn);
+      log(LOG_TAG, [ "Error trying to build or post ping request:", e ], LoggingLevel.Warn);
       // An unrecoverable failure will make sure the offending ping is removed from the queue and
       // deleted from the database, which is what we want here.
       return new UploadResult(UploadResultStatus.UnrecoverableFailure);

--- a/glean/tests/unit/core/glean.spec.ts
+++ b/glean/tests/unit/core/glean.spec.ts
@@ -18,7 +18,6 @@ import TestPlatform from "../../../src/platform/test";
 import Plugin from "../../../src/plugins";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
 import { Context } from "../../../src/core/context";
-import { DispatcherState } from "../../../src/core/dispatcher";
 import EventMetricType from "../../../src/core/metrics/types/event";
 import { getGleanRestartedEventMetric } from "../../../src/core/metrics/events_database";
 
@@ -461,7 +460,7 @@ describe("Glean", function() {
     //
     // This disables the uploading and deletion of pings from the pings database,
     // this allows us to query the database to check that our pings are as expected.
-    await stopGleanUploader();
+    stopGleanUploader();
 
     const custom = new PingType({
       name: "custom",
@@ -529,12 +528,6 @@ describe("Glean", function() {
     Glean.setPlatform(MockPlatform);
 
     assert.strictEqual(TestPlatform.name, Context.platform.name);
-  });
-
-  it("shutdown correctly shutsdown dispatcher and ping uploader", async function () {
-    await Glean.shutdown();
-    assert.strictEqual(Context.dispatcher["state"], DispatcherState.Shutdown);
-    assert.strictEqual(Glean["pingUploader"]["dispatcher"]["state"], DispatcherState.Shutdown);
   });
 
   it("shutdown allows all pending pings to be sent before shutting down uploader", async function() {

--- a/glean/tests/unit/core/metrics/labeled.spec.ts
+++ b/glean/tests/unit/core/metrics/labeled.spec.ts
@@ -25,7 +25,7 @@ describe("LabeledMetric", function() {
   beforeEach(async function() {
     await Glean.testResetGlean(testAppId);
     // Disable ping uploading for it not to interfere with this tests.
-    await stopGleanUploader();
+    stopGleanUploader();
   });
 
   afterEach(function () {

--- a/glean/tests/unit/core/pings/maker.spec.ts
+++ b/glean/tests/unit/core/pings/maker.spec.ts
@@ -148,7 +148,7 @@ describe("PingMaker", function() {
 
   it("collect and store triggers the AfterPingCollection and deals with possible result correctly", async function () {
     // Disable ping uploading for it not to interfere with this tests.
-    await stopGleanUploader();
+    stopGleanUploader();
 
     await Glean.testResetGlean(testAppId, true, { plugins: [ new MockPlugin() ]});
     const ping = new PingType({
@@ -173,7 +173,7 @@ describe("PingMaker", function() {
 
   it("ping payload is logged before it is modified by a plugin", async function () {
     // Disable ping uploading for it not to interfere with this tests.
-    await stopGleanUploader();
+    stopGleanUploader();
 
     await Glean.testResetGlean(testAppId, true, { plugins: [ new MockPlugin() ] });
     Glean.setLogPings(true);

--- a/glean/tests/unit/core/pings/ping_type.spec.ts
+++ b/glean/tests/unit/core/pings/ping_type.spec.ts
@@ -40,7 +40,7 @@ describe("PingType", function() {
 
   it("collects and stores ping on submit", async function () {
     // Disable ping uploading for it not to interfere with this tests.
-    await stopGleanUploader();
+    stopGleanUploader();
 
     const ping = new PingType({
       name: "custom",
@@ -63,7 +63,7 @@ describe("PingType", function() {
 
   it("empty pings with send if empty flag are submitted", async function () {
     // Disable ping uploading for it not to interfere with this tests.
-    await stopGleanUploader();
+    stopGleanUploader();
 
     const ping1 = new PingType({
       name: "ping1",

--- a/glean/tests/unit/core/upload/index.spec.ts
+++ b/glean/tests/unit/core/upload/index.spec.ts
@@ -9,12 +9,13 @@ import { v4 as UUIDv4 } from "uuid";
 import { Configuration } from "../../../../src/core/config";
 import { Context } from "../../../../src/core/context";
 import Glean from "../../../../src/core/glean";
-import PingUploader, { MAX_PINGS_PER_INTERVAL, Policy } from "../../../../src/core/upload";
+import PingUploader, { MAX_PINGS_PER_INTERVAL } from "../../../../src/core/upload";
 import { UploadResultStatus } from "../../../../src/core/upload/uploader";
 import { CounterUploader, WaitableUploader } from "../../../utils";
 import { DELETION_REQUEST_PING_NAME } from "../../../../src/core/constants";
 import PingsDatabase from "../../../../src/core/pings/database";
 import { makePath } from "../../../../src/core/pings/maker";
+import Policy from "../../../../src/core/upload/policy";
 
 const sandbox = sinon.createSandbox();
 

--- a/glean/tests/unit/core/upload/rate_limiter.spec.ts
+++ b/glean/tests/unit/core/upload/rate_limiter.spec.ts
@@ -70,22 +70,4 @@ describe("RateLimiter", function() {
     assert.strictEqual(nextState.state, RateLimiterState.Throttled);
     assert.ok(nextState.remainingTime as number <= 1000 && nextState.remainingTime as number > 0);
   });
-
-  it("rate limiter returns stopped state when it is stopped", function () {
-    const rateLimiter = new RateLimiter(
-      1000, /* interval */
-      3, /* maxCount */
-    );
-
-    // Don't reach the count for the current interval.
-    assert.deepStrictEqual(rateLimiter.getState(), { state: RateLimiterState.Incrementing });
-
-    // Stop the rate limiter
-    rateLimiter.stop();
-
-    // Try one more time and we should be stopped.
-    const nextState = rateLimiter.getState();
-    assert.strictEqual(nextState.state, RateLimiterState.Stopped);
-    assert.ok(nextState.remainingTime as number <= 1000 && nextState.remainingTime as number > 0);
-  });
 });

--- a/glean/tests/unit/core/upload/worker.spec.ts
+++ b/glean/tests/unit/core/upload/worker.spec.ts
@@ -1,0 +1,276 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import assert from "assert";
+import sinon from "sinon";
+
+import { UploadTaskTypes } from "../../../../src/core/upload/task";
+import type { UploadTask } from "../../../../src/core/upload/task";
+import uploadTaskFactory from "../../../../src/core/upload/task";
+import PingUploadWorker from "../../../../src/core/upload/worker";
+import TestPlatform from "../../../../src/platform/test";
+import Glean from "../../../../src/core/glean";
+import { CounterUploader } from "../../../utils";
+import { makePath } from "../../../../src/core/pings/maker";
+import { Context } from "../../../../src/core/context";
+import Policy from "../../../../src/core/upload/policy";
+import { UploadResultStatus } from "../../../../src/core/upload/uploader";
+import type { UploadResult } from "../../../../src/core/upload/uploader";
+
+const sandbox = sinon.createSandbox();
+
+const MOCK_PING_NAME = "ping";
+const MOCK_PING_IDENTIFIER = "identifier";
+
+/**
+ * Build mock upload task of a given type.
+ *
+ * @param type The type of the task to build.
+ * @returns An upload task.
+ */
+function buildMockTask(type: UploadTaskTypes): UploadTask {
+  switch(type) {
+  case UploadTaskTypes.Done:
+    return uploadTaskFactory.done();
+  case UploadTaskTypes.Wait:
+    return uploadTaskFactory.wait(10);
+  case UploadTaskTypes.Upload:
+    return uploadTaskFactory.upload({
+      identifier: MOCK_PING_IDENTIFIER,
+      collectionDate: "2021-11-23T17:23:31.661Z",
+      payload: {
+        ping_info: {
+          seq: 1,
+          start_time: "2020-01-11+01:00",
+          end_time: "2020-01-12+01:00",
+        },
+        client_info: {
+          telemetry_sdk_build: "32.0.0"
+        }
+      },
+      path: makePath(
+        MOCK_PING_IDENTIFIER,
+        { name: MOCK_PING_NAME, includeClientId: true, sendIfEmpty: true }
+      )
+    });
+  }
+}
+
+/**
+ * Generator that yields mock tasks of given types in given order.
+ *
+ * @param tasks The tasks to yield.
+ * @yields A task.
+ * @returns The last task is not yielded, it's returned.
+ */
+function* mockGetUploadTasks(tasks: UploadTaskTypes[]): Generator<UploadTask, UploadTask> {
+  let index = 0;
+  while(index < tasks.length - 1) {
+    yield buildMockTask(tasks[index]);
+    index++;
+  }
+
+  return buildMockTask(tasks[index]);
+}
+
+describe("PingUploadWorker", function() {
+  const testAppId = `gleanjs.test.${this.title}`;
+
+  before(async function () {
+    // We call this only once so that the platform is set
+    // and we are able to access the Platform info.
+    await Glean.testResetGlean(testAppId, true);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("whenever a Done task is received the currentJob is ended", async function() {
+    const worker = new PingUploadWorker(TestPlatform.uploader, "https://my-glean-test.com");
+    const tasksGenerator = mockGetUploadTasks([ UploadTaskTypes.Done, UploadTaskTypes.Upload ]);
+
+    worker.work(
+      () => tasksGenerator.next().value,
+      () => Promise.resolve()
+    );
+
+    await worker.blockOnCurrentJob();
+    // Check that we never got to the Upload task enqueued,
+    // due to bailing out when we found a Done task.
+    assert.strictEqual(tasksGenerator.next().value.type, UploadTaskTypes.Upload);
+  });
+
+  it("whenever a Wait task is received the currentJob is ended", async function() {
+    const worker = new PingUploadWorker(TestPlatform.uploader, "https://my-glean-test.com");
+    const tasksGenerator = mockGetUploadTasks([ UploadTaskTypes.Wait, UploadTaskTypes.Upload ]);
+
+    worker.work(
+      () => tasksGenerator.next().value,
+      () => Promise.resolve()
+    );
+
+    await worker.blockOnCurrentJob();
+    // Check that we never got to the Upload task enqueued,
+    // due to bailing out when we found a Wait task.
+    assert.strictEqual(tasksGenerator.next().value.type, UploadTaskTypes.Upload);
+  });
+
+  it("whenever an Upload task is received upload attempts are made", async function() {
+    const uploader = new CounterUploader();
+    const worker = new PingUploadWorker(uploader, "https://my-glean-test.com");
+    const tasksGenerator = mockGetUploadTasks([
+      ...Array(10).fill(UploadTaskTypes.Upload) as UploadTaskTypes.Upload[],
+      // Always end with a Done task to make sure the worker stops asking for more tasks.
+      UploadTaskTypes.Done
+    ]);
+
+    worker.work(
+      () => tasksGenerator.next().value,
+      () => Promise.resolve()
+    );
+
+    await worker.blockOnCurrentJob();
+    // All upload requests were completed.
+    assert.strictEqual(uploader.count, 10);
+  });
+
+  it("ping requests are built correctly", async function () {
+    const postSpy = sandbox.spy(TestPlatform.uploader, "post");
+
+    const worker = new PingUploadWorker(TestPlatform.uploader, "https://my-glean-test.com");
+    const tasksGenerator = mockGetUploadTasks([
+      UploadTaskTypes.Upload,
+      // Always end with a Done task to make sure the worker stops asking for more tasks.
+      UploadTaskTypes.Done
+    ]);
+
+    worker.work(
+      () => tasksGenerator.next().value,
+      () => Promise.resolve()
+    );
+    await worker.blockOnCurrentJob();
+
+    const url = postSpy.firstCall.args[0].split("/");
+    const appId = url[url.length - 4];
+    const documentId = url[url.length - 1];
+    const headers = postSpy.firstCall.args[2] || {};
+
+    assert.strictEqual(documentId, MOCK_PING_IDENTIFIER);
+    assert.strictEqual(appId, Context.applicationId);
+
+    assert.ok("Date" in headers);
+    assert.ok("Content-Length" in headers);
+    assert.ok("Content-Type" in headers);
+    assert.ok("X-Client-Type" in headers);
+    assert.ok("X-Client-Version" in headers);
+    assert.ok("X-Telemetry-Agent" in headers);
+    assert.strictEqual(headers["Content-Encoding"], "gzip");
+  });
+
+  it("succesfull upload attemps return the correct upload result", async function () {
+    const postSpy = sandbox.stub(TestPlatform.uploader, "post")
+      .onFirstCall().callsFake(() => Promise.resolve({
+        status: 200,
+        result: UploadResultStatus.Success
+      }))
+      .onSecondCall().callsFake(() => Promise.resolve({
+        status: 404,
+        result: UploadResultStatus.Success
+      }))
+      .onThirdCall().callsFake(() => Promise.resolve({
+        status: 500,
+        result: UploadResultStatus.Success
+      }));
+
+    const worker = new PingUploadWorker(TestPlatform.uploader, "https://my-glean-test.com");
+    const tasksGenerator = mockGetUploadTasks([
+      UploadTaskTypes.Upload,
+      UploadTaskTypes.Upload,
+      UploadTaskTypes.Upload,
+      // Always end with a Done task to make sure the worker stops asking for more tasks.
+      UploadTaskTypes.Done
+    ]);
+
+    const processSpy = sandbox.spy();
+    worker.work(
+      () => tasksGenerator.next().value,
+      processSpy
+    );
+    await worker.blockOnCurrentJob();
+
+    assert.strictEqual(postSpy.callCount, 3);
+
+    const resultSuccess = (processSpy.firstCall.args as [never, UploadResult])[1];
+    assert.strictEqual(resultSuccess.result, UploadResultStatus.Success);
+    assert.strictEqual(resultSuccess.status, 200);
+
+    const resultNotFound = (processSpy.secondCall.args as [never, UploadResult])[1];
+    assert.strictEqual(resultNotFound.result, UploadResultStatus.Success);
+    assert.strictEqual(resultNotFound.status, 404);
+
+    const resultInternalServerError = (processSpy.thirdCall.args as [never, UploadResult])[1];
+    assert.strictEqual(resultInternalServerError.result, UploadResultStatus.Success);
+    assert.strictEqual(resultInternalServerError.status, 500);
+  });
+
+  it("pings which exceed max ping body size are not sent and an correct result is returned", async function () {
+    const uploader = new CounterUploader();
+    // Create a new worker with a very low max ping body size,
+    // so that virtually any ping body will throw an error.
+    const worker = new PingUploadWorker(
+      uploader,
+      "https://my-glean-test.com",
+      new Policy(
+        3, // maxWaitAttempts
+        3, // maxRecoverableFailures
+        1, // maxPingBodySize
+      )
+    );
+    const tasksGenerator = mockGetUploadTasks([
+      UploadTaskTypes.Upload,
+      // Always end with a Done task to make sure the worker stops asking for more tasks.
+      UploadTaskTypes.Done
+    ]);
+
+    const processSpy = sandbox.spy();
+    worker.work(
+      () => tasksGenerator.next().value,
+      processSpy
+    );
+    await worker.blockOnCurrentJob();
+
+    // Check that none of those pings were actually sent.
+    assert.strictEqual(uploader.count, 0);
+    // Check that an UnrecoverableFailure was returned by the upload attempt.
+    const uploadResult = (processSpy.firstCall.args as [never, UploadResult])[1];
+    assert.strictEqual(uploadResult.result, UploadResultStatus.UnrecoverableFailure);
+  });
+
+  it("attempting to start a new job when another is ongoing is a no-op", async function() {
+    const worker = new PingUploadWorker(TestPlatform.uploader, "https://my-glean-test.com");
+    const tasksGenerator = mockGetUploadTasks([
+      ...Array(10).fill(UploadTaskTypes.Upload) as UploadTaskTypes.Upload[],
+      // Always end with a Done task to make sure the worker stops asking for more tasks.
+      UploadTaskTypes.Done
+    ]);
+
+    worker.work(
+      () => tasksGenerator.next().value,
+      () => Promise.resolve()
+    );
+
+    const initialCurrentJob = worker["currentJob"];
+
+    worker.work(
+      () => tasksGenerator.next().value,
+      () => Promise.resolve()
+    );
+
+    assert.strictEqual(worker["currentJob"], initialCurrentJob);
+
+    // Wait for the queue to be processed before exiting the test.
+    await worker.blockOnCurrentJob();
+  });
+});

--- a/glean/tests/unit/core/upload/worker.spec.ts
+++ b/glean/tests/unit/core/upload/worker.spec.ts
@@ -215,7 +215,7 @@ describe("PingUploadWorker", function() {
     assert.strictEqual(resultInternalServerError.status, 500);
   });
 
-  it("pings which exceed max ping body size are not sent and an correct result is returned", async function () {
+  it("pings which exceed max ping body size are not sent and a correct result is returned", async function () {
     const uploader = new CounterUploader();
     // Create a new worker with a very low max ping body size,
     // so that virtually any ping body will throw an error.

--- a/glean/tests/utils.ts
+++ b/glean/tests/utils.ts
@@ -28,11 +28,12 @@ export function unzipPingPayload(payload: Uint8Array | string): JSONObject {
 }
 
 /**
- * Disables the uploader on the Glean singleton,
+ * Disables the uploading on the Glean singleton,
  * so that it doesn't interefe with tests.
  */
-export async function stopGleanUploader(): Promise<void> {
-  await Glean["pingUploader"]["dispatcher"].shutdown();
+export function stopGleanUploader(): void {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  Glean["pingUploader"]["worker"]["work"] = () => {};
 }
 
 /**


### PR DESCRIPTION
With the previous design it was hard and hacky to enforce the rate limit defaults at the correct time.

The new design (or old, depends on how you look at it) allows to do that easily. 

It also has the following added benefits 1) logic is better encapsulated in different structures 2) the design is almost exactly the same as the one in glean-core, so transfer of knowledge and ensurace of standardized functionality is easier to do 3) it doesn't have an internal dispatcher instance 4) it's just easier to reason about it, IMO.

Note: I suggest reviewing this PR commit by commit. I did my best to isolate changes, but this is a big change and there is no going around that.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
   - The gist of this implementation is documented here: https://mozilla.github.io/glean/dev/core/internal/upload.html#upload-task-api. 
   - However, I know that is pushing it a bit, so I'll finaly take https://bugzilla.mozilla.org/show_bug.cgi?id=1687288 and document this in the Glean.js dev docs.
