### PR TITLE
Revert "Bump selenium-webdriver from 4.4.0 to 4.5.0 in /automation"

### DIFF
--- a/automation/package-lock.json
+++ b/automation/package-lock.json
@@ -12,7 +12,7 @@
         "@octokit/request": "^6.2.1",
         "browserstack-local": "^1.5.1",
         "geckodriver": "^3.0.2",
-        "selenium-webdriver": "^4.5.0",
+        "selenium-webdriver": "^4.4.0",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1"
@@ -3224,9 +3224,9 @@
       "dev": true
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.5.0.tgz",
-      "integrity": "sha512-9mSFii+lRwcnT2KUAB1kqvx6+mMiiQHH60Y0VUtr3kxxi3oZ3CV3B8e2nuJ7T4SPb+Q6VA0swswe7rYpez07Bg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.4.0.tgz",
+      "integrity": "sha512-Du+/xfpvNi9zHAeYgXhOWN9yH0hph+cuX+hHDBr7d+SbtQVcfNJwBzLsbdHrB1Wh7MHXFuIkSG88A9TRRQUx3g==",
       "dev": true,
       "dependencies": {
         "jszip": "^3.10.0",
@@ -3234,7 +3234,7 @@
         "ws": ">=8.7.0"
       },
       "engines": {
-        "node": ">= 14.20.0"
+        "node": ">= 10.15.0"
       }
     },
     "node_modules/selfsigned": {
@@ -6800,9 +6800,9 @@
       "dev": true
     },
     "selenium-webdriver": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.5.0.tgz",
-      "integrity": "sha512-9mSFii+lRwcnT2KUAB1kqvx6+mMiiQHH60Y0VUtr3kxxi3oZ3CV3B8e2nuJ7T4SPb+Q6VA0swswe7rYpez07Bg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.4.0.tgz",
+      "integrity": "sha512-Du+/xfpvNi9zHAeYgXhOWN9yH0hph+cuX+hHDBr7d+SbtQVcfNJwBzLsbdHrB1Wh7MHXFuIkSG88A9TRRQUx3g==",
       "dev": true,
       "requires": {
         "jszip": "^3.10.0",

--- a/automation/package.json
+++ b/automation/package.json
@@ -22,7 +22,7 @@
     "@octokit/request": "^6.2.1",
     "browserstack-local": "^1.5.1",
     "geckodriver": "^3.0.2",
-    "selenium-webdriver": "^4.5.0",
+    "selenium-webdriver": "^4.4.0",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1"


### PR DESCRIPTION
Reverts mozilla/glean.js#1527

`browser-compat-smoke-tests` are failing after merging this, we can revert to see if this fixes it

https://email.circleci.com/c/eJxFT0FuxCAMfA25EQVICDnksFW1PfTU9gGVF0zCFkJESLft60u0lSpZlmc8Y3lwZFK2ivNBqMqMSg6qcqPAZrBPzf769vyALFlM7vRS_ytV35O2WeOWwdfaJe2RepxAf9MlZmcdJvrJqNadla1Vmpo8fMlqHg0iDKoXHZMdXJgxTCkjrDA9M6C0qfw457xuRJwIP5e6H9eu1jEUOM2lhfjjvIcDeoSlvm5l5I3ggojznsO7hrCCmxYiHm8xfVgfb9SC82gIl4cgoHF7KGsMhf4jt7gnjYW8R9CQXVyqNKa4wXxJ-xJL5ukwHM_8At9fZY8