### PR TITLE
Bug 1897203 - remove links to old docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you are using Glean.js in your project, this is the place to go.
 
 ### [The Glean Book](https://mozilla.github.io/glean/)
 
-The Glean Book contains user guides on getting started and other topics, as well as reference to Glean APIs.
+The Glean Book contains general information on the Glean ecosystem and about the SDKs on other platforms, as well as reference to Glean APIs (which are common to all the platforms).
 
 ### [Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs)
 

--- a/README.md
+++ b/README.md
@@ -8,21 +8,17 @@
 
 All documentation is available online:
 
+### [The Glean.js Docs](https://mozilla.github.io/glean.js/)
+
+If you are using Glean.js in your project, this is the place to go.
+
 ### [The Glean Book](https://mozilla.github.io/glean/)
 
-If you are using Glean.js in your project, this is the place to go. 
-It contains user guides on getting started and other topics, as well as reference to Glean APIs.
+The Glean Book contains user guides on getting started and other topics, as well as reference to Glean APIs.
 
 ### [Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs)
 
 If you want to contribute to the Glean.js code base this is the place to go.
-
-### [Glean.js internal reference](https://mozilla.github.io/glean.js/)
-
-If you are looking for detailed documentation on the Glean APIs (internal or external) this is the place to go.
-
-_This documentation is auto generated from the doc comments throughout the Glean.js code base and
-the Glean book should be preferred over this documentation whenever possible._
 
 ## Contact
 

--- a/docs/implementation/plugins-events.md
+++ b/docs/implementation/plugins-events.md
@@ -4,7 +4,7 @@ Plugins provide a way for the Glean JS SDK to support specialized use cases with
 the size of the library. Each plugin can be attached to a Glean core event to augment
 or modify its behavior.
 
-A Glean plugin is a class that extends the [`Plugin`](https://mozilla.github.io/glean.js/classes/plugins.default.html) class. Each plugin instance exposes an
+A Glean plugin is a class that extends the `Plugin` class. Each plugin instance exposes an
 `action` API, to be triggered by the event. The signature of the `action` API will depend on
 the event the plugin is attached to.
 
@@ -12,7 +12,7 @@ the event the plugin is attached to.
 
 Events denote a specific moment in code that may have a plugin attached to it.
 
-A Glean event is an instance of the [`CoreEvent`](https://mozilla.github.io/glean.js/classes/core_events.CoreEvent.html) class. These instances expose a `trigger` API,
+A Glean event is an instance of the `CoreEvent` class. These instances expose a `trigger` API,
 for triggering the action of a plugin that may be attached to it. Each event defines a different
 signature for the `trigger` API.
 
@@ -24,7 +24,7 @@ we should create a new plugin and event for it. However, when is that?
 Plugins should always be the choice when we are implementing a feature that has a very specialized
 use case and would be left unused by most users.
 
-The [`PingEncryptionPlugin`](https://mozilla.github.io/glean.js/classes/plugins_encryption.default.html)
+The `PingEncryptionPlugin`
 is a good example of that. That plugin encrypts all outgoing pings when enabled. It is a fairly large
 plugin due to the encryption dependencies it includes in the bundle and it is only used by a small
 amount of clients. It makes sense to make it a stand-alone feature.


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
