### PR TITLE
Bug 1793777 - Update glean_parser to  v6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v1.2.0...main)
 
+* [#1544](https://github.com/mozilla/glean.js/pull/1544): Upgrade `glean_parser` version to `6.2.1`.
 * [#1516](https://github.com/mozilla/glean.js/pull/1516): Implement the Custom Distribution metric type.
 * [#1514](https://github.com/mozilla/glean.js/pull/1514): Implement the Memory Distribution metric type.
 * [#1475](https://github.com/mozilla/glean.js/pull/1475): Implement the Timing Distribution metric type.

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -27,7 +27,7 @@ const LOG_TAG = "CLI";
 const VIRTUAL_ENVIRONMENT_DIR = process.env.VIRTUAL_ENV || path.join(process.cwd(), ".venv");
 
 // The version of glean_parser to install from PyPI.
-const GLEAN_PARSER_VERSION = "5.1.0";
+const GLEAN_PARSER_VERSION = "6.2.1";
 
 // This script runs a given Python module as a "main" module, like
 // `python -m module`. However, it first checks that the installed

--- a/glean/tests/integration/schema/schema.spec.ts
+++ b/glean/tests/integration/schema/schema.spec.ts
@@ -83,6 +83,10 @@ describe("schema", function() {
     metrics.timespan.setRawNanos(10 * 10**6);
     metrics.uuid.generateAndSet();
     metrics.url.set("glean://test");
+
+    metrics.rate.addToNumerator(1);
+    metrics.rate.addToDenominator(2);
+
     const timerId = metrics.timingDistribution.start();
     metrics.timingDistribution.stopAndAccumulate(timerId);
     metrics.memoryDistribution.accumulate(100000);

--- a/samples/qt/requirements.txt
+++ b/samples/qt/requirements.txt
@@ -1,1 +1,1 @@
-glean_parser==5.1.0
+glean_parser==6.2.1


### PR DESCRIPTION
Updates the version of `glean_parser` that Glean.js uses. This is currently the latest version of `glean_parser` that has support added for the `rate` metric, specifically for Glean.js.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
