### PR TITLE
Bug 1893015 - Fix an issue where experimentation-id wasn't making it into certain pings

### DIFF
--- a/glean/src/core/pings/maker.ts
+++ b/glean/src/core/pings/maker.ts
@@ -254,8 +254,14 @@ export function collectPing(ping: CommonPingData, reason?: string): PingPayload 
 
   // Insert the experimentation id if the metrics aren't empty
   if (ping.includeClientId && Context.config.experimentationId) {
-    if (metricsData != undefined) {
-      metricsData["string"]["glean.client.annotation.experimentation_id"] = Context.config.experimentationId;
+    if (metricsData !== undefined) {
+      metricsData = {
+        ...metricsData,
+        string: {
+          ...metricsData?.string || undefined,
+          "glean.client.annotation.experimentation_id": Context.config.experimentationId
+        }
+      };
     } else {
       metricsData = {
         "string": {


### PR DESCRIPTION
This fixes the way the experimentation id was getting added to pings that didn't have other metrics already in the payload.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
