### PR TITLE
Bug 1742642 - Add command to retrieve glean parser version on the Glean CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.31.0...main)
 
-* [#1220](https://github.com/mozilla/glean.js/pull/1220): Refactor virtual environment behavior to support virtual environments that aren't in the project root. 
+* [#1220](https://github.com/mozilla/glean.js/pull/1220): Refactor virtual environment behavior to support virtual environments that aren't in the project root.
   * This means it's possible to run Glean with a virtual environment created by `virtualenv` or `pyenv-virtualenv` without causing a Glean-specific `.venv` directory to be created in a project that is using Glean.
-
 * [#1130](https://github.com/mozilla/glean.js/pull/1130): BUGFIX: Guarantee event timestamps
 cannot be negative numbers.
   * Timestamps were observed to be negative in a few occurrences, for platforms that do not provide the `performance.now` API, namely QML, and in which we fallback to the `Date.now` API.
@@ -16,6 +15,7 @@ cannot be negative numbers.
 * [#1178](https://github.com/mozilla/glean.js/pull/1178): Enable running the `glean` command with as many or as little arguments as wanted.
   * Previously the command could only be run with 3 commands, even though all glean_parser commands would have been valid commands for the `glean` CLI.
 * [#1210](https://github.com/mozilla/glean.js/pull/1210): Show comprehensive error message when missing `storage` permissions for Glean on web extensions.
+* [#1223](https://github.com/mozilla/glean.js/pull/1223): Add `--glean-parser-version` command to CLI to allow users to retrieve the glean_parser version without installing glean_parser.
 
 # v0.31.0 (2022-01-25)
 

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -57,7 +57,8 @@ When CI has finished and is green for your specific release branch, you are read
     1. [Draft a New Release](https://github.com/mozilla/glean.js/releases/new) in the GitHub UI (`Releases > Draft a New Release`).
     2. Enter `v<myversion>` as the tag. It's important this is the same as the version you specified to the `prepare_release.sh` script, with the `v` prefix added.
     3. Select the `release` branch as the target.
-     4. Under the description, paste the contents of the release notes from `CHANGELOG.md`.
+    4. Under the description, paste the contents of the release notes from `CHANGELOG.md`.
+    5. Below the `CHANGELOG.md` contents, include the glean_parser version correspondent with the release, for future reference.
 5. Wait for the CI build to complete for the tag.
     * You can check [on CircleCI for the running build](https://circleci.com/gh/mozilla/glean.js).
 6. Send a pull request to merge back the specific release branch to the development branch: <https://github.com/mozilla/glean.js/compare/main...release-v25.0.0?expand=1>

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -230,6 +230,11 @@ function stopSpinner(spinner: NodeJS.Timeout) {
  * @param args the arguments passed to this process.
  */
 async function run(args: string[]) {
+  if (args.includes("--glean-parser-version")) {
+    console.log(GLEAN_PARSER_VERSION);
+    process.exit(1);
+  }
+
   try {
     await setup();
   } catch (err) {


### PR DESCRIPTION
Yes, users could potentially use "glean --version"
but that would install glean_parser. This command allows
to retrieve the glean_parser version without installing it.

See: https://bugzilla.mozilla.org/show_bug.cgi?id=1742642#c4

Example: 

```
% ./node_modules/.bin/glean --glean-parser-version
5.0.1
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] ~**Tests**: This PR includes thorough tests or an explanation of why it does not~
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - https://bugzilla.mozilla.org/show_bug.cgi?id=1741829
