### PR TITLE
Bug 1862955 - fix browserstack session tests

### DIFF
--- a/automation/compat/index.js
+++ b/automation/compat/index.js
@@ -8,10 +8,26 @@ import Glean from "@mozilla/glean/web";
 import { benchmark } from "./generated/pings.js";
 import * as metrics from "./generated/sample.js";
 
+Glean.setSourceTags(["automation"]);
+Glean.initialize("glean-compat-benchmark", true, {
+  enableAutoPageLoadEvents: true,
+  // Setting the override to 0 means every action will trigger
+  // a new session. We use this to check that the session ID
+  // changes whenever a session has expired.
+  sessionLengthInMinutesOverride: 0
+});
+
+metrics.pageLoaded.set();
+benchmark.submit();
+
 // !BIG HACK!
 //
 // Overwrite the console.info function in order to know when (and if) the benchmark ping was sent.
 // If a success ping message is logged we show that in the document.
+//
+// We cannot use the ping testing APIs since these "tests" are actually checks
+// running on a live application. For us to utilize the ping testing APIs, 
+// like `<ping>.testBeforeNextSubmit` we would need Glean to be running in testing mode.
 let pingSubmissionCount = 0;
 let sessionId = "";
 console.info = function () {
@@ -37,10 +53,13 @@ console.info = function () {
     }
   }
 
-  const sessionRegex = /"session_id": .+"/;
-  const sessionInfo = sessionRegex.exec(message);
-  if (!!sessionInfo) {
-    const currSessionId = sessionInfo?.[0].split(`"`)?.[3];
+  // Pull all user lifetime metrics from Glean.
+  const userLifetimeMetrics = window.localStorage.getItem("userLifetimeMetrics");
+
+  // Extract the session id metric.
+  const sessionInfo = /"session_id":".{36}"/.exec(userLifetimeMetrics);
+  if (!!sessionInfo.length) {
+    const currSessionId = sessionInfo[0]?.split(":")?.[1]?.split("\"")?.[1];
     if (!!sessionId) {
       if (currSessionId !== sessionId) {
         var elem = document.getElementById("session_msg");
@@ -53,19 +72,3 @@ console.info = function () {
     sessionId = currSessionId;
   }
 }
-
-Glean.setSourceTags(["automation"]);
-
-// This needs to be set so we can pull the session ID from the log messages.
-Glean.setLogPings(true);
-
-Glean.initialize("glean-compat-benchmark", true, {
-  enableAutoPageLoadEvents: true,
-  // Setting the override to 0 means every action will trigger
-  // a new session. We use this to check that the session ID
-  // changes whenever a session has expired.
-  sessionLengthInMinutesOverride: 0
-});
-
-metrics.pageLoaded.set();
-benchmark.submit();


### PR DESCRIPTION
This is a followup to #1850. The changes in that PR broke the browserstack tests. This updates our browserstack tests to rely on data from LocalStorage rather than trying to pull session IDs from log messages.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
-  [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
