### PR TITLE
Bug 1886113 - Add wall-clock timestamps to all events

### DIFF
--- a/glean/src/core/metrics/types/event.ts
+++ b/glean/src/core/metrics/types/event.ts
@@ -49,6 +49,8 @@ export class InternalEventMetricType<
       return;
     }
 
+    const ts = Date.now();
+
     try {
       // Create metric here, in order to run the validations and throw in case input in invalid.
       const metric = new RecordedEvent({
@@ -59,9 +61,8 @@ export class InternalEventMetricType<
       });
 
       // Truncate the extra keys, if needed.
-      let truncatedExtra: ExtraMap | undefined = undefined;
+      const truncatedExtra: ExtraMap = {};
       if (extra && this.allowedExtraKeys) {
-        truncatedExtra = {};
         for (const [name, value] of Object.entries(extra)) {
           if (this.allowedExtraKeys.includes(name)) {
             if (isString(value)) {
@@ -84,6 +85,8 @@ export class InternalEventMetricType<
         }
       }
 
+      // Glean wall-clock timestamp added to all events
+      truncatedExtra["glean_timestamp"] = ts.toString();
       metric.set({
         ...metric.get(),
         extra: truncatedExtra
@@ -111,7 +114,19 @@ export class InternalEventMetricType<
    */
   testGetValue(ping: string = this.sendInPings[0]): Event[] | undefined {
     if (testOnlyCheck("testGetValue", LOG_TAG)) {
-      return Context.eventsDatabase.getEvents(ping, this);
+      const events = Context.eventsDatabase.getEvents(ping, this);
+      if (!events) return events;
+
+      events.forEach((ev) => {
+        if (ev.extra) {
+          delete ev.extra["glean_timestamp"];
+          if (Object.keys(ev.extra).length == 0) {
+            ev.extra = undefined;
+          }
+        }
+      });
+
+      return events;
     }
   }
 }


### PR DESCRIPTION
Not sure how to best that other than manual, which I've done in the sample app.
We remove the glean_timestamp from testGetValue so consumers don't need to check for it.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
