### PR TITLE
Bug 1849862 - sync URL set function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v2.0.1...main)
 
+* [#1755](https://github.com/mozilla/glean.js/pull/1755): Add sync check to `set` function for the URL metric.
+
 # v2.0.1 (2023-08-11)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v2.0.0...v2.0.1)

--- a/glean/src/core/metrics/types/url.ts
+++ b/glean/src/core/metrics/types/url.ts
@@ -90,6 +90,14 @@ class InternalUrlMetricType extends MetricType {
   }
 
   /// SHARED ///
+  set(url: string): void {
+    if (Context.isPlatformSync()) {
+      this.setSync(url);
+    } else {
+      this.setAsync(url);
+    }
+  }
+
   setUrl(url: URL): void {
     if (Context.isPlatformSync()) {
       this.setSync(url.toString());
@@ -100,10 +108,6 @@ class InternalUrlMetricType extends MetricType {
 
   /// ASYNC ///
   setAsync(url: string) {
-    this.set(url);
-  }
-
-  set(url: string): void {
     Context.dispatcher.launch(async () => {
       if (!this.shouldRecord(Context.uploadEnabled)) {
         return;


### PR DESCRIPTION
Fixes #1753 

During the initial migration the URL `set` function didn't get a synchronous implementation.

[Recorded URL in the debug ping viewer](https://debug-ping-preview.firebaseapp.com/pings/glean-from-website/7a1ca7a9-eba8-4616-b8b6-3c27804e6834#L10)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
