### PR TITLE
No bug - Don't attempt to access platform before it was set in Context 

### DIFF
--- a/glean/src/core/context.ts
+++ b/glean/src/core/context.ts
@@ -238,4 +238,8 @@ export class Context {
 
     return Context.instance._platform;
   }
+
+  static isPlatformSet(): boolean {
+    return !!Context.instance._platform;
+  }
 }

--- a/glean/src/core/context.ts
+++ b/glean/src/core/context.ts
@@ -82,7 +82,7 @@ export class Context {
         [
           "Attempted to access Context.uploadEnabled before it was set. This may cause unexpected behaviour.",
         ],
-        LoggingLevel.Error
+        LoggingLevel.Trace
       );
     }
 
@@ -100,7 +100,7 @@ export class Context {
         [
           "Attempted to access Context.metricsDatabase before it was set. This may cause unexpected behaviour.",
         ],
-        LoggingLevel.Error
+        LoggingLevel.Trace
       );
     }
 
@@ -118,7 +118,7 @@ export class Context {
         [
           "Attempted to access Context.eventsDatabase before it was set. This may cause unexpected behaviour.",
         ],
-        LoggingLevel.Error
+        LoggingLevel.Trace
       );
     }
 
@@ -136,7 +136,7 @@ export class Context {
         [
           "Attempted to access Context.pingsDatabase before it was set. This may cause unexpected behaviour.",
         ],
-        LoggingLevel.Error
+        LoggingLevel.Trace
       );
     }
 
@@ -154,7 +154,7 @@ export class Context {
         [
           "Attempted to access Context.errorManager before it was set. This may cause unexpected behaviour.",
         ],
-        LoggingLevel.Error
+        LoggingLevel.Trace
       );
     }
 
@@ -172,7 +172,7 @@ export class Context {
         [
           "Attempted to access Context.applicationId before it was set. This may cause unexpected behaviour.",
         ],
-        LoggingLevel.Error
+        LoggingLevel.Trace
       );
     }
 
@@ -198,7 +198,7 @@ export class Context {
         [
           "Attempted to access Context.debugOptions before it was set. This may cause unexpected behaviour.",
         ],
-        LoggingLevel.Error
+        LoggingLevel.Trace
       );
     }
 
@@ -232,7 +232,7 @@ export class Context {
         [
           "Attempted to access Context.platform before it was set. This may cause unexpected behaviour.",
         ],
-        LoggingLevel.Error
+        LoggingLevel.Trace
       );
     }
 

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -487,7 +487,7 @@ class Glean {
       return;
     }
 
-    if (Context.platform && Context.platform.name !== platform.name && !Context.testing) {
+    if (Context.isPlatformSet() && Context.platform.name !== platform.name && !Context.testing) {
       log(
         LOG_TAG,
         [

--- a/glean/src/core/log.ts
+++ b/glean/src/core/log.ts
@@ -11,7 +11,9 @@ export enum LoggingLevel {
   // Will result in calling the `console.warn` API.
   Warn = "warn",
   // Will result in calling the `console.error` API.
-  Error = "error"
+  Error = "error",
+  // Will result in calling the `console.trace` API.
+  Trace = "trace",
 }
 
 /**


### PR DESCRIPTION
This was creating an annoying log spam in tests because
Glean would always attempt to access the platform before
it was set on the first time calling testResetGlean.