### PR TITLE
Bug 1863916 - Add support for cutting 'prerelease' releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,9 +213,30 @@ jobs:
       - run:
           name: NPM Authentication
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > glean/.npmrc
-      - run:
-          name: Publish to npm
-          command: export PATH=.:$PATH && (cd glean && npm publish --access public)
+      # This conditional matches the tag that contains 'pre', used
+      # to mark prerelease builds. Since CircleCI conditionals do
+      # not directly support 'else's, we need another conditional.
+      - when:
+          condition:
+            matches:
+              pattern: "^v.*-pre.*$"
+              value: << pipeline.git.tag >>
+          steps:
+            - run:
+                name: Publish to npm (prerelease)
+                command: export PATH=.:$PATH && (cd glean && npm publish --access public --tag prerelease)
+      # This conditional matches 'release': we won't tag the npm
+      # release in this case, because no 'pre' is found in the tag.
+      - when:
+          condition:
+            not:
+              matches:
+                pattern: "^v.*-pre.*$"
+                value: << pipeline.git.tag >>
+          steps:
+            - run:
+                name: Publish to npm
+                command: export PATH=.:$PATH && (cd glean && npm publish --access public)
       - run:
           name: Get ghr release tool
           command: |

--- a/.dictionary
+++ b/.dictionary
@@ -61,6 +61,7 @@ md
 mdroettboom
 mozilla
 npm
+prerelease
 runtime
 schemas
 setRawNanos

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -6,7 +6,8 @@ That package will contain sub packages with Glean.js builds for each environment
 
 The development & release process roughly follows the [Git Flow model](https://nvie.com/posts/a-successful-git-branching-model/).
 
-> **Note**: The rest of this section assumes that `upstream` points to the `https://github.com/mozilla/glean.js` repository, while `origin` points to the developer fork. For some developer workflows, `upstream` can be the same as `origin`.
+> [!NOTE]
+> The rest of this section assumes that `upstream` points to the `https://github.com/mozilla/glean.js` repository, while `origin` points to the developer fork. For some developer workflows, `upstream` can be the same as `origin`.
 
 ## Standard release
 
@@ -14,7 +15,15 @@ Releases can only be done by one of the Glean maintainers.
 
 - Main development branch: `main`
 - Main release branch: `release`
-- Specific release branch: `release-vX.Y.Z`
+- Specific release branch: `release-vX.Y.Z` (or `release-vX.Y.Z-pre.N` for prerelease)
+
+> [!IMPORTANT]
+> Adding a suffix to the version **and** the branch/tag names such as
+> `-pre.0` triggers publishing to the NPM `prerelease` channel. This enables early
+> consumers to test the latest capabilities, without widely rolling them out to
+> all the consumers.
+> If cutting a prerelease, whenever `release-vX.Y.Z` is specified in the rest of the
+> document assume it refers to `release-vX.Y.Z-pre.N`.
 
 ### Create a release branch
 


### PR DESCRIPTION
The same mechanism was tested on my toy repo [here](https://github.com/Dexterp37/test_ci/blob/d0654884411fd41e900a6925df9aadcb0ffeba06/.circleci/config.yml#L45-L65). This is what I did for testing it there:

1. I merged my configuration changes
2. I cut 3 github releases, with the following tags: `real-random-v`, `v0.0.1`, `v0.0.2-pre.0`.
3. I checked that the triggered publish jobs acted as follows:
  3a. For `real-random-v`, no workflow is triggered at all.
  3b. For `v0.0.1`, the workflow for "release" is triggered.
  3c. For `v0.0.2-pre.0` the workflow for "prerelease" is triggered.

These are the outputs I got:

![immagine](https://github.com/mozilla/glean.js/assets/883721/7fba9b56-a8ed-4d8f-9b6b-7619fe0c5a10)
![immagine](https://github.com/mozilla/glean.js/assets/883721/38d4853f-ac89-4efa-ba10-3b40b36697a6)

Which seems to imply the conditions were working fine.

TODO:

- [x] Add documentation

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
