### PR TITLE
Bug 1888430 - Add `page_id`  to Glean automatic events

### DIFF
--- a/glean/src/core/glean_metrics.ts
+++ b/glean/src/core/glean_metrics.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Context } from "./context.js";
+import UUIDMetric from "./metrics/types/uuid.js";
 import EventMetricType from "./metrics/types/event.js";
 import { EVENTS_PING_NAME } from "./constants.js";
 import { Lifetime } from "./metrics/lifetime.js";
@@ -51,6 +52,15 @@ namespace GleanMetrics {
       },
       // extras defined in `src/metrics.yaml`.
       ["id", "type", "label"]
+    ),
+    pageId: new UUIDMetric(
+      {
+        category: "glean",
+        name: "page_id",
+        sendInPings: [EVENTS_PING_NAME],
+        lifetime: Lifetime.Application,
+        disabled: false,
+      }
     )
   };
 
@@ -71,6 +81,9 @@ namespace GleanMetrics {
       );
       return;
     }
+
+    // Rotate the page_id for each page_load event.
+    metrics.pageId.generateAndSet();
 
     // Each key defaults to the override. If no override is provided, we fall
     // back to the default value IF the `window` or the `document` objects

--- a/glean/src/metrics.yaml
+++ b/glean/src/metrics.yaml
@@ -539,3 +539,20 @@ glean:
       label:
         description: The label of the element clicked. For automatic collection, its value is the element's `data-glean-label` data attribute value.
         type: string
+  page_id:
+    type: uuid
+    description: |
+      Uniquely identifies a page_load, not the page itself, for the purpose of associating other events with the specific page load event. This gets
+      rotated with each page load and is sent along with each event ping.
+    send_in_pings:
+      - events
+    lifetime: application
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1888430
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1888430
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
