### PR TITLE
Bug 1742613 - Remove deprecated headers from Glean pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   new behaviour only deletes the actually invalid data and leave the rest of the ping intact.
 * [#1065](https://github.com/mozilla/glean.js/pull/1065): Only import metric types into the library when they are used either by the user or Glean itself.
   * Previously the code required to deserialize metric data from the database was always imported by the library even if the metric type was never used by the client. This effort will decrease the size of the Glean.js bundles that don't import all the metric types.
+* [#1046](https://github.com/mozilla/glean.js/pull/1046): Remove legacy X-Client-Type X-Client-Version from Glean pings.
+
 # v0.30.0 (2022-01-10)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.29.0...v0.30.0)

--- a/glean/src/core/upload/worker.ts
+++ b/glean/src/core/upload/worker.ts
@@ -70,8 +70,6 @@ class PingUploadWorker {
       ...ping.headers,
       "Content-Type": "application/json; charset=utf-8",
       "Date": (new Date()).toISOString(),
-      "X-Client-Type": "Glean.js",
-      "X-Client-Version": GLEAN_VERSION,
       "X-Telemetry-Agent": `Glean/${GLEAN_VERSION} (JS on ${await Context.platform.info.os()})`
     };
 

--- a/glean/tests/unit/core/upload/worker.spec.ts
+++ b/glean/tests/unit/core/upload/worker.spec.ts
@@ -216,8 +216,6 @@ describe("PingUploadWorker", function() {
     assert.ok("Date" in headers);
     assert.ok("Content-Length" in headers);
     assert.ok("Content-Type" in headers);
-    assert.ok("X-Client-Type" in headers);
-    assert.ok("X-Client-Version" in headers);
     assert.ok("X-Telemetry-Agent" in headers);
     assert.strictEqual(headers["Content-Encoding"], "gzip");
   });


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
   - https://github.com/mozilla/glean/pull/1911
