### PR TITLE
Bug 1742450 - Make shutdown a no-op in case Glean is not initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#988](https://github.com/mozilla/glean.js/pull/988): BUGFIX: Enforce rate limitation at upload time, not at ping submission time.
   * Note: This change required a big refactoring of the internal uploading logic.
 * [#1015](https://github.com/mozilla/glean.js/pull/1015): BUGFIX: Make attempting to call the `setUploadEnabled` API before initializing Glean a no-op.
+* [#1016](https://github.com/mozilla/glean.js/pull/1016): BUGFIX: Make shutdown a no-op in case Glean is not initialized.
 
 # v0.27.0 (2021-11-22)
 

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -448,6 +448,8 @@ class Glean {
    * Finishes executing all pending tasks
    * and shuts down both Glean's dispatcher and the ping uploader.
    *
+   * If Glean is not initialized this is a no-op.
+   *
    * # Important
    *
    * This is irreversible.
@@ -456,6 +458,11 @@ class Glean {
    * @returns A promise which resolves once the shutdown is complete.
    */
   static async shutdown(): Promise<void> {
+    if (!Context.initialized) {
+      log(LOG_TAG, "Attempted to shutdown Glean, but Glean is not initialized. Ignoring.");
+      return;
+    }
+
     // Order here matters!
     //
     // The dispatcher needs to be shutdown first,

--- a/glean/tests/unit/core/glean.spec.ts
+++ b/glean/tests/unit/core/glean.spec.ts
@@ -553,6 +553,14 @@ describe("Glean", function() {
     assert.ok(postSpy.getCall(0).args[0].indexOf(DELETION_REQUEST_PING_NAME) !== -1);
   });
 
+  it("attempting to shutdown Glean prior to initialize is a no-op", async function() {
+    await Glean.testUninitialize();
+
+    const launchSpy = sandbox.spy(Context.dispatcher, "launch");
+    await Glean.shutdown();
+    assert.strictEqual(launchSpy.callCount, 0);
+  });
+
   it("events database is initialized at a time when metrics can already be recorded", async function() {
     const event = new EventMetricType({
       category: "test",


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Docstring has been updated. Don't think there are any other places to update.
