### PR TITLE
Bug 1749301 - Do not clear app lifetime metrics if sending deletion-request ping on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.29.0...main)
 
 * [#1045](https://github.com/mozilla/glean.js/pull/1045): BUGFIX: Provide informative error message when unable to access database in QML.
+* [#1077](https://github.com/mozilla/glean.js/pull/1077): BUGFIX: Do not clear lifetime metrics before submitting `deletion-request` ping on initialize.
+  - This bug causes malformed `deletion-request` pings in Glean is initialized with `uploadEnabled=false`.
 
 # v0.29.0 (2022-01-04)
 

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -220,18 +220,23 @@ namespace Glean {
       // other task. No external API call will be executed before we leave this task.
       Context.initialized = true;
 
-      // IMPORTANT!
-      // Any pings we want to send upon initialization should happen before this line.
-      //
-      // Clear application lifetime metrics.
-      await Context.metricsDatabase.clear(Lifetime.Application);
-
       Context.uploadEnabled = uploadEnabled;
       // The upload enabled flag may have changed since the last run, for
       // example by the changing of a config file.
       if (uploadEnabled) {
-        // If upload is enabled, just follow the normal code path to
-        // instantiate the core metrics.
+        // IMPORTANT!
+        // Any pings we want to send upon initialization should happen before this line.
+        //
+        // Clear application lifetime metrics.
+        //
+        // If upload is disabled we don't need to do this,
+        // all metrics will be cleared anyways and we want
+        // application lifetime metrics intact in case
+        // we need to send a deletion-request ping.
+        await Context.metricsDatabase.clear(Lifetime.Application);
+
+        // If upload is enabled,
+        // just follow the normal code path to instantiate the core metrics.
         await onUploadEnabled();
       } else {
         // If upload is disabled, and we've never run before, only set the

--- a/glean/tests/integration/schema/schema.spec.ts
+++ b/glean/tests/integration/schema/schema.spec.ts
@@ -103,4 +103,19 @@ describe("schema", function() {
 
     validate(await deletionPingBody, pingSchema, { throwError: true });
   });
+
+  it("validate that the deletion-request ping sent upon init is valid against glean schema", async function () {
+    const httpClient = new WaitableUploader();
+    const deletionPingBody = httpClient.waitForPingSubmission("deletion-request");
+
+    // Reset Glean and enable upload.
+    await Glean.testResetGlean(testAppId, true);
+
+    // Re-start Glean with upload disabled, but don't clear stores.
+    // We want to know that we were previously started with the upload enabled.
+    await Glean.testUninitialize(false);
+    await Glean.testInitialize(testAppId, false, { httpClient });
+
+    validate(await deletionPingBody, pingSchema, { throwError: true });
+  });
 });


### PR DESCRIPTION
This is how deletion-request pings were looking like before the fix.

```
 (Glean.core.Pings.Maker) {
  "ping_info": {
    "seq": 0,
    "start_time": "2022-01-10T14:36+01:00",
    "end_time": "2022-01-10T14:36+01:00"
  },
  "client_info": {
    "telemetry_sdk_build": "0.29.0",
    "client_id": "da8d1774-2704-4828-ac4c-e2949f55d887",
    "first_run_date": "2022-01-10+01:00"
  }
}
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] ~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~
