### PR TITLE
Add words to dictionary to fix spellcheck CI step

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 73 
+personal_ws-1.1 en 76 
 API's
 APIs
 BUGFIX
@@ -8,6 +8,7 @@ Changelog
 CircleCI
 Ciufo
 CommonJS
+ESM
 Glean's
 Gzip
 HTTPS
@@ -35,7 +36,9 @@ booleans
 brizental
 changelog
 chutten
+ci
 compat
+config
 datetime
 deserialize
 deserializing


### PR DESCRIPTION
### Description ###
CI spellcheck step is failing because of a few words. This, along with #1457, is the reason that all the dependabot PRs show failing checks.

Example of a failing CI job - https://app.circleci.com/pipelines/github/mozilla/glean.js/4025/workflows/b56fc69a-474f-4f54-b079-1868785156cf/jobs/18266/steps

### Testing ###
From the top level of the Glean.js repo, run `bin/spellcheck.sh list `, you should see no misspelled words.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
