### PR TITLE
Bug 1867294: Support for automatically collecting element click events (first version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v4.0.0-pre.2...main)
 
+[#1848](https://github.com/mozilla/glean.js/pull/1848): Support for automatically collecting element click events (first version)
+
 # v4.0.0-pre.2 (2023-12-06)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v4.0.0-pre.1...v4.0.0-pre.2)

--- a/glean/src/core/config.ts
+++ b/glean/src/core/config.ts
@@ -50,6 +50,9 @@ export interface ConfigurationInterface {
   // Allow the client to explicitly specify whether they want page load events to be
   // collected automatically.
   readonly enableAutoPageLoadEvents?: boolean,
+  // Allow the client to explicitly specify whether they want click events to be
+  // collected automatically.
+  readonly enableAutoClickEvents?: boolean,
 }
 
 // Important: the `Configuration` should only be used internally by the Glean singleton.
@@ -62,6 +65,7 @@ export class Configuration implements ConfigurationInterface {
   readonly maxEvents: number;
   readonly migrateFromLegacyStorage?: boolean;
   readonly enableAutoPageLoadEvents?: boolean;
+  readonly enableAutoClickEvents?: boolean;
 
   // Debug configuration.
   debug: DebugOptions;
@@ -76,6 +80,7 @@ export class Configuration implements ConfigurationInterface {
     this.maxEvents = config?.maxEvents || DEFAULT_MAX_EVENTS;
     this.migrateFromLegacyStorage = config?.migrateFromLegacyStorage;
     this.enableAutoPageLoadEvents = config?.enableAutoPageLoadEvents;
+    this.enableAutoClickEvents = config?.enableAutoClickEvents;
 
     this.debug = {};
 

--- a/glean/src/core/config.ts
+++ b/glean/src/core/config.ts
@@ -50,9 +50,9 @@ export interface ConfigurationInterface {
   // Allow the client to explicitly specify whether they want page load events to be
   // collected automatically.
   readonly enableAutoPageLoadEvents?: boolean,
-  // Allow the client to explicitly specify whether they want click events to be
-  // collected automatically.
-  readonly enableAutoClickEvents?: boolean,
+  // Allow the client to explicitly specify whether they want to automatically capture
+  // element clicks.
+  readonly enableAutoElementClickEvents?: boolean,
 }
 
 // Important: the `Configuration` should only be used internally by the Glean singleton.
@@ -65,7 +65,7 @@ export class Configuration implements ConfigurationInterface {
   readonly maxEvents: number;
   readonly migrateFromLegacyStorage?: boolean;
   readonly enableAutoPageLoadEvents?: boolean;
-  readonly enableAutoClickEvents?: boolean;
+  readonly enableAutoElementClickEvents?: boolean;
 
   // Debug configuration.
   debug: DebugOptions;
@@ -80,7 +80,7 @@ export class Configuration implements ConfigurationInterface {
     this.maxEvents = config?.maxEvents || DEFAULT_MAX_EVENTS;
     this.migrateFromLegacyStorage = config?.migrateFromLegacyStorage;
     this.enableAutoPageLoadEvents = config?.enableAutoPageLoadEvents;
-    this.enableAutoClickEvents = config?.enableAutoClickEvents;
+    this.enableAutoElementClickEvents = config?.enableAutoElementClickEvents;
 
     this.debug = {};
 

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -325,10 +325,8 @@ namespace Glean {
         GleanMetrics.pageLoad();
       }
 
-      // Record all click events if the client has auto click events enabled.
+      // Record click events if the client has auto click events enabled.
       if (config?.enableAutoClickEvents) {
-        // This function call has no parameters because auto-instrumentation
-        // means there are no overrides.
         document.addEventListener('click', (event) => {
           GleanMetrics.handleClickEvent(event);
         });

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -325,8 +325,8 @@ namespace Glean {
         GleanMetrics.pageLoad();
       }
 
-      // Record click events if the client has auto click events enabled.
-      if (config?.enableAutoClickEvents) {
+      // Record click events if the client has auto element click events enabled.
+      if (config?.enableAutoElementClickEvents) {
         document.addEventListener("click", (event) => {
           GleanMetrics.handleClickEvent(event);
         });

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -324,6 +324,15 @@ namespace Glean {
         // means there are no overrides.
         GleanMetrics.pageLoad();
       }
+
+      // Record all click events if the client has auto click events enabled.
+      if (config?.enableAutoClickEvents) {
+        // This function call has no parameters because auto-instrumentation
+        // means there are no overrides.
+        document.addEventListener('click', (event) => {
+          GleanMetrics.handleClickEvent(event);
+        });
+      }
     } else {
       // If upload is disabled, and we've never run before, only set the
       // client_id to KNOWN_CLIENT_ID, but do not send a deletion request

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -327,7 +327,7 @@ namespace Glean {
 
       // Record click events if the client has auto click events enabled.
       if (config?.enableAutoClickEvents) {
-        document.addEventListener('click', (event) => {
+        document.addEventListener("click", (event) => {
           GleanMetrics.handleClickEvent(event);
         });
       }

--- a/glean/src/core/glean_metrics.ts
+++ b/glean/src/core/glean_metrics.ts
@@ -17,9 +17,9 @@ interface PageLoadParams {
 }
 
 interface ElementClickParams {
-  elementId?: string;
-  elementType?: string;
-  elementLabel?: string;
+  id?: string;
+  type?: string;
+  label?: string;
 }
 
 /**
@@ -50,7 +50,7 @@ namespace GleanMetrics {
         disabled: false,
       },
       // extras defined in `src/metrics.yaml`.
-      ["element_id", "element_type", "element_label"]
+      ["id", "type", "label"]
     )
   };
 
@@ -108,7 +108,7 @@ namespace GleanMetrics {
   export function handleClickEvent(event: Event) {
     const htmlElement = event.target as HTMLElement;
     if (htmlElement?.dataset?.gleanId || htmlElement?.dataset?.gleanType || htmlElement?.dataset?.gleanLabel) {
-      recordElementClick({ elementId: htmlElement?.dataset?.gleanId, elementType : htmlElement?.dataset?.gleanType, elementLabel : htmlElement?.dataset?.gleanLabel });
+      recordElementClick({ id: htmlElement?.dataset?.gleanId, type : htmlElement?.dataset?.gleanType, label : htmlElement?.dataset?.gleanLabel });
     }
   }
 
@@ -127,7 +127,7 @@ namespace GleanMetrics {
       );
       return;
     }
-    metrics.elementClick.record({element_id: elementClickParams?.elementId ?? "", element_type: elementClickParams?.elementType ?? "", element_label: elementClickParams?.elementLabel ?? ""});
+    metrics.elementClick.record({id: elementClickParams?.id ?? "", type: elementClickParams?.type ?? "", label: elementClickParams?.label ?? ""});
   }
 }
 

--- a/glean/src/core/glean_metrics.ts
+++ b/glean/src/core/glean_metrics.ts
@@ -16,11 +16,11 @@ interface PageLoadParams {
   title?: string;
 }
 
-interface ElementClickParams {
+type ElementClickEventContext = {
   id?: string;
   type?: string;
   label?: string;
-}
+};
 
 /**
  * This namespace contains functions to support Glean's auto-instrumentation
@@ -107,17 +107,21 @@ namespace GleanMetrics {
    */
   export function handleClickEvent(event: Event) {
     const htmlElement = event.target as HTMLElement;
-    if (htmlElement?.dataset?.gleanId || htmlElement?.dataset?.gleanType || htmlElement?.dataset?.gleanLabel) {
-      recordElementClick({ id: htmlElement?.dataset?.gleanId, type : htmlElement?.dataset?.gleanType, label : htmlElement?.dataset?.gleanLabel });
-    }
+
+    const elementClickEventContext: ElementClickEventContext = {};
+    if (htmlElement?.dataset?.gleanId) elementClickEventContext.id = htmlElement?.dataset?.gleanId;
+    if (htmlElement?.dataset?.gleanType) elementClickEventContext.type = htmlElement?.dataset?.gleanType;
+    if (htmlElement?.dataset?.gleanLabel) elementClickEventContext.label = htmlElement?.dataset?.gleanLabel;
+
+    if (Object.keys(elementClickEventContext).length > 0) recordElementClick(elementClickEventContext);
   }
 
   /**
    * Record click on an html element.
    *
-   * @param elementClickParams element click extra keys.
+   * @param elementClickEventContext element click event extra keys.
    */
-  export function recordElementClick(elementClickParams?: ElementClickParams) {
+  export function recordElementClick(elementClickEventContext: ElementClickEventContext) {
     // Cannot record an event if Glean has not been initialized.
     if (!Context.initialized) {
       log(
@@ -127,7 +131,8 @@ namespace GleanMetrics {
       );
       return;
     }
-    metrics.elementClick.record({id: elementClickParams?.id ?? "", type: elementClickParams?.type ?? "", label: elementClickParams?.label ?? ""});
+
+    metrics.elementClick.record(elementClickEventContext);
   }
 }
 

--- a/glean/src/core/glean_metrics.ts
+++ b/glean/src/core/glean_metrics.ts
@@ -16,8 +16,10 @@ interface PageLoadParams {
   title?: string;
 }
 
-interface ClickParams {
-  id: string;
+interface AnchorClickParams {
+  url?: string;
+  id?: string;
+  class?: string;
 }
 
 /**
@@ -48,7 +50,7 @@ namespace GleanMetrics {
         disabled: false,
       },
       // extras defined in `src/metrics.yaml`.
-      ["id"]
+      ["url", "id", "class"]
     )
   };
 
@@ -100,17 +102,20 @@ namespace GleanMetrics {
     console.log("element: ", element.tagName);
     if ((event.target as Element)?.tagName.toUpperCase() === "A") {
       let anchorElement = event.target as HTMLAnchorElement;
-      console.log("id, href, classList, className, innerHTML: ", anchorElement.id, anchorElement.href, anchorElement.classList, anchorElement.className, anchorElement.innerHTML);
-      recordAnchorClick({ id : anchorElement?.id });
+      const elementUrl = anchorElement.href;
+      const elementId = anchorElement.id;
+      const elementClass = anchorElement.className;
+      console.log("href, id, classes, innerHTML: ", elementUrl, elementId, elementClass, anchorElement.innerHTML);
+      recordAnchorClick({ url: elementUrl, id : elementId, class : elementClass });
     }
   }
 
   /**
-   * If the client has automatic clicks enabled, we will record click events.
+   * Record clicks on anchor html elements.
    *
-   * @param overrides Overrides for each click extra key.
+   * @param anchorClickParams anchor click extra keys.
    */
-  export function recordAnchorClick(clickParams: ClickParams) {
+  export function recordAnchorClick(anchorClickParams: AnchorClickParams) {
     // Cannot record an event if Glean has not been initialized.
     if (!Context.initialized) {
       log(
@@ -120,14 +125,7 @@ namespace GleanMetrics {
       );
       return;
     }
-
-    // Each key defaults to the override. If no override is provided, we fall
-    // back to the default value IF the `window` or the `document` objects
-    // are available.
-    //
-    // If neither of those are available, then we default to a value that shows
-    // that no value is available.
-    metrics.anchorClick.record({id: clickParams.id});
+    metrics.anchorClick.record({url: anchorClickParams?.url ?? "", id: anchorClickParams?.id ?? "", class: anchorClickParams?.class ?? ""});
   }
 }
 

--- a/glean/src/core/glean_metrics.ts
+++ b/glean/src/core/glean_metrics.ts
@@ -97,16 +97,18 @@ namespace GleanMetrics {
     });
   }
 
+  /**
+   * Handle "click" event on an element.
+   *
+   * It records click events on anchor element. Rest of the events are ignored.
+   *
+   * @param event Event object.
+   */
   export function handleClickEvent(event: Event) {
-    let element = event.target as Element;
-    console.log("element: ", element.tagName);
+    // handle click event on anchor html element
     if ((event.target as Element)?.tagName.toUpperCase() === "A") {
-      let anchorElement = event.target as HTMLAnchorElement;
-      const elementUrl = anchorElement.href;
-      const elementId = anchorElement.id;
-      const elementClass = anchorElement.className;
-      console.log("href, id, classes, innerHTML: ", elementUrl, elementId, elementClass, anchorElement.innerHTML);
-      recordAnchorClick({ url: elementUrl, id : elementId, class : elementClass });
+      const anchorElement = event.target as HTMLAnchorElement;
+      recordAnchorClick({ url: anchorElement.href, id : anchorElement.id, class : anchorElement.className });
     }
   }
 

--- a/glean/src/metrics.yaml
+++ b/glean/src/metrics.yaml
@@ -452,15 +452,21 @@ glean:
       (`enableAutoClickEvents`). Glean provides a separate API for
       clients to record anchor clicks manually.**
     bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1867126
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1867294
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1867126#c8
+      - #ToDo
     data_sensitivity:
       - interaction
     notification_emails:
       - glean-team@mozilla.com
     expires: never
     extra_keys:
+      url:
+        description: The url of the link.
+        type: string
       id:
         description: The id of the element clicked.
+        type: string
+      class:
+        description: The class of the element clicked.
         type: string

--- a/glean/src/metrics.yaml
+++ b/glean/src/metrics.yaml
@@ -442,3 +442,25 @@ glean:
       title:
         description: The page title.
         type: string
+  anchor_click:
+    type: event
+    description: |
+      A event triggered whenever an anchor html element is clicked on a page.
+
+      **This event by default is not collected automatically. This can be
+      turned on by the client in the Glean configuration object
+      (`enableAutoClickEvents`). Glean provides a separate API for
+      clients to record anchor clicks manually.**
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1867126
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1867126#c8
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+    extra_keys:
+      id:
+        description: The id of the element clicked.
+        type: string

--- a/glean/src/metrics.yaml
+++ b/glean/src/metrics.yaml
@@ -462,12 +462,12 @@ glean:
       - glean-team@mozilla.com
     expires: never
     extra_keys:
-      element_id:
+      id:
         description: An identifier of the element clicked. For automatic collection, its value is the element's `data-glean-id` data attribute value.
         type: string
-      element_type:
+      type:
         description: The type of the element clicked. For automatic collection, its value is the element's `data-glean-type` data attribute value.
         type: string
-      element_label:
+      label:
         description: The label of the element clicked. For automatic collection, its value is the element's `data-glean-label` data attribute value.
         type: string

--- a/glean/src/metrics.yaml
+++ b/glean/src/metrics.yaml
@@ -455,7 +455,7 @@ glean:
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1867294
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1867294 #ToDo
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1867294#c29
     data_sensitivity:
       - interaction
     notification_emails:

--- a/glean/src/metrics.yaml
+++ b/glean/src/metrics.yaml
@@ -442,15 +442,16 @@ glean:
       title:
         description: The page title.
         type: string
-  anchor_click:
+  element_click:
     type: event
     description: |
-      A event triggered whenever an anchor html element is clicked on a page.
+      A event triggered whenever an html element is clicked on a page.
 
-      **This event by default is not collected automatically. This can be
-      turned on by the client in the Glean configuration object
-      (`enableAutoClickEvents`). Glean provides a separate API for
-      clients to record anchor clicks manually.**
+      **Clicks are recorded only for those html elements that have at least one of
+      the `data-glean-*` data attributes.
+      By default, this event is not collected automatically. Collection can be turned on
+      by clients via Glean configuration object (`enableAutoElementClickEvents`). Glean
+      also provides a separate API for clients to record element clicks manually.**
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1867294
     data_reviews:
@@ -461,12 +462,12 @@ glean:
       - glean-team@mozilla.com
     expires: never
     extra_keys:
-      url:
-        description: The url of the link.
+      element_id:
+        description: An identifier of the element clicked. For automatic collection, its value is the element's `data-glean-id` data attribute value.
         type: string
-      id:
-        description: The id of the element clicked.
+      element_type:
+        description: The type of the element clicked. For automatic collection, its value is the element's `data-glean-type` data attribute value.
         type: string
-      class:
-        description: The class of the element clicked.
+      element_label:
+        description: The label of the element clicked. For automatic collection, its value is the element's `data-glean-label` data attribute value.
         type: string

--- a/glean/src/metrics.yaml
+++ b/glean/src/metrics.yaml
@@ -454,7 +454,7 @@ glean:
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1867294
     data_reviews:
-      - #ToDo
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1867294 #ToDo
     data_sensitivity:
       - interaction
     notification_emails:


### PR DESCRIPTION
### Description
This PR implements the [first version](https://bugzilla.mozilla.org/show_bug.cgi?id=1867294#c24) to automatically collect click events on html elements:

1. It will record clicks to any [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) that have at least one of `data-glean-id`, `data-glean-type`, `data-glean-label` data attributes.
2. Additional context that is collected with this event (via [extra_keys](https://mozilla.github.io/glean/book/reference/metrics/event.html#extra-metric-parameters)):
    1. `id`: A string indicating an identifier of the clicked element (takes its value from element's `data-glean-id` attribute value if present)
    2. `type`: A string indicating the type of the clicked element (takes its value from element's `data-glean-type` attribute value if present)
    3. `label`: A string indicating the label of the clicked element (takes its value from element's `data-glean-label` attribute value if present)

### How clients can use it:
Clients can set `Configuration.enableAutoElementClickEvents` option to `true` during Glean.js initialization to collect these events automatically. e.g. Like this:
```js
Glean.initialize(APP_NAME, isTelemetryEnabled(), {
    maxEvents: 1,
    channel: process.env.REACT_APP_ENV,
    enableAutoElementClickEvents: true,
  });
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes