### PR TITLE
Bug 1967425 - remove faulty check for sessionStorage to prevent uncau…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased changes
 
+* [#2010](https://github.com/mozilla/glean.js/pull/2010): Remove faulty check for sessionStorage to prevent uncaught error.
+
 [Full changelog](https://github.com/mozilla/glean.js/compare/v5.0.5...main)
 
 # v5.0.5 (2025-07-17)

--- a/glean/src/core/glean.ts
+++ b/glean/src/core/glean.ts
@@ -194,14 +194,6 @@ namespace Glean {
    * Fetch debug options from SessionStorage and set the Glean preInit debug options.
    */
   function setDebugOptionsFromSessionStorage() {
-    // If we cannot access browser APIs, we do nothing.
-    if (
-      typeof window === "undefined" ||
-      typeof window.sessionStorage === "undefined"
-    ) {
-      return;
-    }
-
     const logPings = getDebugOptionFromSessionStorage(DebugOption.LogPings);
     if (logPings) {
       preInitLogPings = extractBooleanFromString(logPings);


### PR DESCRIPTION
If user instructs User Agent to block cookies, every access to sessionStorage outside of try-catch block results in an error. Prior to this commit, `setDebugOptionsFromSessionStorage()` contained a faulty check for this case leading to unpredictable breakages in glean embedders. In particular, Glean was breaking pages on MDN https://developer.mozilla.org/

For details see: https://github.com/mdn/yari/issues/13039

This is just one of many ways o fix the bug. Specifically, I removed faulty check in `setDebugOptionsFromSessionStorage()` in favor of a properly working check (the try-catch block) in `getDebugOptionFromSessionStorage()`.

Tests:
I did not add any tests here because I did not any extra functionality, just removed a faulty check in favor of a functional one.

Changelog:
Updated `CHANGELOG.md` with a reference to this PR.

Documentation:
This change does not require any documentation.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: Make sure this PR builds and runs cleanly.
  - Inside the `glean/` folder, run:
    - `npm run test` Runs _all_ tests
    - `npm run lint` Runs _all_ linters
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry to `CHANGELOG.md` or an explanation of why it does not need one
- [x] **Documentation**: This PR includes documentation changes, an explanation of why it does not need that or a follow-up bug has been filed to do that work
  - Documentation should be added to [The Glean Book](https://mozilla.github.io/glean/book/index.html) when making changes to Glean's user facing API
    - When changes to the Glean Book are necessary, link to the corresponding PR on the [`mozilla/glean`](https://github.com/mozilla/glean) repository
  - Documentation should be added to [the Glean.js developer documentation](https://github.com/mozilla/glean.js/tree/main/docs) when making internal code changes
