### PR TITLE
Bumped glean_parser version to 10.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v2.0.5...main)
 
+* [#1792](https://github.com/mozilla/glean.js/pull/1792): Update `glean_parser` to `v10.0.1`.
+
 # v2.0.5 (2023-10-16)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v2.0.4...v2.0.5)

--- a/glean/src/cli.ts
+++ b/glean/src/cli.ts
@@ -27,7 +27,7 @@ const LOG_TAG = "CLI";
 const VIRTUAL_ENVIRONMENT_DIR = process.env.VIRTUAL_ENV || path.join(process.cwd(), ".venv");
 
 // The version of glean_parser to install from PyPI.
-const GLEAN_PARSER_VERSION = "8.1";
+const GLEAN_PARSER_VERSION = "10.0.1";
 
 // This script runs a given Python module as a "main" module, like
 // `python -m module`. However, it first checks that the installed

--- a/glean/src/core/pings/common_ping_data.ts
+++ b/glean/src/core/pings/common_ping_data.ts
@@ -14,4 +14,7 @@ export default interface CommonPingData {
   readonly sendIfEmpty: boolean;
   // Optional. The valid reason codes for this ping.
   readonly reasonCodes?: string[];
+
+  // Currently NOT IMPLEMENTED.
+  readonly preciseTimestamps?: boolean;
 }

--- a/glean/src/core/pings/ping_type.ts
+++ b/glean/src/core/pings/ping_type.ts
@@ -31,6 +31,9 @@ export class InternalPingType implements CommonPingData {
   readonly sendIfEmpty: boolean;
   readonly reasonCodes: string[];
 
+  // Currently NOT IMPLEMENTED.
+  readonly preciseTimestamps?: boolean;
+
   // The functions and promises required for the test API to
   // execute and synchronize with the submission API.
   private resolveTestPromiseFunction?: PromiseCallback;
@@ -42,6 +45,9 @@ export class InternalPingType implements CommonPingData {
     this.includeClientId = meta.includeClientId;
     this.sendIfEmpty = meta.sendIfEmpty;
     this.reasonCodes = meta.reasonCodes ?? [];
+
+    // Currently NOT IMPLEMENTED.
+    this.preciseTimestamps = meta.preciseTimestamps;
   }
 
   /// SHARED ///

--- a/samples/qt/requirements.txt
+++ b/samples/qt/requirements.txt
@@ -1,1 +1,1 @@
-glean_parser==8.1.1
+glean_parser==10.0.1


### PR DESCRIPTION
Besides bumping the `glean_parser` version, we made preciseTimestamps ping property optional to skip implementing this feature for now. This property can be made optional until this feature is actually implemented. This saves us having to change every place where we manually create a ping object, specifically in tests.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
