### PR TITLE
1219: Allow use of standalone virtual environments (eg, one created by virtualenv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.31.0...main)
 
+* [#1220](https://github.com/mozilla/glean.js/pull/1220): Minorly refactor virtual environment behaviour to support virtualenvs that aren't in the project root. 
+  * This means it's possible to run Glean with a virtual environment created by `virtualenv` or `pyenv-virtualenv` without causing a Glean-specific `.venv` dir to be created in a project is using Glean.
+
 * [#1130](https://github.com/mozilla/glean.js/pull/1130): BUGFIX: Guarantee event timestamps
 cannot be negative numbers.
   * Timestamps were observed to be negative in a few occurrences, for platforms that do not provide the `performance.now` API, namely QML, and in which we fallback to the `Date.now` API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.31.0...main)
 
-* [#1220](https://github.com/mozilla/glean.js/pull/1220): Minorly refactor virtual environment behaviour to support virtualenvs that aren't in the project root. 
-  * This means it's possible to run Glean with a virtual environment created by `virtualenv` or `pyenv-virtualenv` without causing a Glean-specific `.venv` dir to be created in a project is using Glean.
+* [#1220](https://github.com/mozilla/glean.js/pull/1220): Refactor virtual environment behavior to support virtual environments that aren't in the project root. 
+  * This means it's possible to run Glean with a virtual environment created by `virtualenv` or `pyenv-virtualenv` without causing a Glean-specific `.venv` directory to be created in a project that is using Glean.
 
 * [#1130](https://github.com/mozilla/glean.js/pull/1130): BUGFIX: Guarantee event timestamps
 cannot be negative numbers.

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -22,8 +22,19 @@ const LOG_TAG = "CLI";
 // > one is running inside a virtual environment.
 //
 // See: https://docs.python.org/3/library/venv.html
-// (Also applies to envs created using virtualenv though)
-const VIRTUAL_ENVIRONMENT_DIR = process.env.VIRTUAL_ENV?.split("/").slice(-1)[0] || ".venv";
+// (Also applies to envs created using virtualenv though, so we check whether they are 
+// separate/standlone or created in a subdir of the project)
+let STANDALONE_VIRTUAL_ENV_EXISTS: boolean = false;
+let VIRTUAL_ENVIRONMENT_DIR: string;
+if (process.env.VIRTUAL_ENV != undefined && !process.env.VIRTUAL_ENV.startsWith(process.cwd())){
+  // We have a pre-existing virtual environment that is not a child of the project dir
+  VIRTUAL_ENVIRONMENT_DIR = process.env.VIRTUAL_ENV;
+  STANDALONE_VIRTUAL_ENV_EXISTS = true;
+} else {
+  // Legacy support for how things used to run: assume virtual environment is inside 
+  // the project and create our default one if necessary
+  VIRTUAL_ENVIRONMENT_DIR = process.env.VIRTUAL_ENV?.split("/").slice(-1)[0] || ".venv";
+}
 
 // The version of glean_parser to install from PyPI.
 const GLEAN_PARSER_VERSION = "5.0.1";
@@ -111,7 +122,7 @@ function getPythonVenvBinariesPath(venvRoot: string): string {
  *          is accessible, `false` otherwise.
  */
 async function checkPythonVenvExists(venvPath: string): Promise<boolean> {
-  log(LOG_TAG, `Checking for a Glean virtual environment at ${venvPath}`);
+  log(LOG_TAG, `Checking for a virtual environment at ${venvPath}`);
 
   const venvPython =
     path.join(getPythonVenvBinariesPath(venvPath), getSystemPythonBinName());
@@ -135,7 +146,7 @@ async function checkPythonVenvExists(venvPath: string): Promise<boolean> {
  * @returns `true` if the environment was correctly created, `false` otherwise.
  */
 async function createPythonVenv(venvPath: string): Promise<boolean> {
-  log(LOG_TAG, `Creating a Glean virtual environment at ${venvPath}`);
+  log(LOG_TAG, `Creating a virtual environment at ${venvPath}`);
 
   const pipFilename = (platform === "win32") ? "pip3.exe" : "pip3";
   const venvPip =
@@ -163,19 +174,41 @@ async function createPythonVenv(venvPath: string): Promise<boolean> {
 }
 
 /**
+ * Derives the most appropriate path to a viable virtualenv, which may be
+ * inside the project dir, or entirely separate, depending on configuration
+ *
+ * @param projectRoot the project's root directory.
+ *
+ * @returns a string path to the virtual environment's root dir
+ */
+
+async function getVenvRoot(projectRoot:string) {
+  if (STANDALONE_VIRTUAL_ENV_EXISTS){
+    // The virtual environment exists outside of the project
+    // root (eg a pyenv virtualenv or virtualenv in $HOME),
+    // so that's all we need
+    return VIRTUAL_ENVIRONMENT_DIR
+  }
+  // The default/most simple place for a Python virtual environment created
+  // with `python venv` is in the project itself, so we need a path
+  // relative to the project root
+  return path.join(projectRoot, VIRTUAL_ENVIRONMENT_DIR);
+
+}
+
+/**
  * Checks if a virtual environment for running the glean_parser exists,
  * otherwise it creates it.
  *
  * @param projectRoot the project's root directory.
  */
 async function setup(projectRoot: string) {
-  const venvRoot = path.join(projectRoot, VIRTUAL_ENVIRONMENT_DIR);
-
+  const venvRoot = await getVenvRoot(projectRoot);
   const venvExists = await checkPythonVenvExists(venvRoot);
   if (venvExists) {
-    log(LOG_TAG, `Using Glean virtual environment at ${venvRoot}`);
+    log(LOG_TAG, `Using virtual environment at ${venvRoot}`);
   } else if (!await createPythonVenv(venvRoot)){
-    log(LOG_TAG, `Failed to create a Glean virtual environment at ${venvRoot}`);
+    log(LOG_TAG, `Failed to create a virtual environment at ${venvRoot}`);
     process.exit(1);
   }
 }
@@ -188,7 +221,7 @@ async function setup(projectRoot: string) {
  */
 async function runGlean(projectRoot: string, parserArgs: string[]) {
   const spinner = getStartedSpinner();
-  const venvRoot = path.join(projectRoot, VIRTUAL_ENVIRONMENT_DIR);
+  const venvRoot = await getVenvRoot(projectRoot);
   const pythonBin = path.join(getPythonVenvBinariesPath(venvRoot), getSystemPythonBinName());
   const isOnlineArg = process.env.OFFLINE ? "offline" : "online";
   const cmd = `${pythonBin} -c "${PYTHON_SCRIPT}" ${isOnlineArg} glean_parser ${GLEAN_PARSER_VERSION} ${parserArgs.join(" ")}`;


### PR DESCRIPTION
This changeset minorly refactors how Glean detects virtual environments, in order to support virtualenvs that aren't in the project root. 

This was a problem for projects that wanted to use Glean, but had a virtual environment created separately and located elsewhere (eg in `$HOME/.virtualenvs/` or `$HOME/.pyenv/3.X.X/some/venv/path/` -- Glean would fail to detect them and would make a `.venv` directory in the project root.

The changes mean it's now possible to run Glean with a virtual environment created by `virtualenv` or `pyenv-virtualenv` without causing a Glean-specific `.venv` dir to be created.

### Pull Request checklist ###
- [X] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [X] **Tests**: There were no existing tests for the amended functionality; See below for CLI output of manual tests
- [X] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [X] **Documentation**: Code comments updated to cover broadened virtualenv support


#### Example CLI output

**With a virtualenv that already exists, elsewhere on the filesystem (eg one made with `virtualenv` or `pyenv-virtualenv` and located in `$HOME/.virtualenvs/`, for instance)**

```
(bedrock) [steve] ~/Code/bedrock $ npm run glean-build                                                     

> bedrock@0.1.0 preglean-build
> npm run glean-lint

> bedrock@0.1.0 glean-lint
> glean glinter glean/metrics.yaml glean/pings.yaml

(Glean.CLI) Checking for a virtual environment at /Users/steve/.pyenv/versions/3.9.10/envs/bedrock
(Glean.CLI) Using virtual environment at /Users/steve/.pyenv/versions/3.9.10/envs/bedrock

[... python deps were already present in this example... ]

(Glean.CLI)

> bedrock@0.1.0 glean-build
> glean translate glean/metrics.yaml glean/pings.yaml -f javascript -o media/js/glean/generated/

(Glean.CLI) Checking for a virtual environment at /Users/steve/.pyenv/versions/3.9.10/envs/bedrock
(Glean.CLI) Using virtual environment at /Users/steve/.pyenv/versions/3.9.10/envs/bedrock
(Glean.CLI)
```

---- 

**Making a fresh venv because none exists**

```
[steve] ~/Code/bedrock $ npm run glean-build                                                               

> bedrock@0.1.0 preglean-build
> npm run glean-lint


> bedrock@0.1.0 glean-lint
> glean glinter glean/metrics.yaml glean/pings.yaml

(Glean.CLI) Checking for a virtual environment at /Users/steve/Code/bedrock/.venv
(Glean.CLI) Creating a virtual environment at /Users/steve/Code/bedrock/.venv
(Glean.CLI)
(Glean.CLI) Collecting wheel
  Using cached wheel-0.37.1-py2.py3-none-any.whl (35 kB)
Installing collected packages: wheel
Successfully installed wheel-0.37.1

(Glean.CLI) Collecting glean_parser==5.0.1
  Using cached glean_parser-5.0.1-py3-none-any.whl (88 kB)

[... other installations snipped out ...]

Successfully installed Click-8.0.4 Jinja2-3.0.3 MarkupSafe-2.1.0 PyYAML-6.0 appdirs-1.4.4 attrs-21.4.0 diskcache-5.4.0 glean-parser-5.0.1 jsonschema-4.4.0 pathspec-0.9.0 pyrsistent-0.18.1 yamllint-1.26.3

> bedrock@0.1.0 glean-build
> glean translate glean/metrics.yaml glean/pings.yaml -f javascript -o media/js/glean/generated/

(Glean.CLI) Checking for a virtual environment at /Users/steve/Code/bedrock/.venv
(Glean.CLI) Using virtual environment at /Users/steve/Code/bedrock/.venv
(Glean.CLI)
```

---- 

**Using a pre-existing venv made with `python -m venv /path/to/venv` inside the existing project root**

```
[steve] ~/Code/bedrock $ python3 -m venv ./my-custom-venv-dir                                              
[steve] ~/Code/bedrock $ source ./my-custom-venv-dir/bin/activate                                          
(my-custom-venv-dir) [steve] ~/Code/bedrock $ npm run glean-build                                          

> bedrock@0.1.0 preglean-build
> npm run glean-lint


> bedrock@0.1.0 glean-lint
> glean glinter glean/metrics.yaml glean/pings.yaml

(Glean.CLI) Checking for a virtual environment at /Users/steve/Code/bedrock/my-custom-venv-dir
(Glean.CLI) Using virtual environment at /Users/steve/Code/bedrock/my-custom-venv-dir
(Glean.CLI) Collecting glean_parser==5.0.1
  Using cached glean_parser-5.0.1-py3-none-any.whl (88 kB)

[... other installations snipped out ...]

Successfully installed Click-8.0.4 Jinja2-3.0.3 MarkupSafe-2.1.0 PyYAML-6.0 appdirs-1.4.4 attrs-21.4.0 diskcache-5.4.0 glean-parser-5.0.1 jsonschema-4.4.0 pathspec-0.9.0 pyrsistent-0.18.1 yamllint-1.26.3

> bedrock@0.1.0 glean-build
> glean translate glean/metrics.yaml glean/pings.yaml -f javascript -o media/js/glean/generated/

(Glean.CLI) Checking for a virtual environment at /Users/steve/Code/bedrock/my-custom-venv-dir
(Glean.CLI) Using virtual environment at /Users/steve/Code/bedrock/my-custom-venv-dir
(Glean.CLI)
```

