### PR TITLE
Bug 1898681 - fix missing base url in md links

### DIFF
--- a/documentation/src/content/docs/automatic_instrumentation/click_events.md
+++ b/documentation/src/content/docs/automatic_instrumentation/click_events.md
@@ -64,4 +64,4 @@ GleanMetrics.recordElementClick({
 
 ## Try it out
 
-To see automatic click events in action, check out our [interactive playground](/playground).
+To see automatic click events in action, check out our [interactive playground](../playground).

--- a/documentation/src/content/docs/automatic_instrumentation/page_load_events.md
+++ b/documentation/src/content/docs/automatic_instrumentation/page_load_events.md
@@ -61,4 +61,4 @@ GleanMetrics.pageLoad({
 
 ## Try it out
 
-To see automatic page load events in action, check out our [interactive playground](/playground).
+To see automatic page load events in action, check out our [interactive playground](../playground).

--- a/documentation/src/content/docs/debugging/browser.md
+++ b/documentation/src/content/docs/debugging/browser.md
@@ -3,7 +3,7 @@ title: Debugging in the browser
 description: How to debug in the browser with Glean.js.
 ---
 
-All the available [debugging options](/debugging/options) are available in the browser. You can
+All the available [debugging options](./options) are available in the browser. You can
 enable these options using the `window.Glean` object.
 
 The debugging preferences are set in the browser's `sessionStorage`. Once set

--- a/documentation/src/content/docs/getting_started/installation.md
+++ b/documentation/src/content/docs/getting_started/installation.md
@@ -7,7 +7,7 @@ description: Installing Glean.js in your project.
 npm i @mozilla/glean
 ```
 
-The way you import Glean changes depending on your platform. Please reference the [platforms](/getting_started/platforms) page for more details about available platforms.
+The way you import Glean changes depending on your platform. Please reference the [platforms](./platforms) page for more details about available platforms.
 
 ## Web
 

--- a/documentation/src/content/docs/getting_started/setup.md
+++ b/documentation/src/content/docs/getting_started/setup.md
@@ -26,9 +26,9 @@ Glean.initialize("app-name", uploadEnabled, config);
 
 Glean.js-specific configuration options:
 
-- `enableAutoPageLoadEvents`: Enables [automatic page load](/automatic_instrumentation/page_load_events) events.
-- `enableAutoElementClickEvents`: Enables [automatic click](/automatic_instrumentation/click_events) events.
-- `sessionLengthInMinutesOverride`: Overrides the default [session](/reference/sessions) length of 30 minutes.
+- `enableAutoPageLoadEvents`: Enables [automatic page load](../automatic_instrumentation/page_load_events) events.
+- `enableAutoElementClickEvents`: Enables [automatic click](../automatic_instrumentation/click_events) events.
+- `sessionLengthInMinutesOverride`: Overrides the default [session](../reference/sessions) length of 30 minutes.
 - `experimentationId`: Experimentation identifier to be set in all pings.
 
 <a href="https://mozilla.github.io/glean/book/reference/general/initializing.html#configuration" target="_blank">Full list of configuration options</a>
@@ -37,4 +37,4 @@ Glean.js-specific configuration options:
 
 Glean.js should be initialized **as soon as possible at the start of the application**. You should set all debugging options prior to `Glean.initialize`.
 
-[Example initialization](/debugging/options#usage)
+[Example initialization](../debugging/options#usage)

--- a/documentation/src/content/docs/playground.mdx
+++ b/documentation/src/content/docs/playground.mdx
@@ -11,8 +11,8 @@ and then click **Initialize**.
 
 ### Further reading
 
-- [Automatic Click Events](/automatic_instrumentation/click_events)
-- [Automatic Page Load Events](/automatic_instrumentation/page_load_events)
-- [Debugging](/debugging/browser)
-- [Sessions](/reference/sessions)
-- [Uploaders](/reference/uploaders)
+- [Automatic Click Events](./automatic_instrumentation/click_events)
+- [Automatic Page Load Events](./automatic_instrumentation/page_load_events)
+- [Debugging](./debugging/browser)
+- [Sessions](./reference/sessions)
+- [Uploaders](./reference/uploaders)


### PR DESCRIPTION
Add relative links so the base URLs are respected in markdown.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
