### PR TITLE
Bug 1845362 - SSR support for Glean.js

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -78,3 +78,4 @@ webpack
 async
 queueing
 LocalStorage
+ssr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v1.4.0...main)
 
+* [#1733](https://github.com/mozilla/glean.js/pull/1733): Add SSR support for Glean.js
 * [#1728](https://github.com/mozilla/glean.js/pull/1728): Migrate client_id and first_run_date.
 * [#1695](https://github.com/mozilla/glean.js/pull/1695): Update Glean.js web to use LocalStorage.
 

--- a/glean/src/core/internal_metrics/sync.ts
+++ b/glean/src/core/internal_metrics/sync.ts
@@ -11,7 +11,7 @@ import { InternalDatetimeMetricType as DatetimeMetricType } from "../metrics/typ
 import { InternalStringMetricType as StringMetricType } from "../metrics/types/string.js";
 import { createMetric } from "../metrics/utils.js";
 import TimeUnit from "../metrics/time_unit.js";
-import { generateUUIDv4 } from "../utils.js";
+import { generateUUIDv4, isWindowObjectUnavailable } from "../utils.js";
 import { Lifetime } from "../metrics/lifetime.js";
 import log, { LoggingLevel } from "../log.js";
 import { Context } from "../context.js";
@@ -126,6 +126,13 @@ export class CoreMetricsSync {
   }
 
   initialize(): void {
+    // The "sync" version of Glean.js is only meant to be used in the browser.
+    // If we cannot access the window object, then we are unable to store
+    // any of the metric data in `localStorage`.
+    if (isWindowObjectUnavailable()) {
+      return;
+    }
+
     // If the client had used previous versions of Glean.js before we moved
     // to LocalStorage as the data store, then we need to move important
     // user data from IndexedDB to LocalStorage.

--- a/glean/src/core/utils.ts
+++ b/glean/src/core/utils.ts
@@ -311,3 +311,15 @@ export function getCurrentTimeInNanoSeconds(): number {
   }
   return now;
 }
+
+/**
+ * Checks if the current environment has access to the `window` object. This
+ * check is used to conditional-ize browser code for SSR projects. If the
+ * platform does not have access to the `window` APIs, then we are unable to
+ * store data in the browser.
+ *
+ * @returns Whether or not the current platform has access to the `window` object.
+ */
+export function isWindowObjectUnavailable(): boolean {
+  return typeof window === "undefined";
+}

--- a/glean/src/platform/browser/web/platform_info.ts
+++ b/glean/src/platform/browser/web/platform_info.ts
@@ -7,7 +7,12 @@ import { KnownOperatingSystems } from "../../../core/platform_info/shared.js";
 
 const BrowserPlatformInfo: PlatformInfoSync = {
   os(): KnownOperatingSystems {
-    const ua = navigator.userAgent;
+    let ua;
+    if (!!navigator && !!navigator.userAgent) {
+      ua = navigator.userAgent;
+    } else {
+      ua = KnownOperatingSystems.Unknown;
+    }
 
     if (ua.includes("Windows")) {
       return KnownOperatingSystems.Windows;

--- a/glean/src/platform/browser/web/storage.ts
+++ b/glean/src/platform/browser/web/storage.ts
@@ -12,9 +12,11 @@ import {
   getValueFromNestedObject,
   updateNestedObject
 } from "../../../core/storage/utils.js";
+import { isWindowObjectUnavailable } from "../../../core/utils.js";
 
 const LOG_TAG = "platform.web.Storage";
 
+// If `window.localStorage` is unavailable, we return undefined for all.
 class WebStore implements SynchronousStore {
   private logTag: string;
 
@@ -23,6 +25,10 @@ class WebStore implements SynchronousStore {
   }
 
   get(index: StorageIndex = []): JSONValue | undefined {
+    if (isWindowObjectUnavailable()) {
+      return;
+    }
+
     let result;
 
     try {
@@ -42,6 +48,10 @@ class WebStore implements SynchronousStore {
   }
 
   update(index: StorageIndex, transformFn: (v?: JSONValue) => JSONValue): void {
+    if (isWindowObjectUnavailable()) {
+      return;
+    }
+
     try {
       const json = localStorage.getItem(this.rootKey) || "{}";
       const obj = JSON.parse(json) as JSONObject;
@@ -54,6 +64,10 @@ class WebStore implements SynchronousStore {
   }
 
   delete(index: StorageIndex): void {
+    if (isWindowObjectUnavailable()) {
+      return;
+    }
+
     try {
       const json = localStorage.getItem(this.rootKey) || "{}";
       const obj = JSON.parse(json) as JSONObject;


### PR DESCRIPTION
Adds additional checks to verify `window` and `localStorage` object exist before making any calls. This handles errors that are ONLY generated when compiling an SSR project. If you run an SSR project locally, the errors don't show because the browser has access to the `window` object.

This was tested by
- Creating a new nextjs project
- Integrating Glean.js
- Locally running `next dev`
- Building locally via `next build`
- Running the out directory on a simple web server via Python from my mac `python3 -m http.server`


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
