### PR TITLE
No bug - Check if Glean is initialized before dispatching toggle upload task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#984](https://github.com/mozilla/glean.js/pull/984): BUGFIX: Return correct upload result in case an error happens while building a ping request.
 * [#988](https://github.com/mozilla/glean.js/pull/988): BUGFIX: Enforce rate limitation at upload time, not at ping submission time.
   * Note: This change required a big refactoring of the internal uploading logic.
+* [#1015](https://github.com/mozilla/glean.js/pull/1015): BUGFIX: Make attempting to call the `setUploadEnabled` API before initializing Glean a no-op.
 
 # v0.27.0 (2021-11-22)
 

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -355,6 +355,19 @@ class Glean {
    * @param flag When true, enable metric collection.
    */
   static setUploadEnabled(flag: boolean): void {
+    if (!Context.initialized) {
+      log(
+        LOG_TAG,
+        [
+          "Changing upload enabled before Glean is initialized is not supported.\n",
+          "Pass the correct state into `Glean.initialize`.\n",
+          "See documentation at https://mozilla.github.io/glean/book/user/general-api.html#initializing-the-glean-sdk`"
+        ],
+        LoggingLevel.Error
+      );
+      return;
+    }
+
     if (!isBoolean(flag)) {
       log(
         LOG_TAG,
@@ -365,19 +378,6 @@ class Glean {
     }
 
     Context.dispatcher.launch(async () => {
-      if (!Context.initialized) {
-        log(
-          LOG_TAG,
-          [
-            "Changing upload enabled before Glean is initialized is not supported.\n",
-            "Pass the correct state into `Glean.initialize\n`.",
-            "See documentation at https://mozilla.github.io/glean/book/user/general-api.html#initializing-the-glean-sdk`"
-          ],
-          LoggingLevel.Error
-        );
-        return;
-      }
-
       if (Context.uploadEnabled !== flag) {
         if (flag) {
           await Glean.onUploadEnabled();

--- a/glean/tests/unit/core/glean.spec.ts
+++ b/glean/tests/unit/core/glean.spec.ts
@@ -164,6 +164,14 @@ describe("Glean", function() {
     assert.strictEqual(spy.callCount, 1);
   });
 
+  it("attempting to change upload status prior to initialize is a no-op", async function() {
+    await Glean.testUninitialize();
+
+    const launchSpy = sandbox.spy(Context.dispatcher, "launch");
+    Glean.setUploadEnabled(false);
+    assert.strictEqual(launchSpy.callCount, 0);
+  });
+
   it("initialization throws if applicationId is an empty string", async function() {
     await Glean.testUninitialize();
     try {


### PR DESCRIPTION
Checking inside the task had no meaning, because that would guarantee
the check to be executed _after_ the initialize task. That is the case,
because the initialize task is _always_ the first task to be executed by
the dispatcher regardless of any other previously dispatched tasks.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] ~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~
