### PR TITLE
Bug 1894064: remove migration code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v5.0.1...main)
 
+* [#1935](https://github.com/mozilla/glean.js/pull/1935): **BREAKING CHANGE**: Remove `migrateFromLegacyStorage` capability and configuration option. If your project currently sets the `migrateFromLegacyStorage` value, this will no longer work.
+
 # v5.0.1 (2024-04-30)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v5.0.0...v5.0.1)

--- a/glean/src/core/config.ts
+++ b/glean/src/core/config.ts
@@ -44,9 +44,6 @@ export interface ConfigurationInterface {
   httpClient?: Uploader,
   // The build date, provided by glean_parser
   readonly buildDate?: Date,
-  // Migrate from legacy storage (IndexedDB) to the new one (LocalStorage).
-  // This should only be true for older projects that have existing data in IndexedDB.
-  readonly migrateFromLegacyStorage?: boolean,
   // Allow the client to explicitly specify whether they want page load events to be
   // collected automatically.
   readonly enableAutoPageLoadEvents?: boolean,
@@ -67,7 +64,6 @@ export class Configuration implements ConfigurationInterface {
   readonly serverEndpoint: string;
   readonly buildDate?: Date;
   readonly maxEvents: number;
-  readonly migrateFromLegacyStorage?: boolean;
   readonly enableAutoPageLoadEvents?: boolean;
   readonly enableAutoElementClickEvents?: boolean;
   experimentationId?: string;
@@ -84,7 +80,6 @@ export class Configuration implements ConfigurationInterface {
     this.appDisplayVersion = config?.appDisplayVersion;
     this.buildDate = config?.buildDate;
     this.maxEvents = config?.maxEvents || DEFAULT_MAX_EVENTS;
-    this.migrateFromLegacyStorage = config?.migrateFromLegacyStorage;
     this.enableAutoPageLoadEvents = config?.enableAutoPageLoadEvents;
     this.enableAutoElementClickEvents = config?.enableAutoElementClickEvents;
     this.experimentationId = config?.experimentationId;

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -96,15 +96,6 @@ namespace Glean {
   }
 
   /**
-   * Initialize core metrics: client_id, first_run_date, os, etc.
-   *
-   * @param migrateFromLegacy Whether or not to migrate data from legacy storage.
-   */
-  function initializeCoreMetrics(migrateFromLegacy?: boolean): void {
-    Context.coreMetrics.initialize(migrateFromLegacy);
-  }
-
-  /**
    * Handles the changing of state from upload enabled to disabled.
    *
    * Should only be called when the state actually changes.
@@ -333,7 +324,7 @@ namespace Glean {
       // If upload is enabled,
       // just follow the normal code path to instantiate the core metrics.
       onUploadEnabled();
-      initializeCoreMetrics(config?.migrateFromLegacyStorage);
+      Context.coreMetrics.initialize();
 
       // Record a page load event if the client has auto page-load events enabled.
       if (config?.enableAutoPageLoadEvents) {
@@ -419,7 +410,7 @@ namespace Glean {
     if (Context.uploadEnabled !== flag) {
       if (flag) {
         onUploadEnabled();
-        initializeCoreMetrics(Context.config.migrateFromLegacyStorage);
+        Context.coreMetrics.initialize();
       } else {
         onUploadDisabled(false);
       }

--- a/glean/src/core/metrics/types/datetime.ts
+++ b/glean/src/core/metrics/types/datetime.ts
@@ -58,18 +58,6 @@ export class DatetimeMetric extends Metric<DatetimeInternalRepresentation, strin
     });
   }
 
-  static fromRawDatetime(
-    isoString: string,
-    timezoneOffset: number,
-    timeUnit: TimeUnit
-  ): DatetimeMetric {
-    return new DatetimeMetric({
-      timeUnit,
-      timezone: timezoneOffset,
-      date: isoString
-    });
-  }
-
   /**
    * Gets the datetime data as a Date object.
    *
@@ -247,32 +235,6 @@ export class InternalDatetimeMetricType extends MetricType {
     }
 
     return truncatedDate;
-  }
-
-  /**
-   * Set a datetime metric from raw values.
-   *
-   * # Important
-   * This method should **never** be exposed to users. This is used solely
-   * for migrating IDB data to LocalStorage.
-   *
-   * @param isoString Raw isoString.
-   * @param timezone Raw timezone.
-   * @param timeUnit Raw timeUnit.
-   */
-  setRaw(isoString: string, timezone: number, timeUnit: TimeUnit) {
-    if (!this.shouldRecord(Context.uploadEnabled)) {
-      return;
-    }
-
-    try {
-      const metric = DatetimeMetric.fromRawDatetime(isoString, timezone, timeUnit);
-      Context.metricsDatabase.record(this, metric);
-    } catch (e) {
-      if (e instanceof MetricValidationError) {
-        e.recordError(this);
-      }
-    }
   }
 
   /// TESTING ///


### PR DESCRIPTION
The only documentation that we had of this was in the CHANGELOG, so there are no accompanying doc changes.

### Why this existed
We are removing this migration code since it is no longer needed. The reason for this code was to help move `client_id`s and `first_run_date`s over from our previous storage solution from when Glean.js was asynchronous. Newer versions of Glean.js use `localStorage` which allows synchronous read/writes. Glean.js used to use `IndexedDB` which forced asynchronous read/writes.

Synchronous is necessary so that we can ensure read/writes execute before pages are unloaded. If we start to write to storage async and the page unloads, that process never finishes and we incur data loss.

### Why it can go away
The only product that used Glean.js in production that was migrating to our new storage solution was MDN. They have been the only ever consumer of this feature. We have had the migration code running for ~9 months in MDN, so the majority of users would have migrated over their data by now.

We are removing it because of an error we are seeing when submitting the first ping for any user before they have migrated. A ping is submitted missing both the `client_id` and the `first_run_date` since they get lost in a race condition. This is causing a lot of schema ingestion errors.

We've run the migration code for long enough and now it is safe to turn it off. This will also stop the large amount of `first_run_date` errors that we have been seeing.


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
