### PR TITLE
Bug 1856730 - store debug values for session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 [Full changelog](https://github.com/mozilla/glean.js/compare/v2.0.3...main)
 
 * [#1772](https://github.com/mozilla/glean.js/pull/1772): Fix bug where `window.Glean` functions were getting set on non-browser properties.
+* [#1784](https://github.com/mozilla/glean.js/pull/1784): Store `window.Glean` debugging values in `sessionStorage`. This will set debug options on page init while the current session is still active.
 
 # v2.0.3 (2023-09-27)
 

--- a/glean/src/core/utils.ts
+++ b/glean/src/core/utils.ts
@@ -123,6 +123,23 @@ export function isInteger(v: unknown): v is number {
 }
 
 /**
+ * Convert a boolean stringified value to a proper boolean.
+ *
+ * @param v The value to convert.
+ * @returns A boolean representing the string or undefined if the string was not a boolean value.
+ */
+export function extractBooleanFromString(v: string): boolean | undefined {
+  if (v.toLowerCase() === "true") {
+    return true;
+  } else if (v.toLowerCase() === "false") {
+    return false;
+  }
+
+  // The string is not a boolean value, so we do not return a boolean.
+  return undefined;
+}
+
+/**
  * Generates a pipeline-friendly string
  * that replaces non alphanumeric characters with dashes.
  *


### PR DESCRIPTION
Store the debug values set via `window.Glean` in `sessionStorage` which persists until the user closes the current tab.

I am not exactly sure what tests for this might look like. The only way to really write tests for this would be inside of BrowserStack, but to actually verify it works you need to see either console output or an entry in the debug ping viewer.

Doc updates - https://github.com/mozilla/glean/pull/2638



https://github.com/mozilla/glean.js/assets/24759139/b3ad5fbd-bb8b-40ec-a94d-b6c0411716ae




### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
