### PR TITLE
Make tests run a bit faster

### DIFF
--- a/glean/src/platform/browser/uploader.ts
+++ b/glean/src/platform/browser/uploader.ts
@@ -9,7 +9,7 @@ import { DEFAULT_UPLOAD_TIMEOUT_MS, UploadResultStatus, UploadResult } from "../
 const LOG_TAG = "platform.browser.Uploader";
 
 class BrowserUploader extends Uploader {
-  defaultTimeoutMs: number = DEFAULT_UPLOAD_TIMEOUT_MS;
+  timeoutMs: number = DEFAULT_UPLOAD_TIMEOUT_MS;
 
   async post(
     url: string,
@@ -18,7 +18,7 @@ class BrowserUploader extends Uploader {
     keepalive = true
   ): Promise<UploadResult> {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.defaultTimeoutMs);
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
 
     let response;
     try {

--- a/glean/src/platform/browser/uploader.ts
+++ b/glean/src/platform/browser/uploader.ts
@@ -9,6 +9,8 @@ import { DEFAULT_UPLOAD_TIMEOUT_MS, UploadResultStatus, UploadResult } from "../
 const LOG_TAG = "platform.browser.Uploader";
 
 class BrowserUploader extends Uploader {
+  defaultTimeoutMs: number = DEFAULT_UPLOAD_TIMEOUT_MS;
+
   async post(
     url: string,
     body: string | Uint8Array,
@@ -16,7 +18,7 @@ class BrowserUploader extends Uploader {
     keepalive = true
   ): Promise<UploadResult> {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), DEFAULT_UPLOAD_TIMEOUT_MS);
+    const timeout = setTimeout(() => controller.abort(), this.defaultTimeoutMs);
 
     let response;
     try {

--- a/glean/tests/unit/platform/browser/uploader.spec.ts
+++ b/glean/tests/unit/platform/browser/uploader.spec.ts
@@ -9,7 +9,7 @@ import nock from "nock";
 import fetch from "node-fetch";
 
 import BrowserUploader from "../../../../src/platform/browser/uploader";
-import { DEFAULT_UPLOAD_TIMEOUT_MS, UploadResult, UploadResultStatus } from "../../../../src/core/upload/uploader";
+import { UploadResult, UploadResultStatus } from "../../../../src/core/upload/uploader";
 
 const sandbox = sinon.createSandbox();
 
@@ -38,7 +38,11 @@ describe("Uploader/Browser", function () {
   });
 
   it("returns the correct status for timeout requests", async function () {
-    nock(MOCK_ENDPOINT).post(/./i).delay(DEFAULT_UPLOAD_TIMEOUT_MS + 1).reply(500);
+    const TEST_TIMEOUT_MS = 100;
+    const ORIGINAL_TIMEOUT_MS = BrowserUploader.defaultTimeoutMs;
+    BrowserUploader.defaultTimeoutMs = TEST_TIMEOUT_MS;
+
+    nock(MOCK_ENDPOINT).post(/./i).delay(TEST_TIMEOUT_MS + 1).reply(500);
 
     const response = BrowserUploader.post(MOCK_ENDPOINT, "");
     const expectedResponse = new UploadResult(UploadResultStatus.RecoverableFailure);
@@ -46,6 +50,7 @@ describe("Uploader/Browser", function () {
       await response,
       expectedResponse
     );
+    BrowserUploader.defaultTimeoutMs = ORIGINAL_TIMEOUT_MS;
   });
 
   it("returns the correct status for request errors", async function () {

--- a/glean/tests/unit/platform/browser/uploader.spec.ts
+++ b/glean/tests/unit/platform/browser/uploader.spec.ts
@@ -39,8 +39,8 @@ describe("Uploader/Browser", function () {
 
   it("returns the correct status for timeout requests", async function () {
     const TEST_TIMEOUT_MS = 100;
-    const ORIGINAL_TIMEOUT_MS = BrowserUploader.defaultTimeoutMs;
-    BrowserUploader.defaultTimeoutMs = TEST_TIMEOUT_MS;
+    const ORIGINAL_TIMEOUT_MS = BrowserUploader.timeoutMs;
+    BrowserUploader.timeoutMs = TEST_TIMEOUT_MS;
 
     nock(MOCK_ENDPOINT).post(/./i).delay(TEST_TIMEOUT_MS + 1).reply(500);
 
@@ -50,7 +50,7 @@ describe("Uploader/Browser", function () {
       await response,
       expectedResponse
     );
-    BrowserUploader.defaultTimeoutMs = ORIGINAL_TIMEOUT_MS;
+    BrowserUploader.timeoutMs = ORIGINAL_TIMEOUT_MS;
   });
 
   it("returns the correct status for request errors", async function () {


### PR DESCRIPTION
This changes the uploader code so that it doesn't wait for 10 seconds to check for timeouts.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
