### PR TITLE
Bug 1848200 - add migration flag to init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v2.0.0...main)
 
+* [#1751](https://github.com/mozilla/glean.js/pull/1751): Add a migration flag to initialize. If not explicitly set in the `config` object the migration from IndexedDB to LocalStorage will not occur. **The only projects that should ever set this flag are those that have used Glean.js in production with a version <v2.0.0 and have upgraded.**
+
 # v2.0.0 (2023-08-03)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v1.4.0...v2.0.0)

--- a/glean/src/core/config.ts
+++ b/glean/src/core/config.ts
@@ -56,6 +56,9 @@ export interface ConfigurationInterface {
   readonly osVersion?: string,
   // The build date, provided by glean_parser
   readonly buildDate?: Date,
+  // Migrate from legacy storage (IndexedDB) to the new one (LocalStorage).
+  // This should only be true for older projects that have existing data in IndexedDB.
+  readonly migrateFromLegacyStorage?: boolean,
 }
 
 // Important: the `Configuration` should only be used internally by the Glean singleton.
@@ -68,6 +71,7 @@ export class Configuration implements ConfigurationInterface {
   readonly osVersion?: string;
   readonly buildDate?: Date;
   readonly maxEvents: number;
+  readonly migrateFromLegacyStorage?: boolean;
 
   // Debug configuration.
   debug: DebugOptions;
@@ -82,6 +86,7 @@ export class Configuration implements ConfigurationInterface {
     this.osVersion = config?.osVersion;
     this.buildDate = config?.buildDate;
     this.maxEvents = config?.maxEvents || DEFAULT_MAX_EVENTS;
+    this.migrateFromLegacyStorage = config?.migrateFromLegacyStorage;
 
     this.debug = {};
 

--- a/glean/src/core/internal_metrics/sync.ts
+++ b/glean/src/core/internal_metrics/sync.ts
@@ -125,7 +125,7 @@ export class CoreMetricsSync {
     );
   }
 
-  initialize(): void {
+  initialize(migrateFromLegacyStorage?: boolean): void {
     // The "sync" version of Glean.js is only meant to be used in the browser.
     // If we cannot access the window object, then we are unable to store
     // any of the metric data in `localStorage`.
@@ -140,11 +140,9 @@ export class CoreMetricsSync {
     // Currently we are interested in migrating two things
     // 1. The client_id - consistent clientId across all sessions.
     // 2. The first_run_date - the date when the client was first run.
-
-    // The migration is done only once per client. The flag is set in
-    // LocalStorage to indicate that the migration has been completed.
-    const migrationFlag = localStorage.getItem("GLEAN_MIGRATION_FLAG");
-    if (migrationFlag !== "1") {
+    if (!!migrateFromLegacyStorage && localStorage.getItem("GLEAN_MIGRATION_FLAG") !== "1") {
+      // The migration is done only once per client. The flag is set in
+      // LocalStorage to indicate that the migration has been completed.
       this.migrateCoreMetricsFromIdb();
       localStorage.setItem("GLEAN_MIGRATION_FLAG", "1");
     } else {


### PR DESCRIPTION
Conditionally migrate IDB data only if it already exists. If the project has never used an older version of Glean, then we want to avoid migration because of a potential race condition when submitting pings on first page load.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
