### PR TITLE
Bug 1760556 - Update internal ping validation function to account for collectionDate e prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v1.0.0...main)
 
+* [#1271](https://github.com/mozilla/glean.js/pull/1271): BUGFIX: Fix pings validation function when scanning pings database on initialize.
+  * This bug was preventing pings that contained custom headers from being succesfully validated and enqueued on initialize.
+
 # v1.0.0 (2022-03-17)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v0.32.0...v1.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 [Full changelog](https://github.com/mozilla/glean.js/compare/v1.0.0...main)
 
 * [#1271](https://github.com/mozilla/glean.js/pull/1271): BUGFIX: Fix pings validation function when scanning pings database on initialize.
-  * This bug was preventing pings that contained custom headers from being succesfully validated and enqueued on initialize.
+  * This bug was preventing pings that contained custom headers from being successfully validated and enqueued on initialize.
 
 # v1.0.0 (2022-03-17)
 

--- a/glean/src/core/metrics/events_database/recorded_event.ts
+++ b/glean/src/core/metrics/events_database/recorded_event.ts
@@ -89,7 +89,7 @@ export class RecordedEvent extends Metric<Event, Event> {
 
   validate(v: unknown): MetricValidationResult {
     // The expected object here is the Event object, which may have 3 or 4 properties.
-    if (!isObject(v) || ![3,4].includes(Object.keys(v).length)) {
+    if (!isObject(v)) {
       return {
         type: MetricValidation.Error,
         errorMessage: `Expected Glean event object, got ${typeof v}`

--- a/glean/src/core/pings/database.ts
+++ b/glean/src/core/pings/database.ts
@@ -49,7 +49,7 @@ export interface PingInternalRepresentation extends JSONObject {
  *          stating whether `v` is in the correct ping internal representation.
  */
 export function isValidPingInternalRepresentation(v: unknown): v is PingInternalRepresentation {
-  if (isObject(v) && [3, 4].includes(Object.keys(v).length)) {
+  if (isObject(v)) {
     const hasValidCollectionDate = "collectionDate" in v && isString(v.collectionDate) && isNumber(new Date(v.collectionDate).getTime());
     const hasValidPath = "path" in v && isString(v.path);
     const hasValidPayload = "payload" in v && isJSONValue(v.payload) && isObject(v.payload);


### PR DESCRIPTION
This was causing a bug in the following situation:

1. User submits a ping that contains custom headers
2. Restarts the app, the app scans the pending pings directory
3. Ping is thrown away because validation function only accepts pings with 2 to 3 properties and since v0.19.0 the internal pings have 3 to 4 properties due to the addition of the `collectionDate` property.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] ~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~
