### PR TITLE
Add window.Glean.debugSession() web API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v5.0.2...main)
 
+* [#1970](https://github.com/mozilla/glean.js/pull/1970): Add `window.Glean.debugSession` API for automatically opening a link to the Debug Ping Viewer with your current session selected.
+
 # v5.0.2 (2024-05-23)
 
 [Full changelog](https://github.com/mozilla/glean.js/compare/v5.0.1...v5.0.2)

--- a/automation/compat/tests/utils.js
+++ b/automation/compat/tests/utils.js
@@ -82,7 +82,8 @@ export async function runWebTest(driver) {
         window.Glean &&
         window.Glean.setDebugViewTag &&
         window.Glean.setLogPings &&
-        window.Glean.setSourceTags
+        window.Glean.setSourceTags &&
+        window.Glean.debugSession
       ) {
         return true;
       }

--- a/documentation/src/content/docs/debugging/browser.md
+++ b/documentation/src/content/docs/debugging/browser.md
@@ -20,6 +20,9 @@ window.Glean.setDebugViewTag("example-tag");
 
 // Tag pings with source tags.
 window.Glean.setSourceTags(["my-tag", "your-tag", "our-tag"]);
+
+// Open a new tab in the browser showing the Debug Ping Viewer with the active session in focus.
+window.Glean.debugSession();
 ```
 
 ## Try it out

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -527,6 +527,7 @@ declare global {
       setLogPings: (flag: boolean) => void;
       setDebugViewTag: (value: string) => void;
       setSourceTags: (value: string[]) => void;
+      debugSession: () => void;
     };
   }
 }
@@ -558,6 +559,21 @@ if (
         "Pings will be given the specified tags until the tab is closed."
       );
     },
+    debugSession: () => {
+      const sessionId = Context.metricsDatabase.getMetric(
+        CLIENT_INFO_STORAGE,
+        Context.coreMetrics.sessionId
+      );
+
+      if (!!sessionId && typeof sessionId === "string" && !!Context.config.debugViewTag) {
+        window.open(
+          `https://debug-ping-preview.firebaseapp.com/stream/${Context.config.debugViewTag}#${sessionId}`,
+          "_blank"
+        );
+      } else {
+        console.info("You must set a debug tag via `window.Glean.setDebugViewTag` before debugging your session.");
+      }
+    }
   };
 }
 


### PR DESCRIPTION
Accompanies work done in the DPV to allow for individual session debugging. Whenever the user calls `window.Glean.debugSession()` We will call `window.open()` with the appropriate DPV URL specifically displaying that session in the event stream.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
