### PR TITLE
Bug 1790949 - bump url metric limit to 8k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v1.1.0...main)
 
+* [#1513](https://github.com/mozilla/glean.js/pull/1513): Bump URL metric character limit to 8k to support longer URLs. URLs that are too long now are truncated to `URL_MAX_LENGTH` and still recorded along with an Overflow error.
 * [#1500](https://github.com/mozilla/glean.js/pull/1500): BUGFIX: Update how we invoke CLI python script to fix `npm run glean` behavior on Windows.
 * [#1457](https://github.com/mozilla/glean.js/pull/1457): Update `ts-node` to 10.8.0 to resolve ESM issues when running tests inside of `webext` sample project.
 * [#1452](https://github.com/mozilla/glean.js/pull/1452): Remove `glean.restarted` trailing events from events list.

--- a/glean/src/core/utils.ts
+++ b/glean/src/core/utils.ts
@@ -194,7 +194,7 @@ export function getMonotonicNow(): number {
  *
  * @param metric The metric to record an error to, if necessary,
  * @param value The string to truncate.
- * @param length The lenght to truncate to.
+ * @param length The length to truncate to.
  * @returns A string with at most `length` bytes.
  * @throws In case `value` is not a string.
  */

--- a/glean/tests/unit/core/metrics/url.spec.ts
+++ b/glean/tests/unit/core/metrics/url.spec.ts
@@ -124,17 +124,25 @@ describe("UrlMetric", function() {
       disabled: false,
     });
 
-    // The numbers in this test may seem arbitrary, but they are not. `glean://` is 8 characters
-    // and `abcdefgh` is 8 characters (8 * 1024 = 8192 is our MAX_URL_LENGTH). Whenever the URL
-    // is longer than our MAX_URL_LENGTH, we truncate the URL to our specified length. That
-    // means in this scenario, since we have an extra 8 characters in our `testUrl`, 8
-    // characters get truncated. For our expected value, we have the 8 + (8 * 1023) = 8192.
+    // Whenever the URL is longer than our MAX_URL_LENGTH, we truncate the URL to the
+    // MAX_URL_LENGTH.
+    //
+    // This 8-character string was chosen so we could have an even number that is
+    // a divisor of our MAX_URL_LENGTH.
+    const longPathBase = "abcdefgh";
 
-    const testUrl = `glean://${"abcdefgh".repeat(1024)}`;
+    // Using 2000 creates a string > 16000 characters, well over MAX_URL_LENGTH.
+    const testUrl = `glean://${longPathBase.repeat(2000)}`;
     metric.set(testUrl);
     metric.setUrl(new URL(testUrl));
 
-    assert.strictEqual(await metric.testGetValue("aPing"), `glean://${"abcdefgh".repeat(1023)}`);
+    // "glean://" is 8 characters
+    // "abcdefgh" (longPathBase) is 8 characters
+    // `longPathBase` is repeated 1023 times (8184)
+    // 8 + 8184 = 8192 (MAX_URL_LENGTH)
+    const expected = `glean://${longPathBase.repeat(1023)}`;
+
+    assert.strictEqual(await metric.testGetValue("aPing"), expected);
 
     // This count is 2 because we test both `set` and `setUrl`.
     assert.strictEqual(await metric.testGetNumRecordedErrors(ErrorType.InvalidOverflow), 2);


### PR DESCRIPTION
I updated the URL metric `URL_MAX_LENGTH` to be 8k rather than 2k.

I tested this in browser sample project by creating a string of length ~16000 chars and verifying in debug viewer that it was truncated to `8192` characters.

**Documentation**
`glean` PR to update metric & docs - https://github.com/mozilla/glean/pull/2199

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes