### PR TITLE
Bug 1746375 - Expose testResetGlean on a standalone endpoint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * [#1065](https://github.com/mozilla/glean.js/pull/1065): Only import metric types into the library when they are used either by the user or Glean itself.
   * Previously the code required to deserialize metric data from the database was always imported by the library even if the metric type was never used by the client. This effort will decrease the size of the Glean.js bundles that don't import all the metric types.
 * [#1046](https://github.com/mozilla/glean.js/pull/1046): Remove legacy X-Client-Type X-Client-Version from Glean pings.
+* [#1071](https://github.com/mozilla/glean.js/pull/1071): **BREAKING CHANGE**: Move the `testResetGlean` API from the Glean singletion and into it's own entry point `@mozilla/glean/testing`.
+  * In order to use this API one must import it through `import { testResetGlean } from "@mozilla/glean/testing"` instead of using it from the Glean singleton directly.
+  * This lower the size of the Glean library, because testing functionality is not imported unless in a testing environment.
+  * This change does not apply to QML. In this environment the API remains the same.
 
 # v0.30.0 (2022-01-10)
 

--- a/glean/package.json
+++ b/glean/package.json
@@ -10,6 +10,7 @@
     "./private/ping": "./dist/core/pings/ping_type.js",
     "./plugins/*": "./dist/plugins/*.js",
     "./uploader": "./dist/core/upload/uploader.js",
+    "./testing": "./dist/core/testing/index.js",
     "./node": "./dist/index/node.js",
     "./webext": "./dist/index/webext.js",
     "./web": "./dist/index/web.js"
@@ -36,6 +37,9 @@
       ],
       "uploader": [
         "./dist/types/core/upload/uploader.d.ts"
+      ],
+      "testing": [
+        "./dist/types/core/testing/index.d.ts"
       ]
     }
   },

--- a/glean/src/core/context.ts
+++ b/glean/src/core/context.ts
@@ -72,7 +72,7 @@ export class Context {
   }
 
   /**
-   * Test-only API**
+   * Test-only API
    *
    * Resets the Context to an uninitialized state.
    */

--- a/glean/src/core/dispatcher.ts
+++ b/glean/src/core/dispatcher.ts
@@ -406,7 +406,7 @@ class Dispatcher {
   }
 
   /**
-   * Test-Only API**
+   * Test-only API
    *
    * Returns a promise that resolves once the current task execution in finished.
    *
@@ -420,7 +420,7 @@ class Dispatcher {
   }
 
   /**
-   * Test-Only API**
+   * Test-only API
    *
    * Returns the dispatcher back to an uninitialized state.
    *

--- a/glean/src/core/events/utils.ts
+++ b/glean/src/core/events/utils.ts
@@ -35,7 +35,7 @@ export function registerPluginToEvent<E extends CoreEvent>(plugin: Plugin<E>): v
 }
 
 /**
- * Test-only API**
+ * Test-only API
  *
  * Deregister plugins registered to all Glean events.
  */

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -14,10 +14,9 @@ import EventsDatabase from "./metrics/events_database/index.js";
 import UUIDMetricType from "./metrics/types/uuid.js";
 import DatetimeMetricType, { DatetimeMetric } from "./metrics/types/datetime.js";
 import CorePings from "./internal_pings.js";
-import { registerPluginToEvent, testResetEvents } from "./events/utils.js";
+import { registerPluginToEvent } from "./events/utils.js";
 import ErrorManager from "./error/index.js";
 import type Platform from "../platform/index.js";
-import TestPlatform from "../platform/test/index.js";
 import { Lifetime } from "./metrics/lifetime.js";
 import { Context } from "./context.js";
 import PingType from "./pings/ping_type.js";
