### PR TITLE
Bug 1790035 - Write python script to temp file, execute, then delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v1.1.0...main)
 
+* [#1500](https://github.com/mozilla/glean.js/pull/1500): BUGFIX: Update how we invoke CLI python script to fix `npm run glean` behavior on Windows.
 * [#1457](https://github.com/mozilla/glean.js/pull/1457): Update `ts-node` to 10.8.0 to resolve ESM issues when running tests inside of `webext` sample project.
 * [#1452](https://github.com/mozilla/glean.js/pull/1452): Remove `glean.restarted` trailing events from events list.
 * [#1450](https://github.com/mozilla/glean.js/pull/1450): Update `ts-node` to 10.8.0 to resolve ESM issues when running tests.

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -208,7 +208,7 @@ async function runGlean(parserArgs: string[]) {
       ["Unable to write utility script to tmp directory.\n", error],
       LoggingLevel.Error
     );
-    return;
+    process.exit(1);
   }
 
   const cmd = `${pythonBin} ${tmpDir}/${scriptName} ${isOnlineArg} glean_parser ${GLEAN_PARSER_VERSION} ${parserArgs.join(" ")}`;

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -206,7 +206,7 @@ async function runGlean(parserArgs: string[]) {
     exec.exec(cmd, (err, stdout, stderr) => {
       resolve({err, stdout, stderr});
 
-      // after script succeeds, we remove it
+      // After script succeeds, we remove it.
       fs.unlinkSync("cli_util.py");
     });
   });

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -269,7 +269,7 @@ async function run(args: string[]) {
   await runGlean(args.slice(2));
 }
 
-// For discover-ability, try to leave this function as the last one on this file.
+// For discoverability, try to leave this function as the last one on this file.
 run(argv).catch(e => {
   log(LOG_TAG, ["There was an error running Glean.\n", e], LoggingLevel.Error);
   process.exit(1);

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -197,10 +197,11 @@ async function runGlean(parserArgs: string[]) {
   // remove the entire directory.
   let tmpDir = "";
   const appPrefix = "glean.js";
+  const scriptName = "script.py";
   const tempDirectory = os.tmpdir();
   try {
     tmpDir = fs.mkdtempSync(path.join(tempDirectory, appPrefix));
-    fs.writeFileSync(path.join(tmpDir, "script.py"), PYTHON_SCRIPT);
+    fs.writeFileSync(path.join(tmpDir, scriptName), PYTHON_SCRIPT);
   } catch (error) {
     log(
       LOG_TAG,
@@ -210,7 +211,7 @@ async function runGlean(parserArgs: string[]) {
     return;
   }
 
-  const cmd = `${pythonBin} ${tmpDir}/script.py ${isOnlineArg} glean_parser ${GLEAN_PARSER_VERSION} ${parserArgs.join(" ")}`;
+  const cmd = `${pythonBin} ${tmpDir}/${scriptName} ${isOnlineArg} glean_parser ${GLEAN_PARSER_VERSION} ${parserArgs.join(" ")}`;
 
   const {err, stdout, stderr} = await new Promise<{err: exec.ExecException | null, stdout: string, stderr: string}>(resolve => {
     exec.exec(cmd, (err, stdout, stderr) => {

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -202,8 +202,11 @@ async function runGlean(parserArgs: string[]) {
     tmpDir = fs.mkdtempSync(path.join(tempDirectory, appPrefix));
     fs.writeFileSync(path.join(tmpDir, "script.py"), PYTHON_SCRIPT);
   } catch (error) {
-    console.error("Unable to write utility script to tmp directory");
-    console.error(error);
+    log(
+      LOG_TAG,
+      ["Unable to write utility script to tmp directory.\n", error],
+      LoggingLevel.Error
+    );
     return;
   }
 


### PR DESCRIPTION
On Windows, users were unable to use the `npm run glean` command because the way we passed the python script as a long, template literal broke the CLI. By moving that script to its own file, executing it, then deleting it, we are able to successfully run the command.

I tested this on Mac and Windows and I am now able to get my `pings` file generated when running `npm run glean`.

**This is a bug fix, it does not require documentation changes.**

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
