### PR TITLE
Update `automation` README

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -1,5 +1,23 @@
 # Glean.js automation
 
+## Setup
+
+1. Install dependencies
+
+```
+npm install
+```
+
+2. Link the `@mozilla/glean` package. There is a convenience script for that:
+
+```
+npm run link:glean
+```
+
+> **Note**: If you get an error complaining about permissions of `node_modules` at any point,
+> just re-run these two commands and the issue should resolve.
+
+
 ## Size
 
 The size project contains scripts


### PR DESCRIPTION
Added
- `npm install` step, its required
- `npm run link:glean` step, not required since it will happen
  automatically, but running it manually causes less permissions issues
- note about permissions issue that can happen and how to fix

We don't need a changelog or documentation update since this is just a small README fix.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