@@ -29,6 +28,9 @@ namespace Glean {
   // The below properties are exported for testing purposes.
   //
   // Instances of Glean's core metrics.
+  //
+  // Disabling the lint, because we will actually re-assign this variable in the testInitializeGlean API.
+  // eslint-disable-next-line prefer-const
   export let coreMetrics = new CoreMetrics();
   // Instances of Glean's core pings.
   export const corePings = new CorePings();
@@ -443,87 +445,6 @@ namespace Glean {
     }
 
     Context.platform = platform;
-  }
-
-  /**
-   * Test-only API**
-   *
-   * Initializes Glean in testing mode.
-   *
-   * All platform specific APIs will be mocked.
-   *
-   * @param applicationId The application ID (will be sanitized during initialization).
-   * @param uploadEnabled Determines whether telemetry is enabled.
-   *        If disabled, all persisted metrics, events and queued pings (except
-   *        first_run_date) are cleared. Default to `true`.
-   * @param config Glean configuration options.
-   */
-  export async function testInitialize(
-    applicationId: string,
-    uploadEnabled = true,
-    config?: ConfigurationInterface
-  ): Promise<void> {
-    // Core metrics need to be re-initialized so that
-    // the supportedMetrics map is re-created.
-    coreMetrics = new CoreMetrics();
-
-    Context.testing = true;
-
-    setPlatform(TestPlatform);
-    initialize(applicationId, uploadEnabled, config);
-
-    await Context.dispatcher.testBlockOnQueue();
-  }
-
-  /**
-   * Test-only API**
-   *
-   * Resets Glean to an uninitialized state.
-   * This is a no-op in case Glean has not been initialized.
-   *
-   * @param clearStores Whether or not to clear the events, metrics and pings databases on uninitialize.
-   */
-  export async function testUninitialize(clearStores = true): Promise<void> {
-    if (Context.initialized) {
-      await shutdown();
-
-      if (clearStores) {
-        await Context.eventsDatabase.clearAll();
-        await Context.metricsDatabase.clearAll();
-        await Context.pingsDatabase.clearAll();
-      }
-
-      // Get back to an uninitialized state.
-      Context.testUninitialize();
-
-      // Deregister all plugins
-      testResetEvents();
-    }
-  }
-
-  /**
-   * Test-only API**
-   *
-   * Resets the Glean singleton to its initial state and re-initializes it.
-   *
-   * Note: There is no way to only allow this function to be called in test mode,
-   * because this is the function that puts Glean in test mode by setting Context.testing to true.
-   *
-   * @param applicationId The application ID (will be sanitized during initialization).
-   * @param uploadEnabled Determines whether telemetry is enabled.
-   *        If disabled, all persisted metrics, events and queued pings (except
-   *        first_run_date) are cleared. Default to `true`.
-   * @param config Glean configuration options.
-   * @param clearStores Whether or not to clear the events, metrics and pings databases on reset.
-   */
-  export async function testResetGlean(
-    applicationId: string,
-    uploadEnabled = true,
-    config?: ConfigurationInterface,
-    clearStores = true,
-  ): Promise<void> {
-    await testUninitialize(clearStores);
-    await testInitialize(applicationId, uploadEnabled, config);
   }
 }
 

--- a/glean/src/core/metrics/types/boolean.ts
+++ b/glean/src/core/metrics/types/boolean.ts
@@ -50,7 +50,7 @@ class BooleanMetricType extends MetricType {
   }
 
   /**
-   * Test-only API**
+   * Test-only API
    *
    * Gets the currently stored value as a boolean.
    *

--- a/glean/src/core/metrics/types/datetime.ts
+++ b/glean/src/core/metrics/types/datetime.ts
@@ -253,7 +253,7 @@ class DatetimeMetricType extends MetricType {
   }
 
   /**
-   * Test-only API**
+   * Test-only API
    *
    * Gets the currently stored value as an ISO date string.
    *
@@ -269,7 +269,7 @@ class DatetimeMetricType extends MetricType {
   }
 
   /**
-   * Test-only API**
+   * Test-only API
    *
    * Gets the currently stored value as a boolean.
    *

--- a/glean/src/core/metrics/types/event.ts
+++ b/glean/src/core/metrics/types/event.ts
@@ -92,7 +92,7 @@ class EventMetricType<SpecificExtraMap extends ExtraMap = ExtraMap> extends Metr
   }
 
   /**
-   * Test-only API**
+   * Test-only API
    *
    * Gets the currently stored events.
    *

--- a/glean/src/core/metrics/types/string.ts
+++ b/glean/src/core/metrics/types/string.ts
@@ -81,7 +81,7 @@ class StringMetricType extends MetricType {
   }
 
   /**
-   * Test-only API**
+   * Test-only API
    *
    * Gets the currently stored value as a string.
    *

--- a/glean/src/core/metrics/types/string_list.ts
+++ b/glean/src/core/metrics/types/string_list.ts
@@ -143,7 +143,7 @@ class StringListMetricType extends MetricType {
   }
 
   /**
-   * Test-only API**
+   * Test-only API
    *
    * Gets the currently stored value as a string array.
    *

--- a/glean/src/core/metrics/types/uuid.ts
+++ b/glean/src/core/metrics/types/uuid.ts
@@ -107,7 +107,7 @@ class UUIDMetricType extends MetricType {
   }
 
   /**
-   * Test-only API**
+   * Test-only API
    *
    * Gets the currently stored value as a string.
    *

--- a/glean/src/core/pings/ping_type.ts
+++ b/glean/src/core/pings/ping_type.ts
@@ -139,7 +139,7 @@ class PingType implements CommonPingData {
   }
 
   /**
-   * Test-only API**
+   * Test-only API
    *
    * Runs a validation function before the ping is collected.
    *

--- a/glean/src/core/testing/index.ts
+++ b/glean/src/core/testing/index.ts
@@ -6,7 +6,7 @@ import type { ConfigurationInterface } from "../config";
 import { testInitializeGlean, testUninitializeGlean } from "./utils.js";
 
 /**
- * Test-only API**
+ * Test-only API
  *
  * Resets the Glean singleton to its initial state and re-initializes it.
  *

--- a/glean/src/core/testing/index.ts
+++ b/glean/src/core/testing/index.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { ConfigurationInterface } from "../config";
+import { testInitializeGlean, testUninitializeGlean } from "./utils.js";
+
+/**
+ * Test-only API**
+ *
+ * Resets the Glean singleton to its initial state and re-initializes it.
+ *
+ * Note: There is no way to only allow this function to be called in test mode,
+ * because this is the function that puts Glean in test mode by setting Context.testing to true.
+ *
+ * @param applicationId The application ID (will be sanitized during initialization).
+ * @param uploadEnabled Determines whether telemetry is enabled.
+ *        If disabled, all persisted metrics, events and queued pings (except
+ *        first_run_date) are cleared. Default to `true`.
+ * @param config Glean configuration options.
+ * @param clearStores Whether or not to clear the events, metrics and pings databases on reset.
+ */
+export async function testResetGlean(
+  applicationId: string,
+  uploadEnabled = true,
+  config?: ConfigurationInterface,
+  clearStores = true,
+): Promise<void> {
+  await testUninitializeGlean(clearStores);
+  await testInitializeGlean(applicationId, uploadEnabled, config);
+}

