### PR TITLE
Add try-catch around `window.sessionStorage` access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased changes
 
+* [#1977](https://github.com/mozilla/glean.js/pull/1977): Add try-catch around window.sessionStorage access to prevent uncaught error upon `import`.
+
 [Full changelog](https://github.com/mozilla/glean.js/compare/v5.0.3...main)
 
 # v5.0.3 (2024-08-02)

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -533,10 +533,19 @@ declare global {
 }
 
 // Only set `Glean` values whenever running inside of a browser.
-if (
-  typeof window !== "undefined" &&
-  typeof window.sessionStorage !== "undefined"
-) {
+// When cookies/localStorage/sessionStorage are disabled (at least in Firefox
+// and Chrome), an access attempt on the window.sessionStorage property will
+// throw an error ("The operation is insecure." in Firefox).
+// So try-catch is needed here.
+let hasStorage = false;
+try {
+  hasStorage = typeof window !== "undefined" &&
+  typeof window.sessionStorage !== "undefined";
+} catch (e) {
+  console.error("No session storage available", e);
+}
+
+if (hasStorage) {
   window.Glean = {
     setLogPings: (flag: boolean) => {
       setDebugOptionInSessionStorage(DebugOption.LogPings, flag);


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - I was not able to find any existing tests around sessionStorage or some kind of mock for the window object
- [ ] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
  - I'm not sure if we are going to tag a release right away.  I can update the changelog if that's the case.
- [ ] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - This PR doesn't change the API.  It prevents an uncaught error that could break some JS based webapps when Glean is in the dependency tree.