### PR TITLE
Bugs 1855792, 1855795 - window.Glean updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v2.0.3...main)
 
+* [#1772](https://github.com/mozilla/glean.js/pull/1772): Fix bug where `window.Glean` functions were getting set on non-browser properties.
+
 # v2.0.3 (2023-09-27)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v2.0.2...v2.0.3)

--- a/automation/compat/tests/utils.js
+++ b/automation/compat/tests/utils.js
@@ -74,6 +74,30 @@ export async function runWebTest(driver) {
     await driver.get(`http://localhost:${PORT}/`);
     // Give it time to send the ping request.
     const successTextContainer = await driver.findElement(By.id("msg"));
+
+    const areGleanWindowVarsSet = await driver.executeScript(() => {
+      // Verify that all Glean `window` vars are properly set.
+      if (
+        window &&
+        window.Glean &&
+        window.Glean.setDebugViewTag &&
+        window.Glean.setLogPings &&
+        window.Glean.setSourceTags
+      ) {
+        return true;
+      }
+
+      // One of our expected values wasn't set, so the test should fail.
+      return false;
+    }).catch(() => {
+      // In case `window` isn't available or something unexpected happens.
+      return false;
+    });
+    
+    if (!areGleanWindowVarsSet) {
+      throw new Error("`window.Glean` variables are not set.");
+    }
+
     await driver.wait(
       until.elementTextIs(
         successTextContainer,

--- a/glean/src/core/glean/sync.ts
+++ b/glean/src/core/glean/sync.ts
@@ -445,10 +445,13 @@ declare global {
   }
 }
 
-window.Glean = {
-  setLogPings: Glean.setLogPings,
-  setDebugViewTag: Glean.setDebugViewTag,
-  setSourceTags: Glean.setSourceTags
-};
+// Only set `Glean` values whenever running inside of a browser.
+if (typeof window !== "undefined") {
+  window.Glean = {
+    setLogPings: Glean.setLogPings,
+    setDebugViewTag: Glean.setDebugViewTag,
+    setSourceTags: Glean.setSourceTags
+  };
+}
 
 export default Glean;


### PR DESCRIPTION
I tested this by pushing up a branch with the `dist` folder checked in and running this version directly inside of the `mdn` project. The `window is not defined` error goes away when wrapped in the `typeof window !== undefined` check.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