--- a/glean/src/core/testing/utils.ts
+++ b/glean/src/core/testing/utils.ts
@@ -10,7 +10,7 @@ import Glean from "../glean.js";
 import { CoreMetrics } from "../internal_metrics.js";
 
 /**
- * Test-only API**
+ * Test-only API
  *
  * Initializes Glean in testing mode.
  *
@@ -40,7 +40,7 @@ export async function testInitializeGlean(
 }
 
 /**
- * Test-only API**
+ * Test-only API
  *
  * Resets Glean to an uninitialized state.
  * This is a no-op in case Glean has not been initialized.

--- a/glean/src/core/testing/utils.ts
+++ b/glean/src/core/testing/utils.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import TestPlatform from "../../platform/test/index.js";
+import type { ConfigurationInterface } from "../config.js";
+import { Context } from "../context.js";
+import { testResetEvents } from "../events/utils.js";
+import Glean from "../glean.js";
+import { CoreMetrics } from "../internal_metrics.js";
+
+/**
+ * Test-only API**
+ *
+ * Initializes Glean in testing mode.
+ *
+ * All platform specific APIs will be mocked.
+ *
+ * @param applicationId The application ID (will be sanitized during initialization).
+ * @param uploadEnabled Determines whether telemetry is enabled.
+ *        If disabled, all persisted metrics, events and queued pings (except
+ *        first_run_date) are cleared. Default to `true`.
+ * @param config Glean configuration options.
+ */
+export async function testInitializeGlean(
+  applicationId: string,
+  uploadEnabled = true,
+  config?: ConfigurationInterface
+): Promise<void> {
+  // Core metrics need to be re-initialized so that
+  // the supportedMetrics map is re-created.
+  Glean.coreMetrics = new CoreMetrics();
+
+  Context.testing = true;
+
+  Glean.setPlatform(TestPlatform);
+  Glean.initialize(applicationId, uploadEnabled, config);
+
+  await Context.dispatcher.testBlockOnQueue();
+}
+
+/**
+ * Test-only API**
+ *
+ * Resets Glean to an uninitialized state.
+ * This is a no-op in case Glean has not been initialized.
+ *
+ * @param clearStores Whether or not to clear the events, metrics and pings databases on uninitialize.
+ */
+export async function testUninitializeGlean(clearStores = true): Promise<void> {
+  if (Context.initialized) {
+    await Glean.shutdown();
+
+    if (clearStores) {
+      await Context.eventsDatabase.clearAll();
+      await Context.metricsDatabase.clearAll();
+      await Context.pingsDatabase.clearAll();
+    }
+
+    // Get back to an uninitialized state.
+    Context.testUninitialize();
+
+    // Deregister all plugins
+    testResetEvents();
+  }
+}

--- a/glean/src/core/utils.ts
+++ b/glean/src/core/utils.ts
@@ -228,7 +228,7 @@ export function testOnlyCheck(name: string, logTag = LOG_TAG): boolean {
       [
         `Attempted to access test only method \`${name || "unknown"}\`,`,
         "but Glean is not in testing mode. Ignoring. Make sure to put Glean in testing mode",
-        "before accessing such methods, by calling `Glean.testResetGlean`."
+        "before accessing such methods, by calling `testResetGlean`."
       ],
       LoggingLevel.Error
     );

--- a/glean/src/index/base.ts
+++ b/glean/src/index/base.ts
@@ -23,11 +23,6 @@ export default (platform: Platform): {
   setDebugViewTag(value: string): void,
   shutdown(): Promise<void>,
   setSourceTags(value: string[]): void,
-  testResetGlean(
-    applicationId: string,
-    uploadEnabled?: boolean,
-    config?: ConfigurationInterface
-  ): Promise<void>
 } => {
   return {
     /**
@@ -120,25 +115,5 @@ export default (platform: Platform): {
     setSourceTags(value: string[]): void {
       Glean.setSourceTags(value);
     },
-
-    /**
-     * Test-only API**
-     *
-     * Resets the Glean singleton to its initial state and re-initializes it.
-     *
-     * @param applicationId The application ID (will be sanitized during initialization).
-     * @param uploadEnabled Determines whether telemetry is enabled.
-     *        If disabled, all persisted metrics, events and queued pings (except
-     *        first_run_date) are cleared. Default to `true`.
-     * @param config Glean configuration options.
-     * @returns A promise that resolves when the initialization is complete.
-     */
-    async testResetGlean(
-      applicationId: string,
-      uploadEnabled = true,
-      config?: RestictedConfigurationInterface
-    ): Promise<void> {
-      return Glean.testResetGlean(applicationId, uploadEnabled, config);
-    }
   };
 };

