### PR TITLE
Bug 1862270 - print messages to the console when debugging APIs are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v4.0.0-pre.1...main)
 
+* [#1846](https://github.com/mozilla/glean.js/pull/1846): Add logging messages when using the debugging APIs from the browser console.
+
 # v4.0.0-pre.1 (2023-12-01)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v4.0.0-pre.0...v4.0.0-pre.1)

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -509,14 +509,19 @@ if (typeof window !== "undefined" && typeof window.sessionStorage !== "undefined
     setLogPings: (flag: boolean) => {
       setDebugOptionInSessionStorage(DebugOption.LogPings, flag);
       Glean.setLogPings(flag);
+      console.log("Pings will be logged to the console until this tab is closed.");
     },
     setDebugViewTag: (value: string) => {
       setDebugOptionInSessionStorage(DebugOption.DebugTag, value);
       Glean.setDebugViewTag(value);
+      console.log(
+        "Pings will be sent to the Debug Ping Viewer until this tab is closed. Pings can be found here: https://debug-ping-preview.firebaseapp.com/."
+      );
     },
     setSourceTags: (value: string[]) => {
       setDebugOptionInSessionStorage(DebugOption.SourceTags, value);
       Glean.setSourceTags(value);
+      console.log("Pings will be given the specified tags until the tab is closed.");
     }
   };
 }


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
