### PR TITLE
Bug 1740448 - Provide informative error message when unable to access DB in QML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.29.0...main)
 
+* [#1045](https://github.com/mozilla/glean.js/pull/1045): BUGFIX: Provide informative error message when unable to access database in QML.
+
 # v0.29.0 (2022-01-04)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.28.0...v0.29.0)

--- a/glean/src/core/dispatcher.ts
+++ b/glean/src/core/dispatcher.ts
@@ -115,7 +115,7 @@ class Dispatcher {
     } catch(e) {
       log(
         this.logTag,
-        `Error executing Glean task${e ? `: ${e}`: ". There might be more error logs above."}`,
+        `Error executing Glean task${e ? `: ${e as string}`: ". There might be more error logs above."}`,
         LoggingLevel.Error
       );
       return false;

--- a/glean/src/core/dispatcher.ts
+++ b/glean/src/core/dispatcher.ts
@@ -113,7 +113,11 @@ class Dispatcher {
       await task();
       return true;
     } catch(e) {
-      log(this.logTag, ["Error executing task:", e], LoggingLevel.Error);
+      log(
+        this.logTag,
+        `Error executing Glean task${e ? `: ${e}`: ". There might be more error logs above."}`,
+        LoggingLevel.Error
+      );
       return false;
     }
   }

--- a/glean/src/platform/qt/storage.ts
+++ b/glean/src/platform/qt/storage.ts
@@ -108,10 +108,13 @@ class QMLStore implements Store {
     private tableName: string,
     private name: string = DATABASE_NAME
   ) {
+    const logTag = `${LOG_TAG}.${tableName}`;
     this.initialized = this._executeQuery(
-      `CREATE TABLE IF NOT EXISTS ${tableName}(key VARCHAR(255), value VARCHAR(255));`
+      `CREATE TABLE IF NOT EXISTS ${tableName}(key VARCHAR(255), value VARCHAR(255));`,
+      logTag
     );
-    this.logTag = `${LOG_TAG}.${tableName}`;
+
+    this.logTag = logTag;
   }
 
   private _createKeyFromIndex(index: StorageIndex) {
@@ -121,9 +124,14 @@ class QMLStore implements Store {
   /**
    * Best effort at getting the database handle.
    *
+   * @param logTag The logTag to add to log messages.
+   *        Having this as an argument is necessary for the case when this
+   *        function gets called before initialize. In that case `this` is `undefined`
+   *        and attempting to call `this.logTag` will throw an error.
+   *
    * @returns The database handle or `undefined`.
    */
-  private get _dbHandle(): LocalStorage.DatabaseHandle | undefined {
+  private _dbHandle(logTag?: string): LocalStorage.DatabaseHandle | undefined {
     try {
       const handle = LocalStorage.LocalStorage.openDatabaseSync(
         this.name, "1.0", `${this.name} Storage`, ESTIMATED_DATABASE_SIZE
@@ -131,7 +139,7 @@ class QMLStore implements Store {
       this.dbHandle = handle;
     } catch(e) {
       log(
-        this.logTag,
+        logTag || this.logTag,
         ["Error while attempting to access LocalStorage.\n", e],
         LoggingLevel.Debug
       );
@@ -140,21 +148,32 @@ class QMLStore implements Store {
     }
   }
 
-  protected _executeQuery(query: string): Promise<LocalStorage.QueryResult | undefined> {
-    const handle = this._dbHandle;
+  /**
+   * Executes an arbitrary query on the database.
+   *
+   * @param query The query to execute.
+   * @param logTag The logTag to add to log messages.
+   *        Having this as an argument is necessary for the case when this
+   *        function gets called before initialize. In that case `this` is `undefined`
+   *        and attempting to call `this.logTag` will throw an error.
+   *
+   * @returns The query result if succesfull. A rejection otherwise.
+   */
+  protected _executeQuery(query: string, logTag?: string): Promise<LocalStorage.QueryResult | undefined> {
+    const handle = this._dbHandle(logTag);
+    if (!handle) {
+      return Promise.reject();
+    }
 
     return new Promise((resolve, reject) => {
       try {
-        // In case the handle is undefined we want to throw and land
-        // in the `catch` block below.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        handle!.transaction((tx: LocalStorage.DatabaseTransaction): void => {
+        handle.transaction((tx: LocalStorage.DatabaseTransaction): void => {
           const result = tx.executeSql(query);
           resolve(result);
         });
       } catch (e) {
         log(
-          this.logTag,
+          logTag || this.logTag,
           [`Error executing LocalStorage query: ${query}.\n`, e],
           LoggingLevel.Debug
         );

--- a/glean/src/platform/qt/storage.ts
+++ b/glean/src/platform/qt/storage.ts
@@ -128,7 +128,6 @@ class QMLStore implements Store {
    *        Having this as an argument is necessary for the case when this
    *        function gets called before initialize. In that case `this` is `undefined`
    *        and attempting to call `this.logTag` will throw an error.
-   *
    * @returns The database handle or `undefined`.
    */
   private _dbHandle(logTag?: string): LocalStorage.DatabaseHandle | undefined {
@@ -156,7 +155,6 @@ class QMLStore implements Store {
    *        Having this as an argument is necessary for the case when this
    *        function gets called before initialize. In that case `this` is `undefined`
    *        and attempting to call `this.logTag` will throw an error.
-   *
    * @returns The query result if succesfull. A rejection otherwise.
    */
   protected _executeQuery(query: string, logTag?: string): Promise<LocalStorage.QueryResult | undefined> {


### PR DESCRIPTION
Updated logs when unable to access the database now look like this:

```
qml: (Glean.platform.qt.Storage.pingLifetimeMetrics) Error executing LocalStorage query: CREATE TABLE IF NOT EXISTS pingLifetimeMetrics(key VARCHAR(255), value VARCHAR(255));.
 Error: Driver not loaded Driver not loaded
QSqlQuery::prepare: database not open
qml: (Glean.platform.qt.Storage.appLifetimeMetrics) Error executing LocalStorage query: CREATE TABLE IF NOT EXISTS appLifetimeMetrics(key VARCHAR(255), value VARCHAR(255));.
 Error: Driver not loaded Driver not loaded
QSqlQuery::prepare: database not open
qml: (Glean.platform.qt.Storage.events) Error executing LocalStorage query: CREATE TABLE IF NOT EXISTS events(key VARCHAR(255), value VARCHAR(255));.
 Error: Driver not loaded Driver not loaded
QSqlQuery::prepare: database not open
qml: (Glean.platform.qt.Storage.pings) Error executing LocalStorage query: CREATE TABLE IF NOT EXISTS pings(key VARCHAR(255), value VARCHAR(255));.
 Error: Driver not loaded Driver not loaded
qml: (Glean.core.Dispatcher) Error executing Glean task. There might be more error logs above.
qml: (Glean.core.Dispatcher) Error initializing dispatcher, won't execute anything further. There might be more error logs above.
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] ~**Tests**: This PR includes thorough tests or an explanation of why it does not~
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] ~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~