--- a/glean/src/index/qt.ts
+++ b/glean/src/index/qt.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ErrorType } from "../core/error/error_type.js";
+import { testResetGlean } from "../core/testing/index.js";
 
 import platform from "../platform/qt/index.js";
 import base from "./base.js";
@@ -27,6 +28,8 @@ export default {
   ...base(platform),
 
   ErrorType,
+
+  testResetGlean,
 
   _private: {
     PingType,

--- a/glean/tests/integration/schema/schema.spec.ts
+++ b/glean/tests/integration/schema/schema.spec.ts
@@ -12,6 +12,8 @@ import { WaitableUploader } from "../../utils";
 // Generated files.
 import * as metrics from "./generated/forTesting";
 import * as pings from "./generated/pings";
+import { testResetGlean } from "../../../src/core/testing";
+import { testInitializeGlean, testUninitializeGlean } from "../../../src/core/testing/utils";
 
 const GLEAN_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/main/schemas/glean/glean/glean.1.schema.json";
 
@@ -55,7 +57,7 @@ describe("schema", function() {
 
   it("validate generated ping is valid against glean schema", async function () {
     const httpClient = new WaitableUploader();
-    await Glean.testResetGlean(testAppId, true, { httpClient });
+    await testResetGlean(testAppId, true, { httpClient });
 
     // Record something for each metric type.
     //
@@ -96,7 +98,7 @@ describe("schema", function() {
 
   it("validate that the deletion-request is valid against glean schema", async function () {
     const httpClient = new WaitableUploader();
-    await Glean.testResetGlean(testAppId, true, { httpClient });
+    await testResetGlean(testAppId, true, { httpClient });
 
     const deletionPingBody = httpClient.waitForPingSubmission("deletion-request");
     Glean.setUploadEnabled(false);
@@ -109,12 +111,12 @@ describe("schema", function() {
     const deletionPingBody = httpClient.waitForPingSubmission("deletion-request");
 
     // Reset Glean and enable upload.
-    await Glean.testResetGlean(testAppId, true);
+    await testResetGlean(testAppId, true);
 
     // Re-start Glean with upload disabled, but don't clear stores.
     // We want to know that we were previously started with the upload enabled.
-    await Glean.testUninitialize(false);
-    await Glean.testInitialize(testAppId, false, { httpClient });
+    await testUninitializeGlean(false);
+    await testInitializeGlean(testAppId, false, { httpClient });
 
     validate(await deletionPingBody, pingSchema, { throwError: true });
   });

--- a/glean/tests/unit/core/context.spec.ts
+++ b/glean/tests/unit/core/context.spec.ts
@@ -10,20 +10,22 @@ import Glean from "../../../src/core/glean";
 import MetricsDatabase from "../../../src/core/metrics/database";
 import EventsDatabase from "../../../src/core/metrics/events_database";
 import PingsDatabase from "../../../src/core/pings/database";
+import { testResetGlean } from "../../../src/core/testing";
+import { testUninitializeGlean } from "../../../src/core/testing/utils";
 import { sanitizeApplicationId } from "../../../src/core/utils";
 
 describe("Context", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function () {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("dispatcher contains the expected value", async function () {
     assert.notStrictEqual(Context.dispatcher, undefined);
     assert.ok(Context.dispatcher instanceof Dispatcher);
 
-    await Glean.testUninitialize();
+    await testUninitializeGlean();
     // Dispatcher should be available when Glean is uninitialized too.
     assert.notStrictEqual(Context.dispatcher, undefined);
     assert.ok((Context.dispatcher as unknown) instanceof Dispatcher);
@@ -40,14 +42,14 @@ describe("Context", function() {
   it("appId contains the expected value", async function () {
     assert.strictEqual(Context.applicationId, sanitizeApplicationId(testAppId));
 
-    await Glean.testResetGlean("new-id");
+    await testResetGlean("new-id");
     assert.strictEqual(Context.applicationId, sanitizeApplicationId("new-id"));
   });
 
   it("initialized contains the expected value", async function () {
     assert.strictEqual(Context.initialized, true);
 
-    await Glean.testUninitialize();
+    await testUninitializeGlean();
     assert.strictEqual(Context.initialized, false);
   });
 

--- a/glean/tests/unit/core/error_recording.spec.ts
+++ b/glean/tests/unit/core/error_recording.spec.ts
@@ -6,16 +6,16 @@ import assert from "assert";
 
 import { ErrorType } from "../../../src/core/error/error_type";
 import { Context } from "../../../src/core/context";
-import Glean from "../../../src/core/glean";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
 import LabeledMetricType from "../../../src/core/metrics/types/labeled";
 import StringMetricType from "../../../src/core/metrics/types/string";
+import { testResetGlean } from "../../../src/core/testing";
 
 describe("error_recording", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("records error types correctly", async function () {

--- a/glean/tests/unit/core/metrics/boolean.spec.ts
+++ b/glean/tests/unit/core/metrics/boolean.spec.ts
@@ -8,12 +8,13 @@ import { Context } from "../../../../src/core/context";
 import Glean from "../../../../src/core/glean";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import BooleanMetricType from "../../../../src/core/metrics/types/boolean";
+import { testResetGlean } from "../../../../src/core/testing";
 
 describe("BooleanMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("attempting to get the value of a metric that hasn't been recorded doesn't error", async function() {

--- a/glean/tests/unit/core/metrics/counter.spec.ts
+++ b/glean/tests/unit/core/metrics/counter.spec.ts
@@ -9,12 +9,13 @@ import { ErrorType } from "../../../../src/core/error/error_type";
 import Glean from "../../../../src/core/glean";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import CounterMetricType from "../../../../src/core/metrics/types/counter";
+import { testResetGlean } from "../../../../src/core/testing";
 
 describe("CounterMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("attempting to get the value of a metric that hasn't been recorded doesn't error", async function() {

--- a/glean/tests/unit/core/metrics/database.spec.ts
+++ b/glean/tests/unit/core/metrics/database.spec.ts
@@ -8,16 +8,16 @@ import Database, { generateReservedMetricIdentifiers } from "../../../../src/cor
 import StringMetricType, { StringMetric } from "../../../../src/core/metrics/types/string";
 
 import type { JSONObject, JSONValue } from "../../../../src/core/utils";
-import Glean from "../../../../src/core/glean";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import { Context } from "../../../../src/core/context";
 import { BooleanMetric } from "../../../../src/core/metrics/types/boolean";
+import { testResetGlean } from "../../../../src/core/testing";
 
 describe("MetricsDatabase", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
 
     // These metric types are used throughout tests,
     // but is added directly on the database instead of creating it through new BooleanMetricType.

--- a/glean/tests/unit/core/metrics/datetime.spec.ts
+++ b/glean/tests/unit/core/metrics/datetime.spec.ts
@@ -11,6 +11,7 @@ import DatetimeMetricType, { DatetimeMetric } from "../../../../src/core/metrics
 import TimeUnit from "../../../../src/core/metrics/time_unit";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import { Context } from "../../../../src/core/context";
+import { testResetGlean } from "../../../../src/core/testing";
 
 const sandbox = sinon.createSandbox();
 
@@ -22,7 +23,7 @@ describe("DatetimeMetric", function() {
   });
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("datetime internal representation validation works as expected", function () {

--- a/glean/tests/unit/core/metrics/event.spec.ts
+++ b/glean/tests/unit/core/metrics/event.spec.ts
@@ -8,12 +8,13 @@ import Glean from "../../../../src/core/glean";
 import EventMetricType from "../../../../src/core/metrics/types/event";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import { ErrorType } from "../../../../src/core/error/error_type";
+import { testResetGlean } from "../../../../src/core/testing";
 
 describe("EventMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("the API records to its storage engine", async function () {

--- a/glean/tests/unit/core/metrics/events_database.spec.ts
+++ b/glean/tests/unit/core/metrics/events_database.spec.ts
@@ -6,7 +6,6 @@ import assert from "assert";
 import type { SinonFakeTimers } from "sinon";
 import sinon from "sinon";
 
-import Glean from "../../../../src/core/glean";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import EventsDatabase, { getGleanRestartedEventMetric } from "../../../../src/core/metrics/events_database";
 import EventMetricType from "../../../../src/core/metrics/types/event";
@@ -19,6 +18,7 @@ import { RecordedEvent } from "../../../../src/core/metrics/events_database/reco
 import { GLEAN_EXECUTION_COUNTER_EXTRA_KEY } from "../../../../src/core/constants";
 import { collectPing } from "../../../../src/core/pings/maker";
 import { ErrorType } from "../../../../src/core/error/error_type";
+import { testResetGlean } from "../../../../src/core/testing";
 
 const sandbox = sinon.createSandbox();
 const now = new Date();
@@ -29,7 +29,7 @@ describe("EventsDatabase", function() {
 
   beforeEach(async function() {
     clock = sandbox.useFakeTimers(now.getTime());
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   afterEach(function () {

--- a/glean/tests/unit/core/metrics/labeled.spec.ts
+++ b/glean/tests/unit/core/metrics/labeled.spec.ts
@@ -7,13 +7,14 @@ import sinon from "sinon";
 
 import { Context } from "../../../../src/core/context";
 import { ErrorType } from "../../../../src/core/error/error_type";
-import Glean from "../../../../src/core/glean";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import BooleanMetricType from "../../../../src/core/metrics/types/boolean";
 import CounterMetricType from "../../../../src/core/metrics/types/counter";
 import LabeledMetricType from "../../../../src/core/metrics/types/labeled";
 import StringMetricType from "../../../../src/core/metrics/types/string";
 import PingType from "../../../../src/core/pings/ping_type";
+import { testResetGlean } from "../../../../src/core/testing";
+import { testInitializeGlean, testUninitializeGlean } from "../../../../src/core/testing/utils";
 import type { JSONObject } from "../../../../src/core/utils";
 import { stopGleanUploader } from "../../../utils";
 
@@ -23,7 +24,7 @@ describe("LabeledMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
     // Disable ping uploading for it not to interfere with this tests.
     stopGleanUploader();
   });
@@ -168,7 +169,7 @@ describe("LabeledMetric", function() {
     );
 
     // Make sure Glean isn't initialized, so that tasks get enqueued.
-    await Glean.testUninitialize();
+    await testUninitializeGlean();
 
     for (let i = 0; i <= 20; i++) {
       labeledCounterMetric[`label_${i}`].add(1);
@@ -176,7 +177,7 @@ describe("LabeledMetric", function() {
     // Go back and record in one of the real labels again.
     labeledCounterMetric["label_0"].add(1);
 
-    await Glean.testInitialize("gleanjs.unit.test", true);
+    await testInitializeGlean("gleanjs.unit.test", true);
 
     assert.strictEqual(await labeledCounterMetric["label_0"].testGetValue(), 2);
     for (let i = 1; i <= 15; i++) {
@@ -433,7 +434,7 @@ describe("LabeledMetric", function() {
     }
 
     // Reset glean without clearing the storage.
-    await Glean.testResetGlean(testAppId, true, undefined, false);
+    await testResetGlean(testAppId, true, undefined, false);
 
     // Try to store another label.
     labeledCounterMetric["new_label"].add(40);

--- a/glean/tests/unit/core/metrics/quantity.spec.ts
+++ b/glean/tests/unit/core/metrics/quantity.spec.ts
@@ -9,12 +9,13 @@ import { ErrorType } from "../../../../src/core/error/error_type";
 import Glean from "../../../../src/core/glean";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import QuantityMetricType from "../../../../src/core/metrics/types/quantity";
+import { testResetGlean } from "../../../../src/core/testing";
 
 describe("QuantityMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("attempting to get the value of a metric that hasn't been recorded doesn't error", async function() {

--- a/glean/tests/unit/core/metrics/rate.spec.ts
+++ b/glean/tests/unit/core/metrics/rate.spec.ts
@@ -9,12 +9,13 @@ import Glean from "../../../../src/core/glean";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import RateMetricType from "../../../../src/core/metrics/types/rate";
 import { Context } from "../../../../src/core/context";
+import { testResetGlean } from "../../../../src/core/testing";
 
 describe("RateMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("attempting to get the value of a metric that hasn't been recorded doesn't error", async function() {

--- a/glean/tests/unit/core/metrics/string.spec.ts
+++ b/glean/tests/unit/core/metrics/string.spec.ts
@@ -10,12 +10,13 @@ import { Lifetime } from "../../../../src/core/metrics/lifetime";
 
 import { Context } from "../../../../src/core/context";
 import { ErrorType } from "../../../../src/core/error/error_type";
+import { testResetGlean } from "../../../../src/core/testing";
 
 describe("StringMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("attempting to get the value of a metric that hasn't been recorded doesn't error", async function() {

--- a/glean/tests/unit/core/metrics/string_list.spec.ts
+++ b/glean/tests/unit/core/metrics/string_list.spec.ts
@@ -9,12 +9,13 @@ import { ErrorType } from "../../../../src/core/error/error_type";
 import Glean from "../../../../src/core/glean";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import StringListMetricType, { MAX_LIST_LENGTH, MAX_STRING_LENGTH } from "../../../../src/core/metrics/types/string_list";
+import { testResetGlean } from "../../../../src/core/testing";
 
 describe("StringListMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("attempting to get the value of a metric that hasn't been recorded doesn't error", async function() {

--- a/glean/tests/unit/core/metrics/text.spec.ts
+++ b/glean/tests/unit/core/metrics/text.spec.ts
@@ -9,12 +9,13 @@ import { ErrorType } from "../../../../src/core/error/error_type";
 import Glean from "../../../../src/core/glean";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import TextMetricType, { TEXT_MAX_LENGTH } from "../../../../src/core/metrics/types/text";
+import { testResetGlean } from "../../../../src/core/testing";
 
 describe("TextMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("attempting to get the value of a metric that hasn't been recorded doesn't error", async function() {

--- a/glean/tests/unit/core/metrics/timespan.spec.ts
+++ b/glean/tests/unit/core/metrics/timespan.spec.ts
@@ -12,6 +12,7 @@ import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import TimeUnit from "../../../../src/core/metrics/time_unit";
 import TimespanMetricType, { TimespanMetric } from "../../../../src/core/metrics/types/timespan";
 import { ErrorType } from "../../../../src/core/error/error_type";
+import { testResetGlean } from "../../../../src/core/testing";
 
 const sandbox = sinon.createSandbox();
 
@@ -20,7 +21,7 @@ describe("TimespanMetric", function() {
   let fakeNow: SinonStub;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
     fakeNow = typeof performance === "undefined" ? sandbox.stub(Date, "now") : sandbox.stub(performance, "now");
   });
 

--- a/glean/tests/unit/core/metrics/url.spec.ts
+++ b/glean/tests/unit/core/metrics/url.spec.ts
@@ -9,12 +9,13 @@ import { ErrorType } from "../../../../src/core/error/error_type";
 import Glean from "../../../../src/core/glean";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import UrlMetricType from "../../../../src/core/metrics/types/url";
+import { testResetGlean } from "../../../../src/core/testing";
 
 describe("UrlMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("attempting to get the value of a metric that hasn't been recorded doesn't error", async function() {

--- a/glean/tests/unit/core/metrics/uuid.spec.ts
+++ b/glean/tests/unit/core/metrics/uuid.spec.ts
@@ -10,12 +10,13 @@ import UUIDMetricType from "../../../../src/core/metrics/types/uuid";
 import { Lifetime } from "../../../../src/core/metrics/lifetime";
 import { Context } from "../../../../src/core/context";
 import { ErrorType } from "../../../../src/core/error/error_type";
+import { testResetGlean } from "../../../../src/core/testing";
 
 describe("UUIDMetric", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("attempting to get the value of a metric that hasn't been recorded doesn't error", async function() {

--- a/glean/tests/unit/core/pings/database.spec.ts
+++ b/glean/tests/unit/core/pings/database.spec.ts
@@ -8,8 +8,8 @@ import sinon from "sinon";
 
 import type { Observer} from "../../../../src/core/pings/database";
 import Database, { isValidPingInternalRepresentation } from "../../../../src/core/pings/database";
-import Glean from "../../../../src/core/glean";
 import type { JSONObject } from "../../../../src/core/utils";
+import { testResetGlean } from "../../../../src/core/testing";
 
 const sandbox = sinon.createSandbox();
 const now = new Date();
@@ -20,7 +20,7 @@ describe("PingsDatabase", function() {
 
   beforeEach(async function() {
     clock = sandbox.useFakeTimers(now.getTime());
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   afterEach(function () {

--- a/glean/tests/unit/core/pings/ping_type.spec.ts
+++ b/glean/tests/unit/core/pings/ping_type.spec.ts
@@ -13,6 +13,8 @@ import { Context } from "../../../../src/core/context";
 import { stopGleanUploader } from "../../../utils";
 import type { JSONObject } from "../../../../src/core/utils";
 import TestPlatform from "../../../../src/platform/test";
+import { testResetGlean } from "../../../../src/core/testing";
+import { testUninitializeGlean } from "../../../../src/core/testing/utils";
 
 const sandbox = sinon.createSandbox();
 
@@ -35,7 +37,7 @@ describe("PingType", function() {
   });
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   it("collects and stores ping on submit", async function () {
@@ -99,7 +101,7 @@ describe("PingType", function() {
   });
 
   it("no pings are submitted if Glean has not been initialized", async function() {
-    await Glean.testUninitialize();
+    await testUninitializeGlean();
 
     const spy = sandbox.spy(TestPlatform.uploader, "post");
     const ping = new PingType({

--- a/glean/tests/unit/core/upload/manager.spec.ts
+++ b/glean/tests/unit/core/upload/manager.spec.ts
@@ -8,7 +8,6 @@ import { v4 as UUIDv4 } from "uuid";
 
 import { Configuration } from "../../../../src/core/config";
 import { Context } from "../../../../src/core/context";
-import Glean from "../../../../src/core/glean";
 import PingUploadManager from "../../../../src/core/upload/manager";
 import { UploadResultStatus } from "../../../../src/core/upload/uploader";
 import { CounterUploader, WaitableUploader } from "../../../utils";
@@ -18,6 +17,7 @@ import { makePath } from "../../../../src/core/pings/maker";
 import Policy from "../../../../src/core/upload/policy";
 import { UploadTaskTypes } from "../../../../src/core/upload/task";
 import { MAX_PINGS_PER_INTERVAL } from "../../../../src/core/upload/rate_limiter";
+import { testResetGlean } from "../../../../src/core/testing";
 
 const sandbox = sinon.createSandbox();
 
@@ -62,7 +62,7 @@ describe("PingUploadManager", function() {
   before(async function () {
     // We call this only once so that the platform is set
     // and we are able to create a pings database.
-    await Glean.testResetGlean(testAppId, true);
+    await testResetGlean(testAppId, true);
     pingsDatabase = new PingsDatabase();
   });
 

--- a/glean/tests/unit/core/upload/worker.spec.ts
+++ b/glean/tests/unit/core/upload/worker.spec.ts
@@ -10,7 +10,6 @@ import type { UploadTask } from "../../../../src/core/upload/task";
 import uploadTaskFactory from "../../../../src/core/upload/task";
 import PingUploadWorker from "../../../../src/core/upload/worker";
 import TestPlatform from "../../../../src/platform/test";
-import Glean from "../../../../src/core/glean";
 import { CounterUploader, WaitableUploader } from "../../../utils";
 import { makePath } from "../../../../src/core/pings/maker";
 import { Context } from "../../../../src/core/context";
@@ -18,6 +17,7 @@ import Policy from "../../../../src/core/upload/policy";
 import { UploadResultStatus } from "../../../../src/core/upload/uploader";
 import type { UploadResult } from "../../../../src/core/upload/uploader";
 import { isUndefined } from "../../../../src/core/utils";
+import { testResetGlean } from "../../../../src/core/testing";
 
 const sandbox = sinon.createSandbox();
 
@@ -87,7 +87,7 @@ describe("PingUploadWorker", function() {
   before(async function () {
     // We call this only once so that the platform is set
     // and we are able to access the Platform info.
-    await Glean.testResetGlean(testAppId, true);
+    await testResetGlean(testAppId, true);
   });
 
   afterEach(function () {

--- a/glean/tests/unit/plugins/encryption.spec.ts
+++ b/glean/tests/unit/plugins/encryption.spec.ts
@@ -6,7 +6,6 @@ import assert from "assert";
 import sinon from "sinon";
 import { generateKeyPair, exportJWK, compactDecrypt } from "jose";
 
-import Glean from "../../../src/core/glean";
 import PingType from "../../../src/core/pings/ping_type";
 import type { JSONObject } from "../../../src/core/utils";
 import { WaitableUploader } from "../../utils";
@@ -14,6 +13,7 @@ import PingEncryptionPlugin from "../../../src/plugins/encryption";
 import collectAndStorePing, { makePath } from "../../../src/core/pings/maker";
 import CounterMetricType from "../../../src/core/metrics/types/counter";
 import { Lifetime } from "../../../src/core/metrics/lifetime";
+import { testResetGlean } from "../../../src/core/testing";
 
 const sandbox = sinon.createSandbox();
 
@@ -21,7 +21,7 @@ describe("PingEncryptionPlugin", function() {
   const testAppId = `gleanjs.test.${this.title}`;
 
   beforeEach(async function() {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   afterEach(function () {
@@ -40,7 +40,7 @@ describe("PingEncryptionPlugin", function() {
     const mockUploader = new WaitableUploader();
     const pingBody = mockUploader.waitForPingSubmission("test", path);
 
-    await Glean.testResetGlean(
+    await testResetGlean(
       testAppId,
       true,
       {
@@ -82,7 +82,7 @@ describe("PingEncryptionPlugin", function() {
 
     const httpClient = new WaitableUploader();
     const pingBody = httpClient.waitForPingSubmission("encryptedping");
-    await Glean.testResetGlean(
+    await testResetGlean(
       testAppId,
       true,
       {

--- a/glean/tsconfig/lib.json
+++ b/glean/tsconfig/lib.json
@@ -1,7 +1,7 @@
 {
   "extends": "./base.json",
   "include": [
-    "../src/core/metrics/types/*.ts",
+    "../src/core/**/*.ts",
     "../src/plugins/*.ts",
     "../src/index/node.ts",
     "../src/index/webext.ts",

--- a/glean/tsconfig/types.json
+++ b/glean/tsconfig/types.json
@@ -1,7 +1,7 @@
 {
   "extends": "./base.json",
   "include": [
-    "../src/core/metrics/types/*.ts",
+    "../src/core/**/*.ts",
     "../src/plugins/*.ts",
     "../src/index/node.ts",
     "../src/index/webext.ts"

--- a/samples/browser/webext/tests/unit/index.test.ts
+++ b/samples/browser/webext/tests/unit/index.test.ts
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { strict as assert } from "assert";
-import Glean, { ErrorType } from "@mozilla/glean/webext";
+import { ErrorType } from "@mozilla/glean/webext";
+import { testResetGlean } from "@mozilla/glean/testing";
 
 import * as sample from "../../src/generated/sample.js";
 
@@ -11,7 +12,7 @@ describe("webext", function () {
   const testAppId = `webext.js.test.${this.title}`;
 
   beforeEach(async function () {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   describe("sample test", function () {

--- a/samples/node/main.test.js
+++ b/samples/node/main.test.js
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { strict as assert } from "assert";
-import Glean, { ErrorType } from "@mozilla/glean/node";
+import { ErrorType } from "@mozilla/glean/node";
+import { testResetGlean } from "@mozilla/glean/testing";
 
 import main from "./main.js";
 import { execution } from "./generated/pings.js";
@@ -13,7 +14,7 @@ describe("node-sample", function () {
   const testAppId = `node.test.${this.title}`;
 
   beforeEach(async function () {
-    await Glean.testResetGlean(testAppId);
+    await testResetGlean(testAppId);
   });
 
   describe("sample test", function () {


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - https://bugzilla.mozilla.org/show_bug.cgi?id=1733365
