### PR TITLE
Update to glean-parser 8.1 and allow any patch version

### DIFF
--- a/docs/guides/update_glean_parser.md
+++ b/docs/guides/update_glean_parser.md
@@ -3,8 +3,10 @@
 To update the version of glean_parser used by the Glean.js, run the `bin/update-glean-parser-version.sh` script, providing the version as a command line parameter:
 
 ```bash
-bin/update-glean-parser-version.sh 1.28.3
+bin/update-glean-parser-version.sh 1.28
 ```
+
+It's enough to specify `MINOR.MAJOR`.
 
 This will update the version in all the required places and create a commit with the changes. After that, you just need to create a pull request with the changes.
 


### PR DESCRIPTION
I copied the script from https://github.com/mozilla/glean/blob/3c1c083238876dd6cc4e7577c66b73d309ab83d8/gradle-plugin/src/main/groovy/mozilla/telemetry/glean-gradle-plugin/GleanGradlePlugin.groovy#L61

This now uses `~=` for the glean-parser install, so we don't need to update glean.js for every glean_parser patch update.