### PR TITLE
Bug 1894939: add bugs for not supported common_ping_data features

### DIFF
--- a/glean/src/core/pings/common_ping_data.ts
+++ b/glean/src/core/pings/common_ping_data.ts
@@ -16,8 +16,20 @@ export default interface CommonPingData {
   readonly reasonCodes?: string[];
 
   // Currently NOT IMPLEMENTED.
+  //
+  // NOTE: There are specific bugs for implementing each of these features. If
+  // these features are implemented later, please move the property out of the
+  // "NOT IMPLEMENTED" section and remove the bug.
+
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1895297
   readonly preciseTimestamps?: boolean;
+
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1895299
   readonly includeInfoSections?: boolean;
+
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1895300
   readonly enabled?: boolean;
+
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1895302
   readonly schedulesPings?: string[];
 }


### PR DESCRIPTION
Add instructional comment and individual bugs to the list of unsupported `glean_parser` features.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
