### PR TITLE
Revert "Bump selenium-webdriver from 4.4.0 to 4.6.0 in /automation"

### DIFF
--- a/automation/package-lock.json
+++ b/automation/package-lock.json
@@ -12,7 +12,7 @@
         "@octokit/request": "^6.2.2",
         "browserstack-local": "^1.5.1",
         "geckodriver": "^3.0.2",
-        "selenium-webdriver": "^4.6.0",
+        "selenium-webdriver": "^4.4.0",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1"
@@ -3239,9 +3239,9 @@
       "dev": true
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.6.0.tgz",
-      "integrity": "sha512-HIH/+J+V7l/lbSRSOwyLcpjezg9CV4DLo1pBhP9aphuMlf/PJXEDwC/A/Ht2bFc1AqQppFBGvClYcuMzyO6tRw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.4.0.tgz",
+      "integrity": "sha512-Du+/xfpvNi9zHAeYgXhOWN9yH0hph+cuX+hHDBr7d+SbtQVcfNJwBzLsbdHrB1Wh7MHXFuIkSG88A9TRRQUx3g==",
       "dev": true,
       "dependencies": {
         "jszip": "^3.10.0",
@@ -3249,7 +3249,7 @@
         "ws": ">=8.7.0"
       },
       "engines": {
-        "node": ">= 14.20.0"
+        "node": ">= 10.15.0"
       }
     },
     "node_modules/selfsigned": {
@@ -6832,9 +6832,9 @@
       "dev": true
     },
     "selenium-webdriver": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.6.0.tgz",
-      "integrity": "sha512-HIH/+J+V7l/lbSRSOwyLcpjezg9CV4DLo1pBhP9aphuMlf/PJXEDwC/A/Ht2bFc1AqQppFBGvClYcuMzyO6tRw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.4.0.tgz",
+      "integrity": "sha512-Du+/xfpvNi9zHAeYgXhOWN9yH0hph+cuX+hHDBr7d+SbtQVcfNJwBzLsbdHrB1Wh7MHXFuIkSG88A9TRRQUx3g==",
       "dev": true,
       "requires": {
         "jszip": "^3.10.0",

--- a/automation/package.json
+++ b/automation/package.json
@@ -22,7 +22,7 @@
     "@octokit/request": "^6.2.2",
     "browserstack-local": "^1.5.1",
     "geckodriver": "^3.0.2",
-    "selenium-webdriver": "^4.6.0",
+    "selenium-webdriver": "^4.4.0",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1"


### PR DESCRIPTION
Reverts mozilla/glean.js#1561

Looks like CircleCI builds started having issues after merging. I will look at what we need to do to upgrade next time this dependency tries to update.