### PR TITLE
Bug 1873061 - Add API to dynamically set experimentation id

### DIFF
--- a/glean/src/core/config.ts
+++ b/glean/src/core/config.ts
@@ -54,7 +54,7 @@ export interface ConfigurationInterface {
   // element clicks.
   readonly enableAutoElementClickEvents?: boolean,
   // Experimentation identifier to be set in all pings
-  readonly experimentationId?: string,
+  experimentationId?: string,
 }
 
 // Important: the `Configuration` should only be used internally by the Glean singleton.
@@ -68,7 +68,7 @@ export class Configuration implements ConfigurationInterface {
   readonly migrateFromLegacyStorage?: boolean;
   readonly enableAutoPageLoadEvents?: boolean;
   readonly enableAutoElementClickEvents?: boolean;
-  readonly experimentationId?: string;
+  experimentationId?: string;
 
   // Debug configuration.
   debug: DebugOptions;

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -427,6 +427,15 @@ namespace Glean {
   }
 
   /**
+   * Sets the experimentation identifier
+   *
+   * @param experimentationId The string identifier to set
+   */
+  export function setExperimentationId(experimentationId: string): void {
+    Context.config.experimentationId = experimentationId;
+  }
+
+  /**
    * Sets the `logPings` debug option.
    *
    * When this flag is `true` pings will be logged to the console right before they are collected.

--- a/glean/tests/unit/core/pings/maker.spec.ts
+++ b/glean/tests/unit/core/pings/maker.spec.ts
@@ -161,6 +161,40 @@ describe("PingMaker", function () {
     }
   });
 
+  it("experimentation id is present in all pings when dynamically set", function () {
+    const ping1 = new PingType({
+      name: "ping1",
+      includeClientId: true,
+      sendIfEmpty: true,
+    });
+
+    const payloadWithoutId = PingMaker.collectPing(ping1);
+
+    assert(
+      payloadWithoutId?.metrics?.string[
+        "glean.client.annotation.experimentation_id"
+      ] == undefined
+    );
+
+    Glean.setExperimentationId("test_experiment_id");
+
+    const payloadWithId = PingMaker.collectPing(ping1);
+
+    assert(payloadWithId?.metrics?.string != undefined);
+    if (payloadWithId?.metrics?.string != undefined) {
+      assert(
+        payloadWithId.metrics.string[
+          "glean.client.annotation.experimentation_id"
+        ] != undefined
+      );
+      assert(
+        payloadWithId.metrics.string[
+          "glean.client.annotation.experimentation_id"
+        ] == "test_experiment_id"
+      );
+    }
+  });
+
   it("getPingHeaders returns headers when custom headers are set", function () {
     Glean.setDebugViewTag("test");
     Glean.setSourceTags(["tag1", "tag2", "tag3"]);


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
