### PR TITLE
Bug 1786272 - Qt sample project updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v1.1.0...main)
 
-* [#1449](https://github.com/mozilla/glean.js/pull/1449): BUGFIX: Add missing quotes to `prepare-build` script to fix issues with version numbers in QT sample README & circle ci config.
-* [#1449](https://github.com/mozilla/glean.js/pull/1449): Update QT sample project docs to include note about problems with different version numbers of QT commands.
+* [#1449](https://github.com/mozilla/glean.js/pull/1449): BUGFIX: Add missing quotes to `prepare-release` script to fix issues with version numbers in Qt sample README & circle ci config.
+* [#1449](https://github.com/mozilla/glean.js/pull/1449): Update Qt sample project docs to include note about problems with different version numbers of Qt commands.
 
 # v1.1.0 (2022-07-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v1.1.0...main)
 
+* [#1449](https://github.com/mozilla/glean.js/pull/1449): BUGFIX: Add missing quotes to `prepare-build` script to fix issues with version numbers in QT sample README & circle ci config.
+* [#1449](https://github.com/mozilla/glean.js/pull/1449): Update QT sample project docs to include note about problems with different version numbers of QT commands.
+
 # v1.1.0 (2022-07-18)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v1.0.0...v1.1.0)

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -142,13 +142,13 @@ run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
 FILE=samples/qt/README.md
 run $SED -i.bak -E \
-    -e "s/--option platform=qt --option version=[0-9a-z.-]+/--option platform=qt --option version=\"${GLEAN_VERSION_FOR_QML}\"/" \
+    -e "s/--option platform=qt --option version=\"[0-9a-z.-]+\"/--option platform=qt --option version=\"${GLEAN_VERSION_FOR_QML}\"/" \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 
 FILE=.circleci/config.yml
 run $SED -i.bak -E \
-    -e "s/--option platform=qt --option version=[0-9a-z.-]+/--option platform=qt --option version=\"${GLEAN_VERSION_FOR_QML}\"/" \
+    -e "s/--option platform=qt --option version=\"[0-9a-z.-]+\"/--option platform=qt --option version=\"${GLEAN_VERSION_FOR_QML}\"/" \
     "${WORKSPACE_ROOT}/${FILE}"
 run rm "${WORKSPACE_ROOT}/${FILE}.bak"
 

--- a/samples/qt/README.md
+++ b/samples/qt/README.md
@@ -33,9 +33,11 @@ pip3 install -r requirements.txt # Install glean_parser
 
 4. Generate metrics and pings files:
 
+> **Note**: The version number below should match the last [released version](https://github.com/mozilla/glean.js/releases) number (minus the trailing `.0`). If the version numbers are different you will run into issues with QML code compilation. To resolve these errors you have to adjust the versions manually in the QML files
+
 ```bash
 glean_parser translate src/App/metrics.yaml src/App/pings.yaml -f javascript -o src/App/generated \
---option platform=qt --option version="0.31"
+--option platform=qt --option version="1.1"
 ```
 
 5. Build the app:


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] ~~**Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work~~
  - ~~Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API~~
    - ~~When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository~~
  - ~~Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes~~

### Additional context
I was able to test this locally by using this portion of the `prepare-release` script and running it from the `/samples/qt` directory.

```bash
set -eo pipefail

DOIT=y
SED="sed"
WORKSPACE_ROOT="."
NEW_VERSION=1.1.0 # change this to whatever version you want to test

run() {
  [ "${VERB:-0}" != 0 ] && echo "+ $*"
  if [ "$DOIT" = y ]; then
      "$@"
  else
      true
  fi
}

# This gets the version string without the patch version.
GLEAN_VERSION_FOR_QML=$(node -p -e "'${NEW_VERSION}'.split('.').reverse().slice(1).reverse().join('.')")
FILE=README.md
run $SED -i.bak -E \
    -e "s/--option platform=qt --option version=\"[0-9a-z.-]+\"/--option platform=qt --option version=\"${GLEAN_VERSION_FOR_QML}\"/" \
    "${WORKSPACE_ROOT}/${FILE}"
run rm "${WORKSPACE_ROOT}/${FILE}.bak"

```
