### PR TITLE
Update CI node config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+            curl -SLO https://deb.nodesource.com/nsolid_setup_deb.sh
+            chmod 500 nsolid_setup_deb.sh
+            ./nsolid_setup_deb.sh 18
             sudo apt-get install -y nodejs
 parameters:
   python-version:


### PR DESCRIPTION
When the monthly dependabot PRs were opened this morning, they all failed because they were unable to download node. I found an issue in a GitHub repo that looks to have a fix for this issue.

https://github.com/nodesource/distributions/issues/1706#issuecomment-1789106732

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
