### PR TITLE
Bug 1751402 - Guarantee getMonotonicNow doesn't return a negative value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [#1130](https://github.com/mozilla/glean.js/pull/1130): BUGFIX: Guarantee event timestamps
 cannot be negative numbers.
-  * Timestamps were observed to be negative in a few occurrences, for platforms that do not provide the `performance.now` API, namely QML, and in which we fallback to the `Date.now` API.
+  * Timestamps were observed to be negative in a few occurances, for platforms that do not provide the `performance.now` API, namely QML, and in which we fallback to the `Date.now` API.
   * If event timestamps are negative pings are rejected by the pipeline.
 
 # v0.31.0 (2022-01-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [#1130](https://github.com/mozilla/glean.js/pull/1130): BUGFIX: Guarantee event timestamps
 cannot be negative numbers.
-  * Timestamps were observed to be negative in a few occurances, for platforms that do not provide the `performance.now` API, namely QML, and in which we fallback to the `Date.now` API.
+  * Timestamps were observed to be negative in a few occurrences, for platforms that do not provide the `performance.now` API, namely QML, and in which we fallback to the `Date.now` API.
   * If event timestamps are negative pings are rejected by the pipeline.
 
 # v0.31.0 (2022-01-25)

--- a/glean/src/core/utils.ts
+++ b/glean/src/core/utils.ts
@@ -168,12 +168,6 @@ export function generateUUIDv4(): string {
   }
 }
 
-// For the case when `performance` is not available in the environment,
-// we instead will use Date. To do so, we need to have a TIME_ORIGIN
-// to subtract the current UNIX timestamp from, to make sure using Date
-// works the same as using performance.
-// See: https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp#the_time_origin
-const TIME_ORIGIN = Date.now();
 /**
  * A helper function to get the current amount of milliseconds passed since
  * a given time origin.
@@ -185,7 +179,7 @@ export function getMonotonicNow(): number {
   // means we should get creative to find a proper clock for that platform.
   // Fall back to `Date.now` for now, until bug 1690528 is fixed.
   const now = typeof performance === "undefined"
-    ? (Date.now() - TIME_ORIGIN)
+    ? Date.now()
     : performance.now();
 
   return Math.round(now);

--- a/glean/tests/unit/core/metrics/timespan.spec.ts
+++ b/glean/tests/unit/core/metrics/timespan.spec.ts
@@ -275,7 +275,7 @@ describe("TimespanMetric", function() {
     // Nothing should have been recorded.
     assert.strictEqual(await metric.testGetValue("aPing"), undefined);
 
-    // TODO: Make sure also invalid state error was recorded.
+    assert.strictEqual(await metric.testGetNumRecordedErrors(ErrorType.InvalidState), 1);
   });
 
   it("time cannot go backwards", async function() {


### PR DESCRIPTION
We were previously extracting the TIME_ORIGIN from Date.now()
in case performance.now was not available in the environment.

That could create negative timestamps, because Date.now is not
guaranteed to be monotonically increasing. (Yeah... it is
contradictiory to have a function called getMonotonicNow, but not
guarantee monotonically increasing timestamps for some platforms.
At least there is a TODO comment to address the incoherence at
some point).

Subtracting the TIME_ORIGIN was essentially pointless and I don't really
know why that was the case before. That function is used by the Timestamp
metric type and for event timestamps which are both about elapsed time,
so the absoulte timestamp should not matter.

EXTRA: Address stray TODO comment on TimespanMetricType test suite.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] ~**Tests**: This PR includes thorough tests or an explanation of why it does not~
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] ~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~