### PR TITLE
Bug 1852217 - allow setting python env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v2.0.1...main)
 
+* [#1768](https://github.com/mozilla/glean.js/pull/1768): Add support for `GLEAN_PYTHON` and `GLEAN_PIP` environment variables.
 * [#1755](https://github.com/mozilla/glean.js/pull/1755): Add sync check to `set` function for the URL metric.
 * [#1766](https://github.com/mozilla/glean.js/pull/1766): Update default `maxEvents` count to 1. This means an events ping will be sent after each recorded event unless the `maxEvents` count is explicitly set to a larger number.
 

--- a/bin/python-env-vars-test.sh
+++ b/bin/python-env-vars-test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -eo pipefail
+
+run() {
+    [ "${VERB:-0}" != 0 ] && echo "+ $*"
+    "$@"
+}
+
+# All sed commands below work with either
+# GNU sed (standard on Linux distrubtions) or BSD sed (standard on macOS)
+SED="sed"
+
+WORKSPACE_ROOT="$( cd "$(dirname "$0")/.." ; pwd -P )"
+
+# Set custom values for Python environment variables.
+if [ -x "$(command -v python)" ]; then
+  export GLEAN_PYTHON=python
+fi
+
+if [ -x "$(command -v pip)" ]; then
+  export GLEAN_PIP=pip
+fi
+
+# Delete the .venv so a new one gets created for testing.
+rm -rf .venv
+
+# Generate files using the Glean.js CLI tool (which just runs glean_parser)
+npm run cli -- \
+  translate tests/integration/schema/metrics.yaml tests/integration/schema/pings.yaml \
+  -f typescript \
+  -o tests/integration/schema/generated
+
+# Update metrics import path
+FILE=glean/tests/integration/schema/generated/forTesting.ts
+run $SED -i.bak -E \
+  -e 's#@mozilla/glean/private/metrics#../../../../src/core/metrics/types#g' \
+  "${WORKSPACE_ROOT}/${FILE}"
+run rm "${WORKSPACE_ROOT}/${FILE}.bak"
+
+# Update ping import path
+FILE=glean/tests/integration/schema/generated/pings.ts
+run $SED -i.bak -E \
+ -e 's#@mozilla/glean/private/ping#../../../../src/core/pings/ping_type.js#g' \
+ "${WORKSPACE_ROOT}/${FILE}"
+run rm "${WORKSPACE_ROOT}/${FILE}.bak"
+
+unset GLEAN_PYTHON
+unset GLEAN_PIP
+
+# Delete the custom .venv so next run uses the default Python binaries.
+rm -rf .venv

--- a/glean/package.json
+++ b/glean/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "test": "run-s test:unit test:integration",
     "test:integration": "npm run test:base -- \"tests/integration/**/*.spec.ts\" --recursive",
-    "pretest:integration": "../bin/parser-for-schema-testing.sh",
+    "pretest:integration": "../bin/parser-for-schema-testing.sh && ../bin/python-env-vars-test.sh",
     "test:unit": "run-s test:unit:core test:unit:platform test:unit:plugins",
     "test:unit:core": "npm run test:base -- \"tests/unit/core/**/*.spec.ts\" --recursive",
     "test:unit:plugins": "npm run test:base -- \"tests/unit/plugins/**/*.spec.ts\" --recursive",


### PR DESCRIPTION
Companion docs PR - https://github.com/mozilla/glean/pull/2620

changelog
- `GLEAN_PYTHON` env variable
- `GLEAN_PIP` env variable

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
