### PR TITLE
Bug 1855392 - support window.Glean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v2.0.2...main)
 
+* [#1770](https://github.com/mozilla/glean.js/pull/1770): Allow debugging in browser console via `window.Glean`.
+
 # v2.0.2 (2023-09-14)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v2.0.1...v2.0.2)

--- a/glean/src/core/glean/sync.ts
+++ b/glean/src/core/glean/sync.ts
@@ -434,4 +434,21 @@ namespace Glean {
   }
 }
 
+// Declare global variables for debugging in the browser.
+declare global {
+  interface Window {
+    Glean: {
+      setLogPings: (flag: boolean) => void;
+      setDebugViewTag: (value: string) => void;
+      setSourceTags: (value: string[]) => void;
+    }
+  }
+}
+
+window.Glean = {
+  setLogPings: Glean.setLogPings,
+  setDebugViewTag: Glean.setDebugViewTag,
+  setSourceTags: Glean.setSourceTags
+};
+
 export default Glean;


### PR DESCRIPTION
Allow setting debugging options from the browser console.

changelog
- support `window.Glean.setLogPings`
- support `window.Glean.setDebugViewTag`
- support `window.Glean.setSourceTags`

### Demo
In the video the variable is `window.glean` ignore this, it is capitalized now. I just didn't rerecord the demo.

https://github.com/mozilla/glean.js/assets/24759139/d71f7dfb-62f7-45e2-a89b-534f6ac65894



### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
